### PR TITLE
Handle trips w/o stop times

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/gtfs/GtfsFeed.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/GtfsFeed.java
@@ -43,8 +43,6 @@ public interface GtfsFeed {
 
 	Map<Id<RouteShape>, RouteShape> getShapes();
 
-	boolean usesFrequencies();
-
 	Collection<Transfer> getTransfers();
 
 	/**

--- a/src/main/java/org/matsim/pt2matsim/gtfs/GtfsFeedImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/GtfsFeedImpl.java
@@ -666,11 +666,6 @@ public class GtfsFeedImpl implements GtfsFeed {
 	}
 
 	@Override
-	public boolean usesFrequencies() {
-		return usesFrequencies;
-	}
-
-	@Override
 	public Collection<Transfer> getTransfers() {
 		return transfers;
 	}

--- a/src/main/java/org/matsim/pt2matsim/gtfs/lib/Route.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/lib/Route.java
@@ -39,5 +39,8 @@ public interface Route {
 
 	Map<String, Trip> getTrips();
 
+	/**
+	 * The base route types are part of the extended set, does not return <tt>null</tt>
+	 */
 	GtfsDefinitions.ExtendedRouteType getExtendedRouteType();
 }

--- a/src/main/java/org/matsim/pt2matsim/gtfs/lib/Service.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/lib/Service.java
@@ -51,7 +51,7 @@ public interface Service {
 	Map<String, Trip> getTrips();
 
 	/**
-	 * @return <code>true</code> if the given date is used by the given service.
+	 * @return <code>true</code> if the given date is used by the service.
 	 */
 	boolean runsOnDate(LocalDate extractDate);
 }

--- a/src/main/java/org/matsim/pt2matsim/gtfs/lib/Stop.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/lib/Stop.java
@@ -19,8 +19,6 @@
 package org.matsim.pt2matsim.gtfs.lib;
 
 import org.matsim.api.core.v01.Coord;
-import org.matsim.api.core.v01.Id;
-import org.matsim.pt.transitSchedule.api.TransitStopArea;
 
 import java.util.Collection;
 
@@ -48,6 +46,8 @@ public interface Stop {
 
 	/**
 	 * [optional] Identifies whether this stop represents a stop or station.
+	 *
+	 * @return <tt>null</tt> when not defined
 	 */
 	GtfsDefinitions.LocationType getLocationType();
 
@@ -55,6 +55,8 @@ public interface Stop {
 	 * [optional] For stops that are physically located inside stations, this field identifies the station associated
 	 * with the stop. To use this field, stops.txt must also contain a row where this stop ID is assigned
 	 * location type=1.
+	 *
+	 * @return <tt>null</tt> when not defined
 	 */
 	String getParentStationId();
 

--- a/src/main/java/org/matsim/pt2matsim/gtfs/lib/Transfer.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/lib/Transfer.java
@@ -35,6 +35,8 @@ public interface Transfer {
 
 	/**
 	 * optional, necessary if transferType is REQUIRES_MIN_TRANSFER_TIME
+	 *
+	 * @return <tt>null</tt> when not defined
 	 */
 	Integer getMinTransferTime();
 }

--- a/src/main/java/org/matsim/pt2matsim/gtfs/lib/Trip.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/lib/Trip.java
@@ -34,11 +34,15 @@ public interface Trip {
 
 	Service getService();
 
-	Collection<Frequency> getFrequencies();
-
 	Route getRoute();
 
-	boolean hasShape();
+	/**
+	 * @return Empty collection if trip has no frequencies defined
+	 */
+	Collection<Frequency> getFrequencies();
 
+	/**
+	 * @return <tt>null</tt> if no shape is available
+	 */
 	RouteShape getShape();
 }

--- a/src/main/java/org/matsim/pt2matsim/gtfs/lib/TripImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/lib/TripImpl.java
@@ -77,11 +77,6 @@ public class TripImpl implements Trip {
 		return service;
 	}
 
-	@Override
-	public boolean hasShape() {
-		return shape != null;
-	}
-
 	/** required */
 	@Override
 	public RouteShape getShape() {

--- a/src/test/java/org/matsim/pt2matsim/gtfs/GtfsFeedImplTest.java
+++ b/src/test/java/org/matsim/pt2matsim/gtfs/GtfsFeedImplTest.java
@@ -52,7 +52,6 @@ public class GtfsFeedImplTest {
 		Assert.assertEquals(3, feed.getShapes().size());
 		Assert.assertEquals(6, feed.getTrips().size());
 		Assert.assertEquals(6, feed.getTransfers().size());
-		Assert.assertTrue(feed.usesFrequencies());
 	}
 
 	@Test

--- a/src/test/java/org/matsim/pt2matsim/gtfs/GtfsRealFeedTest.java
+++ b/src/test/java/org/matsim/pt2matsim/gtfs/GtfsRealFeedTest.java
@@ -24,7 +24,6 @@ public class GtfsRealFeedTest {
 		Assert.assertEquals(92, feed.getRoutes().size());
 		Assert.assertEquals(139, feed.getServices().size());
 		Assert.assertEquals(806, feed.getShapes().size());
-		Assert.assertFalse(feed.usesFrequencies());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #61 

Trips without stop times are not converted to prevent crashes of the mapper (a warning is logged). In addition, frequencies are handled for each trip instead of the feed level.