### PR TITLE
it is possible for a min_transfer_time to be null.

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/gtfs/lib/TransferImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/lib/TransferImpl.java
@@ -80,7 +80,15 @@ public class TransferImpl implements Transfer {
 		return (other.getFromStopId().equals(this.getFromStopId()) &&
 				other.getToStopId().equals(this.getToStopId()) &&
 				other.getTransferType().equals(this.getTransferType()) &&
-				other.minTransferTime().equals(this.minTransferTime()));
+				equalsMinTransferTime(other));
+	}
+
+	private boolean equalsMinTransferTime(Transfer other) {
+		if (other.minTransferTime() == null) {
+			return this.minTransferTime == null;
+		} else {
+			return other.minTransferTime().equals(this.minTransferTime());
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This commit fixes a bug in the compare method where otherwise would a NullPointerException be thrown. Sample where this bug occured was from
here: https://daten.berlin.de/datensaetze/vbb-fahrplandaten-dezember-2017-bis-dezember-2018
DOKU: https://developers.google.com/transit/gtfs/reference/#transferstxt