### PR TITLE
Convert gtfs trips to transitRoutes one to one

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
@@ -20,6 +20,7 @@ package org.matsim.pt2matsim.gtfs;
 
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
+import org.matsim.core.utils.collections.MapUtils;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.*;
 import org.matsim.pt2matsim.gtfs.lib.*;
@@ -30,10 +31,7 @@ import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.Vehicles;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Converts a GTFS feed to a MATSim transit schedule
@@ -51,33 +49,34 @@ public class GtfsConverter {
 
 	protected static Logger log = Logger.getLogger(GtfsConverter.class);
 	private final GtfsFeed feed;
+	private final TransitScheduleFactory scheduleFactory = ScheduleTools.createSchedule().getFactory();
 
-	private LocalDate dateUsed = null;
-
-	private TransitSchedule schedule;
-	private Vehicles vhcls;
+	private TransitSchedule transitSchedule;
+	private Vehicles vehiclesContainer;
 
 	public GtfsConverter(GtfsFeed gtfsFeed) {
 		this.feed = gtfsFeed;
 	}
 
+	/**
+	 * @return the converted schedule (field, see {@link #getSchedule()}}
+	 */
 	public TransitSchedule convert(String serviceIdsParam, String outputCoordinateSystem) {
-		TransitSchedule schedule = ScheduleTools.createSchedule();
-		convert(serviceIdsParam, outputCoordinateSystem, schedule, VehicleUtils.createVehiclesContainer());
-		return schedule;
+		convert(serviceIdsParam, outputCoordinateSystem, ScheduleTools.createSchedule(), VehicleUtils.createVehiclesContainer());
+		return getSchedule();
 	}
 
 
 	public TransitSchedule getSchedule() {
-		return schedule;
+		return this.transitSchedule;
 	}
 
 	public Vehicles getVehicles() {
-		return vhcls;
+		return this.vehiclesContainer;
 	}
 
 	/**
-	 * Converts the loaded gtfs data to a matsim transit schedule
+	 * Converts the loaded gtfs data to the given matsim transit schedule
 	 * <ol>
 	 * <li>generate transitStopFacilities from gtfsStops</li>
 	 * <li>Create a transitLine for each Route</li>
@@ -87,164 +86,200 @@ public class GtfsConverter {
 	 * <li>add transitRoute to the transitLine and thus to the schedule</li>
 	 * </ol>
 	 */
-	public void convert(String serviceIdsParam, String transformation, TransitSchedule transitSchedule, Vehicles vehicles) {
+	public void convert(String serviceIdsParam, String transformation, TransitSchedule schedule, Vehicles vehicles) {
 		log.info("#####################################");
 		log.info("Converting to MATSim transit schedule");
 
+		// transform feed
+		this.feed.transform(transformation);
+
+		// get sample date
 		LocalDate extractDate = getExtractDate(serviceIdsParam);
+		if(extractDate != null) log.info("     Extracting schedule from date " + extractDate);
 
-		if(extractDate != null) log.info("    Extracting schedule from date " + extractDate);
-
-		this.schedule = transitSchedule;
-		this.vhcls = vehicles;
-
-		TransitScheduleFactory scheduleFactory = schedule.getFactory();
-
-		int counterLines = 0;
-		int counterRoutes = 0;
-
-		feed.transform(transformation);
-
-		/* [1]
-		  generating transitStopFacilities (mts) from gtfsStops and add them to the schedule.
-		  Coordinates are transformed here.
-		 */
-		for(Map.Entry<String, Stop> stopEntry : feed.getStops().entrySet()) {
-			TransitStopFacility stopFacility = scheduleFactory.createTransitStopFacility(Id.create(stopEntry.getKey(), TransitStopFacility.class), stopEntry.getValue().getCoord(), BLOCKS_DEFAULT);
-			stopFacility.setName(stopEntry.getValue().getName());
+		// generate TransitStopFacilities from gtfsStops and add them to the schedule
+		for(Stop stop : this.feed.getStops().values()) {
+			TransitStopFacility stopFacility = createStopFacility(stop);
 			schedule.addStopFacility(stopFacility);
 		}
 
-		if(feed.usesFrequencies()) {
+		// info
+		log.info("    Creating TransitLines from routes and TransitRoutes from trips...");
+		if(this.feed.usesFrequencies()) {
 			log.info("    Using frequencies.txt to generate departures");
 		} else {
 			log.info("    Using stop_times.txt to generate departures");
 		}
 
-		for(Route gtfsRoute : feed.getRoutes().values()) {
-			/* [2]
-			  Create a MTS transitLine for each Route
-			 */
-			TransitLine transitLine = scheduleFactory.createTransitLine(Id.create(gtfsRoute.getId(), TransitLine.class));
-			transitLine.setName(gtfsRoute.getShortName());
-			schedule.addTransitLine(transitLine);
-			counterLines++;
+		for(Route gtfsRoute : this.feed.getRoutes().values()) {
+			// create a MATSim TransitLine for each Route
+			TransitLine newTransitLine = createTransitLine(gtfsRoute);
+			schedule.addTransitLine(newTransitLine);
 
-			Map<Id<TransitRoute>, Id<RouteShape>> routeShapeAssignment = new HashMap<>();
-
-			/* [3]
-			  loop through each trip for the gtfsRoute and generate transitRoute (if the serviceId is correct)
-			 */
+			// create TransitRoute for each trip
 			for(Trip trip : gtfsRoute.getTrips().values()) {
-				Id<RouteShape> shapeId = trip.getShape() != null ? trip.getShape().getId() : null;
-
+				// check if the trip actually runs on the extract date
 				if(trip.getService().runsOnDate(extractDate)) {
-					/* [4]
-					  Get the stop sequence (with arrivalOffset and departureOffset) of the trip.
-					 */
-					List<TransitRouteStop> transitRouteStops = new ArrayList<>();
-					int startTime = trip.getStopTimes().first().getArrivalTime();
-					int firstSequencePos = trip.getStopTimes().first().getSequencePosition();
-					int lastSequencePos = trip.getStopTimes().last().getSequencePosition();
-
-					for(StopTime stopTime : trip.getStopTimes()) {
-						double arrivalOffset = Time.UNDEFINED_TIME, departureOffset = Time.UNDEFINED_TIME;
-
-						// add arrivalOffset time if current stopTime is not on the first stop of the route
-						if(!stopTime.getSequencePosition().equals(firstSequencePos)) {
-							arrivalOffset = stopTime.getArrivalTime() - startTime;
-						}
-
-						// add departure time if current stopTime is not on the last stop of the route
-						if(!stopTime.getSequencePosition().equals(lastSequencePos)) {
-							departureOffset = stopTime.getArrivalTime() - startTime;
-						}
-						TransitRouteStop newTRS = scheduleFactory.createTransitRouteStop(schedule.getFacilities().get(Id.create(stopTime.getStop().getId(), TransitStopFacility.class)), arrivalOffset, departureOffset);
-						newTRS.setAwaitDepartureTime(AWAIT_DEPARTURE_TIME_DEFAULT);
-						transitRouteStops.add(newTRS);
-					}
-
-					/* [5.1]
-					  Calculate departures from frequencies (if available)
-					 */
-					TransitRoute transitRoute;
-					if(feed.usesFrequencies()) {
-						transitRoute = scheduleFactory.createTransitRoute(Id.create(trip.getId(), TransitRoute.class), null, transitRouteStops, gtfsRoute.getRouteType().name);
-
-						for(Frequency frequency : trip.getFrequencies()) {
-							for(int t = frequency.getStartTime(); t < frequency.getEndTime(); t += frequency.getHeadWaySecs()) {
-								Departure newDeparture = scheduleFactory.createDeparture(createDepartureId(transitRoute, t), t);
-								transitRoute.addDeparture(newDeparture);
-							}
-						}
-						transitLine.addRoute(transitRoute);
-						counterRoutes++;
-					} else {
-
-						/* [5.2]
-						  Calculate departures from stopTimes
-						 */
-
-						/*
-						if stop sequence is already used in the same transitLine: just add new departure for the
-						transitRoute that uses that stop sequence
-						 */
-						boolean createNewTransitRoute = true;
-
-						for(TransitRoute currentTransitRoute : transitLine.getRoutes().values()) {
-							if(currentTransitRoute.getStops().equals(transitRouteStops)) {
-								if(routeShapeAssignment.get(currentTransitRoute.getId()) == shapeId) {
-									Id<Departure> departureId = createDepartureId(currentTransitRoute, startTime);
-									if((!currentTransitRoute.getDepartures().containsKey(departureId))) {
-										Departure newDeparture = scheduleFactory.createDeparture(departureId, startTime);
-										currentTransitRoute.addDeparture(newDeparture);
-										createNewTransitRoute = false;
-										break;
-									}
-								}
-							}
-						}
-
-						/*
-						if stop sequence is not used yet, create a new transitRoute (with transitRouteStops)
-						and add the departure
-						 */
-						if(createNewTransitRoute) {
-							transitRoute = scheduleFactory.createTransitRoute(Id.create(trip.getId(), TransitRoute.class), null, transitRouteStops, gtfsRoute.getRouteType().name);
-							Departure newDeparture = scheduleFactory.createDeparture(createDepartureId(transitRoute, startTime), startTime);
-							transitRoute.addDeparture(newDeparture);
-
-							if(shapeId != null) ScheduleTools.setShapeId(transitRoute, trip.getShape().getId());
-							routeShapeAssignment.put(transitRoute.getId(), shapeId);
-
-							transitLine.addRoute(transitRoute);
-							counterRoutes++;
-						}
-					}
+					TransitRoute transitRoute = createTransitRoute(trip, schedule.getFacilities());
+					newTransitLine.addRoute(transitRoute);
 				}
-			} // foreach trip
-		} // foreach route
+			}
+		}
 
-		/*
-		  Create default vehicles.
-		 */
-		ScheduleTools.createVehicles(schedule, vhcls);
+		// combine TransitRoutes with identical stop/time sequences, add departures
+		combineTransitRoutes(schedule);
 
+		// create default vehicles
+		createVehicles(schedule, vehicles);
+
+		// statistics
+		int counterLines = 0;
+		int counterRoutes = 0;
+		for(TransitLine transitLine : schedule.getTransitLines().values()) {
+			counterLines++;
+			counterRoutes += transitLine.getRoutes().size();
+		}
 		log.info("    Created " + counterRoutes + " routes on " + counterLines + " lines.");
-		if(dateUsed != null) log.info("    Day " + dateUsed);
+		if(extractDate != null) log.info("    Day " + extractDate);
 		log.info("... GTFS converted to an unmapped MATSIM Transit Schedule");
 		log.info("#########################################################");
+
+		this.transitSchedule = schedule;
+		this.vehiclesContainer = vehicles;
 	}
 
-	private Id<Departure> createDepartureId(TransitRoute route, int time) {
+	protected void combineTransitRoutes(TransitSchedule schedule) {
+		log.info("Combining TransitRoutes with equal stop sequence and departure offsets...");
+		int combined = 0;
+		for(TransitLine transitLine : schedule.getTransitLines().values()) {
+			Map<List<String>, List<TransitRoute>> profiles = new HashMap<>();
+			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {
+				List<String> sequence = new LinkedList<>();
+				for(TransitRouteStop routeStop : transitRoute.getStops()) {
+					String s = routeStop.getStopFacility().getId().toString() + "-" + (int) routeStop.getDepartureOffset();
+					sequence.add(s);
+				}
+				MapUtils.getList(sequence, profiles).add(transitRoute);
+			}
+
+			for(List<TransitRoute> routeList : profiles.values()) {
+				if(routeList.size() > 1) {
+					TransitRoute finalRoute = routeList.get(0);
+					for(int i = 1; i < routeList.size(); i++) {
+						TransitRoute routeToRemove = routeList.get(i);
+						routeToRemove.getDepartures().values().forEach(finalRoute::addDeparture);
+						transitLine.removeRoute(routeToRemove);
+						combined++;
+					}
+				}
+			}
+		}
+		log.info("... Combined " + combined + " transit routes");
+	}
+
+	protected TransitRoute createTransitRoute(Trip trip, Map<Id<TransitStopFacility>, TransitStopFacility> stopFacilities) {
+		Id<RouteShape> shapeId = trip.getShape() != null ? trip.getShape().getId() : null;
+
+		// Get the stop sequence (with arrivalOffset and departureOffset) of the trip.
+		List<TransitRouteStop> transitRouteStops = new ArrayList<>();
+		// create transit route stops
+		for(StopTime stopTime : trip.getStopTimes()) {
+			TransitRouteStop newTransitRouteStop = createTransitRouteStop(stopTime, trip, stopFacilities);
+			transitRouteStops.add(newTransitRouteStop);
+		}
+
+		// Calculate departures from frequencies (if available)
+		TransitRoute transitRoute;
+		if(this.feed.usesFrequencies()) {
+			transitRoute = this.scheduleFactory.createTransitRoute(createTransitRouteId(trip), null, transitRouteStops, trip.getRoute().getRouteType().name);
+
+			for(Frequency frequency : trip.getFrequencies()) {
+				for(int t = frequency.getStartTime(); t < frequency.getEndTime(); t += frequency.getHeadWaySecs()) {
+					Departure newDeparture = this.scheduleFactory.createDeparture(createDepartureId(transitRoute, t), t);
+					transitRoute.addDeparture(newDeparture);
+				}
+			}
+			return transitRoute;
+		} else {
+			// Calculate departures from stopTimes
+			int routeStartTime = trip.getStopTimes().first().getDepartureTime();
+
+			transitRoute = this.scheduleFactory.createTransitRoute(createTransitRouteId(trip), null, transitRouteStops, trip.getRoute().getRouteType().name);
+			Departure newDeparture = this.scheduleFactory.createDeparture(createDepartureId(transitRoute, routeStartTime), routeStartTime);
+			transitRoute.addDeparture(newDeparture);
+
+			if(shapeId != null) ScheduleTools.setShapeId(transitRoute, trip.getShape().getId());
+
+			return transitRoute;
+		}
+	}
+
+	protected TransitRouteStop createTransitRouteStop(StopTime stopTime, Trip trip, Map<Id<TransitStopFacility>, TransitStopFacility> stopFacilities) {
+		double arrivalOffset = Time.UNDEFINED_TIME, departureOffset = Time.UNDEFINED_TIME;
+
+		int routeStartTime = trip.getStopTimes().first().getArrivalTime();
+		int firstSequencePos = trip.getStopTimes().first().getSequencePosition();
+		int lastSequencePos = trip.getStopTimes().last().getSequencePosition();
+
+
+		// add arrivalOffset time if current stopTime is not on the first stop of the route
+		if(!stopTime.getSequencePosition().equals(firstSequencePos)) {
+			arrivalOffset = stopTime.getArrivalTime() - routeStartTime;
+		}
+
+		// add departure time if current stopTime is not on the last stop of the route
+		if(!stopTime.getSequencePosition().equals(lastSequencePos)) {
+			departureOffset = stopTime.getArrivalTime() - routeStartTime;
+		}
+
+		TransitStopFacility stopFacility = stopFacilities.get(createStopFacilityId(stopTime.getStop()));
+
+		TransitRouteStop newTransitRouteStop = this.scheduleFactory.createTransitRouteStop(stopFacility, arrivalOffset, departureOffset);
+		newTransitRouteStop.setAwaitDepartureTime(AWAIT_DEPARTURE_TIME_DEFAULT);
+		return newTransitRouteStop;
+	}
+
+	protected TransitLine createTransitLine(Route gtfsRoute) {
+		Id<TransitLine> id = createTransitLineId(gtfsRoute);
+		TransitLine line = this.scheduleFactory.createTransitLine(id);
+		line.setName(gtfsRoute.getShortName());
+		return line;
+	}
+
+	protected TransitStopFacility createStopFacility(Stop stop) {
+		Id<TransitStopFacility> id = createStopFacilityId(stop);
+		TransitStopFacility stopFacility = this.scheduleFactory.createTransitStopFacility(id, stop.getCoord(), BLOCKS_DEFAULT);
+		stopFacility.setName(stop.getName());
+		stopFacility.setStopPostAreaId(stop.getParentStationId());
+		return stopFacility;
+	}
+
+	protected Id<TransitLine> createTransitLineId(Route gtfsRoute) {
+		String id = gtfsRoute.getId();
+		return Id.create(id, TransitLine.class);
+	}
+
+	protected Id<TransitRoute> createTransitRouteId(Trip trip) {
+		return Id.create(trip.getId(), TransitRoute.class);
+	}
+
+	protected Id<TransitStopFacility> createStopFacilityId(Stop stop) {
+		return Id.create(stop.getId(), TransitStopFacility.class);
+	}
+
+	protected Id<Departure> createDepartureId(TransitRoute route, int time) {
 		String str = route.getId().toString() + "_" + Time.writeTime(time, "HH:mm:ss");
 		return Id.create(str, Departure.class);
+	}
+
+	protected void createVehicles(TransitSchedule schedule, Vehicles vehicles) {
+		ScheduleTools.createVehicles(schedule, vehicles);
 	}
 
 	/**
 	 * @return The date from which services and thus trips should be extracted
 	 */
-	private LocalDate getExtractDate(String param) {
+	protected LocalDate getExtractDate(String param) {
 		switch(param) {
 			case ALL_SERVICE_IDS: {
 				log.warn("    Using all trips is not recommended");


### PR DESCRIPTION
GTFS converter first creates all transit routes based on trips. Afterwards, transit routes with equal stop sequences and departure offsets are combined by adding departures. This is a change from previous behaviour where departure offsets were ignored. Transit routes with similar but unequal departure offsets should be combined in a later step (not implemented in pt2matsim).

Plus some minor fixes.