### PR TITLE
Standalone pom & instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,20 @@
 A package to convert input schedule data such as GTFS , HAFAS or OSM to a completely mapped MATSim schedule.
 
 The implementation allows to first create a multi-modal network from OSM and then to map the schedule data onto that network. Tools to validate and edit the mapped schedule are also part of the package.
+
+### Standalone Usage
+
+The tools can be used as a maven package or as a standalone utility. In order to create
+a standalone version the repository needs to be cloned. Afterwards, maven can be used
+to create a runnable jar:
+
+    mvn -Prelease -DskipTests=true
+
+The runnable tools are then located in
+
+    pt2matsim/target/pt2matsim-VERSION-release.zip
+
+The zip file contains the runnable jar and its dependencies in the `lib/` folder.
+The tools can then be run in the following way:
+
+    java -cp pt2matsim-VERSION.jar:libs org.matsim.pt2matsim.gtfs.Gtfs2TransitSchedule

--- a/pom.xml
+++ b/pom.xml
@@ -82,4 +82,36 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <defaultGoal>assembly:assembly</defaultGoal>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-assembly-plugin</artifactId>
+                            <configuration>
+                                <descriptors>
+                                    <descriptor>src/main/assembly/assembly-release.xml</descriptor>
+                                </descriptors>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <artifactId>maven-jar-plugin</artifactId>
+                            <configuration>
+                                <archive>
+                                    <manifest>
+                                        <addClasspath>true</addClasspath>
+                                        <classpathPrefix>libs/</classpathPrefix>
+                                    </manifest>
+                                </archive>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/assembly/assembly-release.xml
+++ b/src/main/assembly/assembly-release.xml
@@ -1,0 +1,25 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+	<id>release</id>
+	<includeBaseDirectory>true</includeBaseDirectory>
+	<baseDirectory>${artifactId}-${version}</baseDirectory>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+			<outputDirectory>/</outputDirectory>
+		</file>
+	</files>
+	
+	<dependencySets>
+		<dependencySet>
+			<useProjectArtifact>false</useProjectArtifact>
+			<outputDirectory>/libs/</outputDirectory>
+			<unpack>false</unpack>
+		</dependencySet>
+	</dependencySets>
+
+</assembly>


### PR DESCRIPTION
I added a release profile to the pom to create a runnable version of the pt2matsim tools (so they can be e.g. used on a cluster). Additionally I added some instructions to the README.