### PR TITLE
Remove minimal transfer times of removed stops.

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
@@ -290,6 +290,7 @@ public class GtfsConverter {
 
 	protected void cleanSchedule(TransitSchedule schedule) {
 		ScheduleCleaner.removeNotUsedStopFacilities(schedule);
+		ScheduleCleaner.removeNotUsedMinimalTransferTimes(schedule);
 	}
 
 	protected Id<TransitLine> createTransitLineId(Route gtfsRoute) {


### PR DESCRIPTION
After conversion, unused stops get removed from the schedule, but minimal transfer times related to these stops were kept, resulting in potential NullPointerExceptions when using the minimal transfer times of such a schedule, as the referenced stops cannot be found in the schedule. Fixing this by also removing minimal transfer times of such removed stops.