### PR TITLE
Always assume UTF-8 as encoding for HAFAS data

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANReader.java
@@ -55,7 +55,7 @@ public class FPLANReader {
 			FPLANRoute currentFPLANRoute = null;
 
 			Counter counter = new Counter("FPLAN line # ");
-			BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(FPLANfile)));
+			BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(FPLANfile), "utf-8"));
 			String newLine = readsLines.readLine();
 			while(newLine != null) {
 				if(newLine.charAt(0) == '*') {

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANReader.java
@@ -55,7 +55,7 @@ public class FPLANReader {
 			FPLANRoute currentFPLANRoute = null;
 
 			Counter counter = new Counter("FPLAN line # ");
-			BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(FPLANfile), "utf-8"));
+			BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(FPLANfile)));
 			String newLine = readsLines.readLine();
 			while(newLine != null) {
 				if(newLine.charAt(0) == '*') {

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/OperatorReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/OperatorReader.java
@@ -37,7 +37,7 @@ public class OperatorReader {
 
 	public static Map<String, String> readOperators(String BETRIEB_DE) throws IOException {
 		Map<String, String> operators = new HashMap<>();
-		BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(BETRIEB_DE)));
+		BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(BETRIEB_DE), "utf-8"));
 		String newLine = readsLines.readLine();
 		while (newLine != null) {
 			String abbrevationOperator = newLine.split("\"")[1].replace(" ","");

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/OperatorReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/OperatorReader.java
@@ -37,7 +37,7 @@ public class OperatorReader {
 
 	public static Map<String, String> readOperators(String BETRIEB_DE) throws IOException {
 		Map<String, String> operators = new HashMap<>();
-		BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(BETRIEB_DE), "latin1"));
+		BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(BETRIEB_DE)));
 		String newLine = readsLines.readLine();
 		while (newLine != null) {
 			String abbrevationOperator = newLine.split("\"")[1].replace(" ","");

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/StopReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/StopReader.java
@@ -64,7 +64,7 @@ public class StopReader {
 
 	private void createStops() throws IOException {
 		log.info("  Read transit stops...");
-			BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(pathToBFKOORD_GEOFile)));
+			BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(pathToBFKOORD_GEOFile), "utf-8"));
 			String newLine = readsLines.readLine();
 			while (newLine != null) {
 				/*

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/StopReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/StopReader.java
@@ -64,7 +64,7 @@ public class StopReader {
 
 	private void createStops() throws IOException {
 		log.info("  Read transit stops...");
-			BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(pathToBFKOORD_GEOFile), "latin1"));
+			BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(pathToBFKOORD_GEOFile)));
 			String newLine = readsLines.readLine();
 			while (newLine != null) {
 				/*


### PR DESCRIPTION
I think the most sensible configuration here is to always assume input as UTF-8, at least with the HAFAS 2017 and 2018 this works. Maybe there has been a change somewhere in the past.