### PR TITLE
Handling of services that are only defined as an exception

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
@@ -396,14 +396,23 @@ public class GtfsConverter extends Gtfs2TransitSchedule {
 			String[] line = reader.readNext();
 			while(line != null) {
 				Service currentService = services.get(line[col.get(GTFSDefinitions.SERVICE_ID)]);
-				if(currentService != null) {
-					if(line[col.get(GTFSDefinitions.EXCEPTION_TYPE)].equals("2"))
-						currentService.addException(line[col.get(GTFSDefinitions.DATE)]);
-					else
-						currentService.addAddition(line[col.get(GTFSDefinitions.DATE)]);
-				} else {
-					throw new RuntimeException("Service id \"" + line[col.get(GTFSDefinitions.SERVICE_ID)] + "\" not defined in calendar.txt");
+
+				if(currentService == null) {
+					currentService = new Service(
+							line[col.get(GTFSDefinitions.SERVICE_ID)],
+							new boolean[] { false, false, false, false, false, false, false },
+							"19700101", "29991231"
+					);
+
+					services.put(currentService.getId(), currentService);
+					log.warn("Service id \"" + currentService.getId() + "\" not defined in calendar.txt (only defined in calendar_dates.txt?)");
 				}
+
+				if(line[col.get(GTFSDefinitions.EXCEPTION_TYPE)].equals("2"))
+					currentService.addException(line[col.get(GTFSDefinitions.DATE)]);
+				else
+					currentService.addAddition(line[col.get(GTFSDefinitions.DATE)]);
+
 				line = reader.readNext();
 			}
 			reader.close();


### PR DESCRIPTION
The GTFS schedule for Île-de-France from STIF  [[1]](https://opendata.stif.info/explore/dataset/offre-horaires-tc-gtfs-idf/information/?basemap=jawg.streets) defines some services, which are only running on an exceptional basis. Therefore, they are only defined in the `calendar_dates.txt`. 

In order to convert the dataset, I changed the code such that those services are created on the fly. I'm not sure if the exceptions are due to a non-standard usage of GTFS in this data set or if such cases just have not been considered in pt2matsim yet. 