### PR TITLE
Plausibility check as geojson

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,11 +301,9 @@ The following files are created in the output folder:
 - _allPlausibilityWarnings.csv_: shows all plausibility warnings in a csv file
 - _stopfacilities.csv_: the number of child stop facilities for all stop facilities as csv
 - _stopfacilities_histogram.png_: a histogram as png showing the number of child stop facilities
-- _shp/warnings/WarningsLoops.shp_: Loops warnings as polyline shapefile
-- _shp/warnings/WarningsTravelTime.shp_: Travel time warnings as polyline shapefile
-- _shp/warnings/WarningsDirectionChange.shp_: Direction change warnings as polyline shapefile
-- _shp/schedule/TransitRoutes.shp_: Transit routes of the schedule as polyline shapefile
-- _shp/schedule/StopFacilities.shp_: Stop Facilities as point shapefile
-- _shp/schedule/StopFacilities_refLinks.shp_: The stop facilities' reference links as polyline shapefile
+- _PlausibilityWarnings.geojson_: Contains all warnings for groups of links
+- _schedule/TransitRoutes.geojson_: Transit routes of the schedule as lines
+- _schedule/StopFacilities.geojson_: Stop Facilities as points
+- _schedule/StopFacilities_refLinks.geojson_: The stop facilities' reference links as polyline shapefile
 
-Shapefiles can be viewed in a GIS, a recommended open source application is [QGIS](https://www.qgis.org). It is also possible to view them in [via](https://www.simunto.com/via/). However, no line attributes can be displayed or viewed there.
+Geojson files can be viewed in a GIS, a recommended open source application is [QGIS](https://www.qgis.org).

--- a/README.md
+++ b/README.md
@@ -301,9 +301,30 @@ The following files are created in the output folder:
 - _allPlausibilityWarnings.csv_: shows all plausibility warnings in a csv file
 - _stopfacilities.csv_: the number of child stop facilities for all stop facilities as csv
 - _stopfacilities_histogram.png_: a histogram as png showing the number of child stop facilities
-- _PlausibilityWarnings.geojson_: Contains all warnings for groups of links
-- _schedule/TransitRoutes.geojson_: Transit routes of the schedule as lines
-- _schedule/StopFacilities.geojson_: Stop Facilities as points
-- _schedule/StopFacilities_refLinks.geojson_: The stop facilities' reference links as polyline shapefile
+- _plausibilityWarnings.geojson_: Contains all warnings for groups of links
+- _schedule_transitRoutes.geojson_: Transit routes of the schedule as lines
+- _schedule_stopFacilities.geojson_: Stop Facilities as points
+- _schedule_stopFacilities_refLinks.geojson_: The stop facilities' reference links as lines
+- _network.geojson_: Network as geojson file containing nodes and links
 
-Geojson files can be viewed in a GIS, a recommended open source application is [QGIS](https://www.qgis.org).
+Geojson files can be viewed in a GIS, a recommended open source application is [QGIS](https://www.qgis.org). It
+allows drag and drop loading and viewing of the plausibility results, network and schedule files.
+
+#### Travel Time Warning
+Warns if the travel time given by the schedule cannot be achieved by a transit route. This indicates that the
+network's freespeed values or link lengths are not suitable for the given transit route. A warning can also point
+to large detours due to one-way or missing links.
+
+#### Artificial Link Warning
+Warns if a link is an artificial link (i.e. created by the pt mapper). To prevent these warnings, edit
+the network before pt mapping in a way that every stop - that should not use artificial links - has a feasible
+link nearby.
+
+#### Loop warning
+Warns if a transit route's link sequence passes a node twice. This might be intended behaviour if a route really has
+loops. Otherwise it might indicate detours due to wrongly chosen link candidates.
+
+#### Direction Change Warning
+Warns if a link sequence has abrupt direction changes. This means by default >60° for bus and >30° for rail.
+Whether they point to real problems depends on network accuracy. Abrupt direction changes in itself do not impact
+a simulation.

--- a/src/main/java/org/matsim/pt2matsim/plausibility/NearbyLinkAnalysis.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/NearbyLinkAnalysis.java
@@ -40,6 +40,7 @@ import java.util.*;
  */
 public class NearbyLinkAnalysis {
 
+	/** Example code/paths **/
 	public static void main(String[] args) {
 		String base = "zvv/";
 		String inputNetworkFile = base + "network/network_unmapped.xml.gz";

--- a/src/main/java/org/matsim/pt2matsim/plausibility/PlausibilityCheck.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/PlausibilityCheck.java
@@ -103,8 +103,8 @@ public class PlausibilityCheck {
 		this.coordinateSystem = coordinateSystem;
 
 		this.thresholds = new HashMap<>();
-		this.thresholds.put("bus", 0.7 * PI);
-		this.thresholds.put("rail", 0.3 * PI);
+		this.thresholds.put("bus", 0.6667 * PI);
+		this.thresholds.put("rail", 0.3333 * PI);
 		this.ttRange = 65;
 
 		this.warnings.put(PlausibilityWarning.Type.ArtificialLinkWarning, new HashSet<>());

--- a/src/main/java/org/matsim/pt2matsim/plausibility/PlausibilityCheck.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/PlausibilityCheck.java
@@ -105,7 +105,7 @@ public class PlausibilityCheck {
 		this.thresholds = new HashMap<>();
 		this.thresholds.put("bus", 0.7 * PI);
 		this.thresholds.put("rail", 0.3 * PI);
-		this.ttRange = 60;
+		this.ttRange = 65;
 
 		this.warnings.put(PlausibilityWarning.Type.ArtificialLinkWarning, new HashSet<>());
 		this.warnings.put(PlausibilityWarning.Type.DirectionChangeWarning, new HashSet<>());

--- a/src/main/java/org/matsim/pt2matsim/plausibility/log/ArtificialLinkWarning.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/log/ArtificialLinkWarning.java
@@ -25,7 +25,7 @@ import org.matsim.pt.transitSchedule.api.TransitRoute;
 import java.util.ArrayList;
 
 /**
- * Plausibility warning if a link sequence has abrupt direction changes
+ * Plausibility warning if a link is an artificial link (i.e. created by the pt mapper).
  *
  * @author polettif
  */

--- a/src/main/java/org/matsim/pt2matsim/plausibility/log/DirectionChangeWarning.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/log/DirectionChangeWarning.java
@@ -25,7 +25,7 @@ import org.matsim.pt.transitSchedule.api.TransitRoute;
 import java.util.ArrayList;
 
 /**
- * Plausibility warning if a link sequence has abrupt direction changes
+ * Plausibility warning if a link sequence has abrupt direction changes.
  *
  * @author polettif
  */

--- a/src/main/java/org/matsim/pt2matsim/plausibility/log/LoopWarning.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/log/LoopWarning.java
@@ -28,7 +28,7 @@ import org.matsim.pt2matsim.tools.ScheduleTools;
 import java.util.List;
 
 /**
- * Plausibility warning if a link sequence passes a node twice
+ * Plausibility warning if a link sequence passes a node twice.
  *
  * @author polettif
  */

--- a/src/main/java/org/matsim/pt2matsim/plausibility/log/TravelTimeWarning.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/log/TravelTimeWarning.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 /**
  * Plausibility warning if the travel time given by the schedule
- * cannot be achieved by a transit route
+ * cannot be achieved by a transit route.
  *
  * @author polettif
  */

--- a/src/main/java/org/matsim/pt2matsim/run/CheckMappedSchedulePlausibility.java
+++ b/src/main/java/org/matsim/pt2matsim/run/CheckMappedSchedulePlausibility.java
@@ -25,8 +25,8 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.utils.TransitScheduleValidator;
 import org.matsim.pt2matsim.plausibility.PlausibilityCheck;
 import org.matsim.pt2matsim.plausibility.StopFacilityHistogram;
+import org.matsim.pt2matsim.run.gis.Network2Geojson;
 import org.matsim.pt2matsim.run.gis.Schedule2Geojson;
-import org.matsim.pt2matsim.run.gis.Schedule2ShapeFile;
 import org.matsim.pt2matsim.tools.NetworkTools;
 import org.matsim.pt2matsim.tools.ScheduleTools;
 
@@ -64,11 +64,13 @@ public final class CheckMappedSchedulePlausibility {
 	 * <li>allPlausibilityWarnings.csv: shows all plausibility warnings in a csv file</li>
 	 * <li>stopfacilities.csv: the number of child stop facilities for all stop facilities as csv</li>
 	 * <li>stopfacilities_histogram.png: a histogram as png showing the number of child stop facilities</li>
-	 * <li>PlausibilityWarnings.geojson: Contains all warnings for groups of links</li>
-	 * <li>schedule/TransitRoutes.geojson: Transit routes of the schedule as lines</li>
-	 * <li>schedule/StopFacilities.geojson: Stop Facilities as points</li>
-	 * <li>schedule/StopFacilities_refLinks.geojson: The stop facilities' reference links as polyline shapefile</li>
+	 * <li>plausibilityWarnings.geojson: Contains all warnings for groups of links</li>
+	 * <li>schedule_TransitRoutes.geojson: Transit routes of the schedule as lines</li>
+	 * <li>schedule_TtopFacilities.geojson: Stop Facilities as points</li>
+	 * <li>schedule_StopFacilities_refLinks.geojson: The stop facilities' reference links as lines</li>
+	 * <li>network.geojson: Network as geojson file containing nodes and links</li>
 	 * </ul>
+	 *
 	 * Geojson can be viewed in an GIS, a recommended open source GIS is QGIS.
 	 *
 	 * @param scheduleFile     the schedule file
@@ -97,24 +99,28 @@ public final class CheckMappedSchedulePlausibility {
 		}
 
 		new File(outputFolder).mkdir();
-		new File(outputFolder + "schedule/").mkdir();
 		check.writeCsv(outputFolder + "allPlausibilityWarnings.csv");
-		check.writeResultsGeojson( outputFolder + "PlausibilityWarnings.geojson");
+		check.writeResultsGeojson( outputFolder + "plausibilityWarnings.geojson");
 
-		// Uncomment for shapefile output
-//		new File(outputFolder + "warnings_shp/").mkdir();
-//		check.writeResultShapeFiles(outputFolder + "warnings_shp/");
+		// "legacy" shapefile output
+		if(false) {
+			new File(outputFolder + "warnings_shp/").mkdir();
+			check.writeResultShapeFiles(outputFolder + "warnings_shp/");
+		}
 
 		// transit schedule as geojson
 		Schedule2Geojson schedule2geojson = new Schedule2Geojson(coordinateSystem, schedule, network);
-		schedule2geojson.writeTransitRoutes(outputFolder + "schedule/TransitRoutes.geojson");
-		schedule2geojson.writeStopFacilities(outputFolder + "schedule/StopFacilities.geojson");
-		schedule2geojson.writeStopRefLinks(outputFolder + "schedule/StopFacilities_refLinks.geojson");
+		schedule2geojson.writeTransitRoutes(outputFolder + "schedule_TransitRoutes.geojson");
+		schedule2geojson.writeStopFacilities(outputFolder + "schedule_StopFacilities.geojson");
+		schedule2geojson.writeStopRefLinks(outputFolder + "schedule_StopFacilities_refLinks.geojson");
 
 		// stop facility histogram
 		StopFacilityHistogram histogram = new StopFacilityHistogram(schedule);
 		histogram.createCsv(outputFolder + "stopfacilities.csv");
 		histogram.createPng(outputFolder + "stopfacilities_histogram.png");
+
+		// write network
+		Network2Geojson.run(network, outputFolder + "network.geojson");
 
 		check.printStatisticsLog();
 	}

--- a/src/main/java/org/matsim/pt2matsim/run/CheckMappedSchedulePlausibility.java
+++ b/src/main/java/org/matsim/pt2matsim/run/CheckMappedSchedulePlausibility.java
@@ -25,6 +25,7 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.utils.TransitScheduleValidator;
 import org.matsim.pt2matsim.plausibility.PlausibilityCheck;
 import org.matsim.pt2matsim.plausibility.StopFacilityHistogram;
+import org.matsim.pt2matsim.run.gis.Schedule2Geojson;
 import org.matsim.pt2matsim.run.gis.Schedule2ShapeFile;
 import org.matsim.pt2matsim.tools.NetworkTools;
 import org.matsim.pt2matsim.tools.ScheduleTools;
@@ -41,10 +42,11 @@ public final class CheckMappedSchedulePlausibility {
 	/**
 	 * Performs a plausibility check on the given schedule and network files
 	 * and writes the results to the output folder.
-	 * @param args	[0] schedule file
-	 *              [1] network file
-	 *              [2]	coordinate system (of both schedule and network)
-	 *              [3]	output folder
+	 *
+	 * @param args [0] schedule file
+	 *             [1] network file
+	 *             [2] coordinate system (of both schedule and network)
+	 *             [3] output folder
 	 */
 	public static void main(final String[] args) {
 		if(args.length == 4) {
@@ -54,29 +56,26 @@ public final class CheckMappedSchedulePlausibility {
 		}
 	}
 
+	// TODO update readme
 	/**
 	 * Performs a plausibility check on the given schedule and network files
 	 * and writes the results to the output folder. The following files are
 	 * created in the output folder:
 	 * <ul>
-	 * 	<li>allPlausibilityWarnings.csv: shows all plausibility warnings in a csv file</li>
-	 * 	<li>stopfacilities.csv: the number of child stop facilities for all stop facilities as csv</li>
-	 * 	<li>stopfacilities_histogram.png: a histogram as png showing the number of child stop facilities</li>
-	 * 	<li>shp/warnings/WarningsLoops.shp: Loops warnings as polyline shapefile</li>
-	 * 	<li>shp/warnings/WarningsTravelTime.shp: Travel time warnings as polyline shapefile</li>
-	 * 	<li>shp/warnings/WarningsDirectionChange.shp: Direction change warnings as polyline shapefile</li>
-	 * 	<li>shp/schedule/TransitRoutes.shp: Transit routes of the schedule as polyline shapefile</li>
-	 * 	<li>shp/schedule/StopFacilities.shp: Stop Facilities as point shapefile</li>
-	 * 	<li>shp/schedule/StopFacilities_refLinks.shp: The stop facilities' reference links as polyline shapefile</li>
+	 * <li>allPlausibilityWarnings.csv: shows all plausibility warnings in a csv file</li>
+	 * <li>stopfacilities.csv: the number of child stop facilities for all stop facilities as csv</li>
+	 * <li>stopfacilities_histogram.png: a histogram as png showing the number of child stop facilities</li>
+	 * <li>PlausibilityWarnings.geojson: Contains all warnings for groups of links</li>
+	 * <li>schedule/TransitRoutes.geojson: Transit routes of the schedule as lines</li>
+	 * <li>schedule/StopFacilities.geojson: Stop Facilities as points</li>
+	 * <li>schedule/StopFacilities_refLinks.geojson: The stop facilities' reference links as polyline shapefile</li>
 	 * </ul>
-	 * Shapefiles can be viewed in an GIS, a recommended open source GIS is QGIS. It is also possible to view them in senozon VIA.
-	 * However, no line attributes can be displayed or viewed there.
-	 * @param scheduleFile the schedule file
-	 * @param networkFile network file
+	 * Geojson can be viewed in an GIS, a recommended open source GIS is QGIS.
+	 *
+	 * @param scheduleFile     the schedule file
+	 * @param networkFile      network file
 	 * @param coordinateSystem A name used by {@link MGC}. Use EPSG:* code to avoid problems.
-	 * @param outputFolder the output folder where all csv and shapefiles are written
-	 *
-	 *
+	 * @param outputFolder     the output folder where all csv and shapefiles are written
 	 */
 	public static void run(String scheduleFile, String networkFile, String coordinateSystem, String outputFolder) {
 		PlausibilityCheck.setLogLevels();
@@ -99,17 +98,14 @@ public final class CheckMappedSchedulePlausibility {
 		}
 
 		new File(outputFolder).mkdir();
-		new File(outputFolder+"shp/").mkdir();
-		new File(outputFolder+"shp/schedule/").mkdir();
-		//noinspection ResultOfMethodCallIgnored
-		new File(outputFolder+"shp/warnings/").mkdir();
+		new File(outputFolder + "schedule/").mkdir();
 		check.writeCsv(outputFolder + "allPlausibilityWarnings.csv");
-		check.writeResultShapeFiles(outputFolder+"shp/warnings/");
+		check.writeResultsGeojson( outputFolder + "PlausibilityWarnings.geojson");
 
-		Schedule2ShapeFile schedule2shp = new Schedule2ShapeFile(coordinateSystem, schedule, network);
-		schedule2shp.routes2Polylines(outputFolder+"shp/schedule/TransitRoutes.shp", true);
-		schedule2shp.stopFacilities2Points(outputFolder+"shp/schedule/StopFacilities.shp");
-		schedule2shp.stopRefLinks2Polylines(outputFolder+"shp/schedule/StopFacilities_refLinks.shp");
+		Schedule2Geojson schedule2geojson = new Schedule2Geojson(coordinateSystem, schedule, network);
+		schedule2geojson.writeTransitRoutes(outputFolder + "schedule/TransitRoutes.geojson");
+		schedule2geojson.writeStopFacilities(outputFolder + "schedule/StopFacilities.geojson");
+		schedule2geojson.writeStopRefLinks(outputFolder + "schedule/StopFacilities_refLinks.geojson");
 
 		// stop facility histogram
 		StopFacilityHistogram histogram = new StopFacilityHistogram(schedule);

--- a/src/main/java/org/matsim/pt2matsim/run/CheckMappedSchedulePlausibility.java
+++ b/src/main/java/org/matsim/pt2matsim/run/CheckMappedSchedulePlausibility.java
@@ -56,7 +56,6 @@ public final class CheckMappedSchedulePlausibility {
 		}
 	}
 
-	// TODO update readme
 	/**
 	 * Performs a plausibility check on the given schedule and network files
 	 * and writes the results to the output folder. The following files are
@@ -73,9 +72,9 @@ public final class CheckMappedSchedulePlausibility {
 	 * Geojson can be viewed in an GIS, a recommended open source GIS is QGIS.
 	 *
 	 * @param scheduleFile     the schedule file
-	 * @param networkFile      network file
+	 * @param networkFile      the network file
 	 * @param coordinateSystem A name used by {@link MGC}. Use EPSG:* code to avoid problems.
-	 * @param outputFolder     the output folder where all csv and shapefiles are written
+	 * @param outputFolder     the output folder where all files are written to
 	 */
 	public static void run(String scheduleFile, String networkFile, String coordinateSystem, String outputFolder) {
 		PlausibilityCheck.setLogLevels();
@@ -102,6 +101,11 @@ public final class CheckMappedSchedulePlausibility {
 		check.writeCsv(outputFolder + "allPlausibilityWarnings.csv");
 		check.writeResultsGeojson( outputFolder + "PlausibilityWarnings.geojson");
 
+		// Uncomment for shapefile output
+//		new File(outputFolder + "warnings_shp/").mkdir();
+//		check.writeResultShapeFiles(outputFolder + "warnings_shp/");
+
+		// transit schedule as geojson
 		Schedule2Geojson schedule2geojson = new Schedule2Geojson(coordinateSystem, schedule, network);
 		schedule2geojson.writeTransitRoutes(outputFolder + "schedule/TransitRoutes.geojson");
 		schedule2geojson.writeStopFacilities(outputFolder + "schedule/StopFacilities.geojson");

--- a/src/main/java/org/matsim/pt2matsim/tools/GeojsonTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/GeojsonTools.java
@@ -21,9 +21,11 @@ package org.matsim.pt2matsim.tools;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geojson.*;
 import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.network.Link;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -60,5 +62,14 @@ public class GeojsonTools {
 
 		lineFeature.setGeometry(geometry);
 		return lineFeature;
+	}
+
+	public static List<Coord> links2Coords(List<Link> links) {
+		List<Coord> coords = new ArrayList<>();
+		coords.add(links.get(0).getFromNode().getCoord());
+		for(Link link : links) {
+			coords.add(link.getToNode().getCoord());
+		}
+		return coords;
 	}
 }

--- a/src/main/java/org/matsim/pt2matsim/workbench/PTMapperShapesExample.java
+++ b/src/main/java/org/matsim/pt2matsim/workbench/PTMapperShapesExample.java
@@ -10,7 +10,7 @@ import org.matsim.pt2matsim.mapping.PTMapper;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRouters;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersGtfsShapes;
 import org.matsim.pt2matsim.plausibility.MappingAnalysis;
-import org.matsim.pt2matsim.run.gis.Schedule2Geojson;
+import org.matsim.pt2matsim.run.CheckMappedSchedulePlausibility;
 import org.matsim.pt2matsim.tools.GtfsTools;
 import org.matsim.pt2matsim.tools.NetworkTools;
 import org.matsim.pt2matsim.tools.ScheduleTools;
@@ -33,7 +33,7 @@ public class PTMapperShapesExample {
 
 	private static GtfsFeed gtfsFeed;
 
-	private static String unmappedScheduleFile = base + "unmapped_schedule.xml.gz";
+	private static String unmappedScheduleFile = outputFolder + "unmapped_schedule.xml.gz";
 	private static String networkOutput1 = outputFolder + "normal_network.xml.gz";
 	private static String scheduleOutput1 = outputFolder + "normal_schedule.xml.gz";
 	private static String networkOutput2 = outputFolder + "shapes_network.xml.gz";
@@ -44,8 +44,9 @@ public class PTMapperShapesExample {
 
 		convertGtfs();
 		mappingAnalysisNormal();
+		checkPlausibility();
 		mappingAnalysisWithShapes();
-		writeShapes();
+		writeGtfsShapes();
 	}
 
 	public static PublicTransitMappingConfigGroup createTestPTMConfig() {
@@ -126,9 +127,14 @@ public class PTMapperShapesExample {
 		analysis.writeQuantileDistancesCsv(outputFolder + "Shapes_DistancesQuantile.csv");
 	}
 
-	public static void writeShapes() {
+	private static void checkPlausibility() {
+		new File(outputFolder + "plausibility/").mkdir();
+		CheckMappedSchedulePlausibility.run(scheduleOutput1, networkOutput1, coordSys, outputFolder + "plausibility/");
+	}
+
+	public static void writeGtfsShapes() {
 		GtfsTools.writeShapesToGeojson(gtfsFeed, outputFolder + "gtfsShapes.geojson");
-		Schedule2Geojson.run(coordSys, outputFolder + "schedule.geojson", outputFolder + "shapes_schedule.xml.gz", outputFolder + "shapes_network.xml.gz");
+//		Schedule2Geojson.run(coordSys, outputFolder + "schedule.geojson", outputFolder + "shapes_schedule.xml.gz", outputFolder + "shapes_network.xml.gz");
 
 //		Map<Id<RouteShape>, RouteShape> shapes = ShapeTools.readShapesFile(gtfsFolder + "shapes.txt", coordSys);
 

--- a/src/test/java/org/matsim/pt2matsim/plausibility/PlausibilityCheckTest.java
+++ b/src/test/java/org/matsim/pt2matsim/plausibility/PlausibilityCheckTest.java
@@ -1,13 +1,20 @@
 package org.matsim.pt2matsim.plausibility;
 
 import com.vividsolutions.jts.util.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt2matsim.plausibility.log.PlausibilityWarning;
+import org.matsim.pt2matsim.run.CheckMappedSchedulePlausibility;
+import org.matsim.pt2matsim.tools.NetworkTools;
 import org.matsim.pt2matsim.tools.NetworkToolsTest;
+import org.matsim.pt2matsim.tools.ScheduleTools;
 import org.matsim.pt2matsim.tools.ScheduleToolsTest;
 
+import java.io.File;
 import java.util.Map;
 import java.util.Set;
 
@@ -16,21 +23,49 @@ import java.util.Set;
  */
 public class PlausibilityCheckTest {
 
-	@Test
-	public void runCheck() {
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private String testDir;
+	private PlausibilityCheck check;
+
+	@Before
+	public void prepare() {
+		testDir = temporaryFolder.getRoot().toString();
+
 		TransitSchedule s = ScheduleToolsTest.initSchedule();
 		Network n = NetworkToolsTest.initNetwork();
 
-		PlausibilityCheck check = new PlausibilityCheck(s, n, null);
+		check = new PlausibilityCheck(s, n, null);
 		check.setDirectionChangeThreshold("bus", Math.PI * 95 / 180);
 		check.setTtRange(0);
 		check.runCheck();
+	}
 
+	@Test
+	public void checks() {
 		Map<PlausibilityWarning.Type, Set<PlausibilityWarning>> warnings = check.getWarnings();
 		Assert.equals(0, warnings.get(PlausibilityWarning.Type.ArtificialLinkWarning).size());
 		Assert.equals(0, warnings.get(PlausibilityWarning.Type.LoopWarning).size());
 		Assert.equals(4, warnings.get(PlausibilityWarning.Type.DirectionChangeWarning).size());
 		Assert.equals(0, warnings.get(PlausibilityWarning.Type.TravelTimeWarning).size());
+	}
+
+	@Test
+	public void writeGeojson() {
+		check.writeResultsGeojson(testDir + "plausibility.geojson");
+		new File(testDir + "plausibility.geojson").delete();
+	}
+
+	@Test
+	public void staticRun() {
+		String scheduleFile = testDir + "testSchedule.xml";
+		String networkFile = testDir + "testNetwork.xml";
+		String outputfolder = testDir + "plausibility/";
+		ScheduleTools.writeTransitSchedule(ScheduleToolsTest.initSchedule(), scheduleFile);
+		NetworkTools.writeNetwork(NetworkToolsTest.initNetwork(), networkFile);
+
+		CheckMappedSchedulePlausibility.run(scheduleFile, networkFile, "Atlantis", outputfolder);
 	}
 
 }


### PR DESCRIPTION
Plausibility checker now writes geojson files instead of [shapefiles](http://switchfromshapefile.org/), which allows for a cleaner output folder structure. Closes #37 

All warnings are written to the same file. Network and schedule files are also written to geojson. Added some doc and tests as well.