### PR TITLE
Fix inconsistent car network

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
@@ -522,7 +522,7 @@ public class OsmMultimodalNetworkConverter {
 	 * Runs the network cleaner on the street network.
 	 */
 	protected void cleanNetwork() {
-		Set<String> roadModes = CollectionUtils.stringToSet("car,bus");
+		Set<String> roadModes = CollectionUtils.stringToSet("car");
 		Network roadNetwork = NetworkTools.createFilteredNetworkByLinkMode(network, roadModes);
 		Network restNetwork = NetworkTools.createFilteredNetworkExceptLinkMode(network, roadModes);
 		this.network = null;

--- a/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
@@ -28,6 +28,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.algorithms.NetworkCleaner;
 import org.matsim.core.utils.collections.CollectionUtils;
 import org.matsim.core.utils.geometry.CoordUtils;
@@ -522,14 +523,22 @@ public class OsmMultimodalNetworkConverter {
 	 * Runs the network cleaner on the street network.
 	 */
 	protected void cleanNetwork() {
-		Set<String> roadModes = CollectionUtils.stringToSet("car");
-		Network roadNetwork = NetworkTools.createFilteredNetworkByLinkMode(network, roadModes);
-		Network restNetwork = NetworkTools.createFilteredNetworkExceptLinkMode(network, roadModes);
-		this.network = null;
-
-		new NetworkCleaner().run(roadNetwork);
-		NetworkTools.integrateNetwork(restNetwork, roadNetwork);
-		this.network = restNetwork;
+		Network carNetwork = NetworkTools.createFilteredNetworkByLinkMode(network, Collections.singleton("car"));
+		new NetworkCleaner().run(carNetwork);
+		
+		Set<String> busModes = new HashSet<>(Arrays.asList("car", "bus"));
+		Network busNetwork = NetworkTools.createFilteredNetworkByLinkMode(network, busModes);
+		new NetworkCleaner().run(busNetwork);
+		busNetwork.getLinks().values().forEach(l -> l.setAllowedModes(Collections.singleton("bus")));
+		
+		Network restNetwork = NetworkTools.createFilteredNetworkExceptLinkMode(network, busModes);
+		
+		Network combinedNetwork = NetworkUtils.createNetwork();
+		NetworkTools.integrateNetwork(combinedNetwork, restNetwork, true);
+		NetworkTools.integrateNetwork(combinedNetwork, busNetwork, true);
+		NetworkTools.integrateNetwork(combinedNetwork, carNetwork, true);
+		
+		this.network = combinedNetwork;
 	}
 
 

--- a/src/main/java/org/matsim/pt2matsim/tools/NetworkTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/NetworkTools.java
@@ -543,19 +543,23 @@ public final class NetworkTools {
 		}
 		
 		// find origin links
-		Set<Link> found = new HashSet<>();		
+		Set<Link> found = new HashSet<>();	
+		Set<Link> visited = new HashSet<>();
+		
 		for(Link currentLink : singleFileLinks) {
 			if(!found.contains(currentLink)) {
 				Link actual = currentLink;
 				Link precedingLink;
+				visited.clear();
 				do {
 					found.add(actual);
+					visited.add(actual);
 					precedingLink = getSingleFilePrecedingLink(actual);
 					if(precedingLink != null && links.contains(precedingLink)) {
 						linkSequence.put(precedingLink, actual);
 						actual = precedingLink;
 						
-						if (actual.equals(currentLink)) {
+						if (visited.contains(actual)) {
 							// We found a closed loop and arrived back at the starting point.
 							break;
 						}
@@ -565,14 +569,16 @@ public final class NetworkTools {
 
 				actual = currentLink;
 				Link succeedingLink;
+				visited.clear();
 				do {
 					found.add(actual);
+					visited.add(actual);
 					succeedingLink = getSingleFileSucceedingLink(actual);
 					if(succeedingLink != null && links.contains(succeedingLink)) {
 						linkSequence.put(actual, succeedingLink);
 						actual = succeedingLink;
 						
-						if (actual.equals(currentLink)) {
+						if (visited.contains(actual)) {
 							// We found a closed loop and arrived back at the starting point.
 							break;
 						}


### PR DESCRIPTION
What happened in that changed line is that the OSM converter created a consistent car+bus network, so if you take all car and bus links you get a connected network without dead ends and islands. Already this is not ideal, because later on MATSim will do something like
```java
new TransportModeNetworkFilter(originalNetwork).filter(roadNetwork, Collections.singleton("car"));
```
to determine the car network for its internal routing. So if some parts of the car network are only connected to a rest by a bus link, the network will fall apart. 

FIx: Here we now do not make sure we have a consistent car+bus network, but we make sure that we have a consistent car-only network where we put all others modes on top.

@polettif Did I miss any specific reason, why there currently is "car,bus"?


