### PR TITLE
Fix routing exception

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
@@ -185,6 +185,7 @@ public class PTMapper {
 				thread.join();
 			} catch (InterruptedException e) {
 				e.printStackTrace();
+				throw new RuntimeException(e);
 			}
 		}
 


### PR DESCRIPTION
Throws an exception when there is a routing error. Before, threads were just silently killed.