### PR TITLE
Improve parallelization & increase verbosity

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/editor/BasicScheduleEditor.java
+++ b/src/main/java/org/matsim/pt2matsim/editor/BasicScheduleEditor.java
@@ -77,7 +77,7 @@ public class BasicScheduleEditor implements ScheduleEditor {
 		this.parentStops = new ParentStops();
 
 		log.info("Guessing routers based on schedule transport modes and used network transport modes.");
-		this.routers = NetworkTools.guessRouters(schedule, network);
+		this.routers = NetworkTools.guessRouters(schedule, network).createInstance();
 	}
 
 	public Network getNetwork() {

--- a/src/main/java/org/matsim/pt2matsim/mapping/Progress.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/Progress.java
@@ -1,0 +1,42 @@
+package org.matsim.pt2matsim.mapping;
+
+import org.apache.log4j.Logger;
+
+public class Progress {
+	private Logger logger = Logger.getLogger(Progress.class);
+
+	private final long total;
+	private final String description;
+
+	private long current = 0;
+	private long lastOutput = 0;
+	
+	private Object lock = new Object();
+
+	public Progress(long total, String description) {
+		this.total = total;
+		this.description = description;
+		print();
+	}
+
+	public void update(long count) {
+		synchronized(lock) {
+			current += count;
+			print();
+		}
+	}
+
+	public void update() {
+		synchronized(lock) {
+			current += 1;
+			print();
+		}
+	}
+
+	private void print() {
+		if ((System.nanoTime() - lastOutput >= 1000000000L) || current == total) {
+			lastOutput = System.nanoTime();
+			logger.info(String.format("%s %d/%d (%.2f%%)", description, current, total, 100.0 * current / total));
+		}
+	}
+}

--- a/src/main/java/org/matsim/pt2matsim/mapping/linkCandidateCreation/LinkCandidateCreatorStandard.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/linkCandidateCreation/LinkCandidateCreatorStandard.java
@@ -30,6 +30,7 @@ import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.pt.transitSchedule.api.*;
 import org.matsim.pt2matsim.config.PublicTransitMappingConfigGroup;
 import org.matsim.pt2matsim.config.PublicTransitMappingStrings;
+import org.matsim.pt2matsim.mapping.Progress;
 import org.matsim.pt2matsim.tools.MiscUtils;
 import org.matsim.pt2matsim.tools.NetworkTools;
 import org.matsim.pt2matsim.tools.PTMapperTools;
@@ -85,6 +86,14 @@ public class LinkCandidateCreatorStandard implements LinkCandidateCreator {
 		Map<String, Set<Link>> closeLinksMap = new HashMap<>();
 
 		Map<Id<PublicTransitStop>, Set<Link>> candidates = new HashMap<>();
+		
+		long totalNumberOfRoutes = 0;
+		
+		for(TransitLine transitLine : schedule.getTransitLines().values()) {
+			totalNumberOfRoutes += transitLine.getRoutes().size();
+		}
+		
+		Progress progress = new Progress(totalNumberOfRoutes, "Getting closest links ...");
 
 		/*
 		  get closest links for each stop facility (separated by mode)
@@ -147,11 +156,15 @@ public class LinkCandidateCreatorStandard implements LinkCandidateCreator {
 					previousLinks = currentLinks;
 					previousRouteStop = currentRouteStop;
 				}
+				
+				progress.update();
 			}
 		}
 
 		Map<Id<PublicTransitStop>, Double> maxStopDist = new HashMap<>();
 		Map<Id<PublicTransitStop>, Double> minStopDist = new HashMap<>();
+		
+		progress = new Progress(candidates.size(), "Creating link candidates ...");
 
 		/*
 		  create and store link candidates
@@ -181,12 +194,16 @@ public class LinkCandidateCreatorStandard implements LinkCandidateCreator {
 
 			maxStopDist.put(stop.getId(), maxDist);
 			minStopDist.put(stop.getId(), minDist);
+			
+			progress.update();
 		}
 
 		/*
 		Set priorities
 		 */
 		int nLC = 0;
+		progress = new Progress(linkCandidates.size(), "Setting candidate priorities ...");
+		
 		for(Map.Entry<Id<PublicTransitStop>, SortedSet<LinkCandidate>> entry : linkCandidates.entrySet()) {
 			double minDist = minStopDist.get(entry.getKey());
 			double maxDist = maxStopDist.get(entry.getKey());

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersFactory.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersFactory.java
@@ -1,0 +1,5 @@
+package org.matsim.pt2matsim.mapping.networkRouter;
+
+public interface ScheduleRoutersFactory {
+	ScheduleRouters createInstance();
+}

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersGtfsShapes.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersGtfsShapes.java
@@ -61,7 +61,7 @@ public class ScheduleRoutersGtfsShapes implements ScheduleRouters {
 	private final Map<TransitLine, Map<TransitRoute, ShapeRouter>> shapeRouters = new HashMap<>();
 
 
-	public ScheduleRoutersGtfsShapes(TransitSchedule schedule, Network network, Map<Id<RouteShape>, RouteShape> shapes, Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType travelCostType, double maxWeightDistance, double cutBuffer) {
+	private ScheduleRoutersGtfsShapes(TransitSchedule schedule, Network network, Map<Id<RouteShape>, RouteShape> shapes, Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType travelCostType, double maxWeightDistance, double cutBuffer) {
 		this.schedule = schedule;
 		this.network = network;
 		this.transportModeAssignment = transportModeAssignment;
@@ -188,4 +188,29 @@ public class ScheduleRoutersGtfsShapes implements ScheduleRouters {
 		}
 	}
 
+	static public class Factory implements ScheduleRoutersFactory {
+		final private TransitSchedule schedule;
+		final private Network network;
+		final private Map<Id<RouteShape>, RouteShape> shapes;
+		final private Map<String, Set<String>> transportModeAssignment;
+		final private PublicTransitMappingConfigGroup.TravelCostType travelCostType;
+		final private double maxWeightDistance;
+		final private double cutBuffer;
+		
+		public Factory(TransitSchedule schedule, Network network, Map<Id<RouteShape>, RouteShape> shapes, Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType travelCostType, double maxWeightDistance, double cutBuffer) {
+			this.schedule = schedule;
+			this.network = network;
+			this.shapes = shapes;
+			this.transportModeAssignment = transportModeAssignment;
+			this.travelCostType = travelCostType;
+			this.maxWeightDistance = maxWeightDistance;
+			this.cutBuffer = cutBuffer;
+		}
+
+		@Override
+		public ScheduleRouters createInstance() {
+			return new ScheduleRoutersGtfsShapes(schedule, network, shapes, transportModeAssignment, travelCostType, maxWeightDistance, cutBuffer);
+		}
+		
+	}
 }

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersOsmAttributes.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersOsmAttributes.java
@@ -179,4 +179,24 @@ public class ScheduleRoutersOsmAttributes implements ScheduleRouters {
         }
     }
 
+    public static class Factory implements ScheduleRoutersFactory {
+    	final private TransitSchedule schedule;
+    	final private Network network;
+    	final private Map<String, Set<String>> transportModeAssignment;
+    	final private PublicTransitMappingConfigGroup.TravelCostType travelCostType;
+    	final private double osmPtLinkTravelCostFactor;
+    	
+    	public Factory(TransitSchedule schedule, Network network, Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType travelCostType, double osmPtLinkTravelCostFactor) {
+    		this.schedule = schedule;
+    		this.network = network;
+    		this.transportModeAssignment = transportModeAssignment;
+    		this.travelCostType = travelCostType;
+    		this.osmPtLinkTravelCostFactor = osmPtLinkTravelCostFactor;
+    	}
+
+		@Override
+		public ScheduleRouters createInstance() {
+			return new ScheduleRoutersOsmAttributes(schedule, network, transportModeAssignment, travelCostType, osmPtLinkTravelCostFactor);
+		}
+    }
 }

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
@@ -48,7 +48,7 @@ public class ScheduleRoutersStandard implements ScheduleRouters {
 	private final Map<String, Network> networksByMode = new HashMap<>();
 	private final boolean considerCandidateDist;
 
-	public ScheduleRoutersStandard(TransitSchedule schedule, Network network, Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType costType, boolean routingWithCandidateDistance) {
+	private ScheduleRoutersStandard(TransitSchedule schedule, Network network, Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType costType, boolean routingWithCandidateDistance) {
 		this.schedule = schedule;
 		this.network = network;
 		this.transportModeAssignment = transportModeAssignment;
@@ -56,10 +56,6 @@ public class ScheduleRoutersStandard implements ScheduleRouters {
 		this.considerCandidateDist = routingWithCandidateDistance;
 
 		load();
-	}
-
-	public ScheduleRoutersStandard(TransitSchedule schedule, Network network, PublicTransitMappingConfigGroup config) {
-		this(schedule, network, config.getTransportModeAssignment(), config.getTravelCostType(), config.getRoutingWithCandidateDistance());
 	}
 
 	/**
@@ -148,4 +144,32 @@ public class ScheduleRoutersStandard implements ScheduleRouters {
 		}
 	}
 
+	/**
+	 * Factory for a ScheduleRoutersStandard instance
+	 */
+	public static class Factory implements ScheduleRoutersFactory {
+		private final TransitSchedule schedule;
+		private final Network network;
+		private final Map<String, Set<String>> transportModeAssignment;
+		private final PublicTransitMappingConfigGroup.TravelCostType costType;
+		private boolean routingWithCandidateDistance;
+		
+		public Factory(TransitSchedule schedule, Network network, Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType costType, boolean routingWithCandidateDistance) {
+			this.schedule = schedule;
+			this.network = network;
+			this.transportModeAssignment = transportModeAssignment;
+			this.costType = costType;
+			this.routingWithCandidateDistance = routingWithCandidateDistance;
+		}
+		
+		public Factory(TransitSchedule schedule, Network network, PublicTransitMappingConfigGroup config) {
+			this(schedule, network, config.getTransportModeAssignment(), config.getTravelCostType(), config.getRoutingWithCandidateDistance());
+		}
+
+		@Override
+		public ScheduleRouters createInstance() {
+			return new ScheduleRoutersStandard(schedule, network, transportModeAssignment, costType, routingWithCandidateDistance);
+		}
+
+	}
 }

--- a/src/main/java/org/matsim/pt2matsim/tools/NetworkTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/NetworkTools.java
@@ -40,6 +40,7 @@ import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt2matsim.config.PublicTransitMappingConfigGroup;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRouters;
+import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersFactory;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersStandard;
 
 import java.util.*;
@@ -414,7 +415,7 @@ public final class NetworkTools {
 	/**
 	 * Creates mode dependent routers based on the actual network modes used.
 	 */
-	public static ScheduleRouters guessRouters(TransitSchedule schedule, Network network) {
+	public static ScheduleRoutersFactory guessRouters(TransitSchedule schedule, Network network) {
 		// for each schedule modes, look which network modes are used
 		Map<String, Set<String>> modeAssignments = new HashMap<>();
 		for(TransitLine transitLine : schedule.getTransitLines().values()) {
@@ -435,7 +436,7 @@ public final class NetworkTools {
 			config.addParameterSet(mra);
 		}
 
-		return new ScheduleRoutersStandard(schedule, network, modeAssignments, PublicTransitMappingConfigGroup.TravelCostType.linkLength, true);
+		return new ScheduleRoutersStandard.Factory(schedule, network, modeAssignments, PublicTransitMappingConfigGroup.TravelCostType.linkLength, true);
 	}
 
 	/**

--- a/src/main/java/org/matsim/pt2matsim/workbench/PTMapperShapesExample.java
+++ b/src/main/java/org/matsim/pt2matsim/workbench/PTMapperShapesExample.java
@@ -8,6 +8,7 @@ import org.matsim.pt2matsim.gtfs.GtfsFeed;
 import org.matsim.pt2matsim.gtfs.GtfsFeedImpl;
 import org.matsim.pt2matsim.mapping.PTMapper;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRouters;
+import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersFactory;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersGtfsShapes;
 import org.matsim.pt2matsim.plausibility.MappingAnalysis;
 import org.matsim.pt2matsim.run.CheckMappedSchedulePlausibility;
@@ -90,12 +91,12 @@ public class PTMapperShapesExample {
 		TransitSchedule schedule = ScheduleTools.readTransitSchedule(unmappedScheduleFile);
 		Network network = NetworkTools.readNetwork(networkInput);
 
-		ScheduleRouters routers = new ScheduleRoutersGtfsShapes(schedule, network,
+		ScheduleRoutersFactory routersFactory = new ScheduleRoutersGtfsShapes.Factory(schedule, network,
 				ShapeTools.readShapesFile(gtfsFolder + "shapes.txt", coordSys), config.getTransportModeAssignment(), config.getTravelCostType(),
 				50, 200);
 
 		PTMapper ptMapper = new PTMapper(schedule, network);
-		ptMapper.run(config, routers);
+		ptMapper.run(config, null, routersFactory);
 
 		NetworkTools.writeNetwork(network, networkOutput2);
 		ScheduleTools.writeTransitSchedule(ptMapper.getSchedule(), scheduleOutput2);

--- a/src/main/java/org/matsim/pt2matsim/workbench/ZVVexample.java
+++ b/src/main/java/org/matsim/pt2matsim/workbench/ZVVexample.java
@@ -14,6 +14,7 @@ import org.matsim.pt2matsim.gtfs.lib.GtfsDefinitions;
 import org.matsim.pt2matsim.tools.lib.RouteShape;
 import org.matsim.pt2matsim.mapping.PTMapper;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRouters;
+import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersFactory;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersGtfsShapes;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersOsmAttributes;
 import org.matsim.pt2matsim.osm.OsmMultimodalNetworkConverter;
@@ -212,10 +213,10 @@ public class ZVVexample {
 		PublicTransitMappingConfigGroup config = PublicTransitMappingConfigGroup.createDefaultConfig();
 		Map<Id<RouteShape>, RouteShape> shapes = ShapeTools.readShapesFile(gtfsShapeFile, coordSys);
 
-		ScheduleRouters router = new ScheduleRoutersGtfsShapes(schedule, network, shapes, config.getTransportModeAssignment(), config.getTravelCostType(), 50, 250);
+		ScheduleRoutersFactory routerFactory = new ScheduleRoutersGtfsShapes.Factory(schedule, network, shapes, config.getTransportModeAssignment(), config.getTravelCostType(), 50, 250);
 
 		PTMapper ptMapper = new PTMapper(schedule, network);
-		ptMapper.run(config, router);
+		ptMapper.run(config, null, routerFactory);
 
 		NetworkTools.writeNetwork(network, outputNetwork2);
 		ScheduleTools.writeTransitSchedule(schedule, outputSchedule2);
@@ -249,10 +250,10 @@ public class ZVVexample {
 		PublicTransitMappingConfigGroup config = PublicTransitMappingConfigGroup.createDefaultConfig();
 
 		// Initiate Router that uses osm data
-		ScheduleRouters router = new ScheduleRoutersOsmAttributes(schedule, network, config.getTransportModeAssignment(), PublicTransitMappingConfigGroup.TravelCostType.linkLength, 0.5);
+		ScheduleRoutersFactory routerFactory = new ScheduleRoutersOsmAttributes.Factory(schedule, network, config.getTransportModeAssignment(), PublicTransitMappingConfigGroup.TravelCostType.linkLength, 0.5);
 
 		PTMapper ptMapper = new PTMapper(schedule, network);
-		ptMapper.run(config, router);
+		ptMapper.run(config, null, routerFactory);
 
 		NetworkTools.writeNetwork(network, outputNetwork3);
 		ScheduleTools.writeTransitSchedule(schedule, outputSchedule3);

--- a/src/test/java/org/matsim/pt2matsim/mapping/PTMapperShapesTest.java
+++ b/src/test/java/org/matsim/pt2matsim/mapping/PTMapperShapesTest.java
@@ -13,6 +13,7 @@ import org.matsim.pt.utils.TransitScheduleValidator;
 import org.matsim.pt2matsim.config.PublicTransitMappingConfigGroup;
 import org.matsim.pt2matsim.config.PublicTransitMappingStrings;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRouters;
+import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersFactory;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersGtfsShapes;
 import org.matsim.pt2matsim.tools.NetworkToolsTest;
 import org.matsim.pt2matsim.tools.ScheduleTools;
@@ -42,9 +43,9 @@ public class PTMapperShapesTest {
 		schedule = ScheduleToolsTest.initUnmappedSchedule();
 
 		Map<Id<RouteShape>, RouteShape> shapes = ShapeToolsTest.initShapes();
-		ScheduleRouters scheduleRouters = new ScheduleRoutersGtfsShapes(schedule, network, shapes, ptmConfig.getTransportModeAssignment(), PublicTransitMappingConfigGroup.TravelCostType.linkLength, 10.0, 99);
+		ScheduleRoutersFactory scheduleRoutersFactory = new ScheduleRoutersGtfsShapes.Factory(schedule, network, shapes, ptmConfig.getTransportModeAssignment(), PublicTransitMappingConfigGroup.TravelCostType.linkLength, 10.0, 99);
 
-		new PTMapper(schedule, network).run(ptmConfig, scheduleRouters);
+		new PTMapper(schedule, network).run(ptmConfig, null, scheduleRoutersFactory);
 
 		ScheduleCleaner.removeNotUsedStopFacilities(schedule);
 	}


### PR DESCRIPTION
I noticed that the parallelization is quite simple: There is one router and multiple thread accessing it while doing some minor additional stuff. When I run pt2matsim with 80 threads they are just waiting for each other most of the time. This PR brings two improvements:

- "True" parallelization, i.e. now there is one separate `ScheduleRouters` object in every thread and therefore no locking.
- More verbosity in the steps that take some time during the process by showing a progess indicator on a per-second basis.