### PR TITLE
Empty transportModeAssignment creates artificial loop links 

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/mapping/linkCandidateCreation/LinkCandidateCreatorStandard.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/linkCandidateCreation/LinkCandidateCreatorStandard.java
@@ -56,17 +56,17 @@ public class LinkCandidateCreatorStandard implements LinkCandidateCreator {
 	private final int nLinks;
 	private final double distanceMultiplier;
 	private final double maxDistance;
-	private final Map<String, Set<String>> routingAssignment;
+	private final Map<String, Set<String>> transportModeAssignments;
 	private double nodeSearchRadius;
 
 
-	public LinkCandidateCreatorStandard(TransitSchedule schedule, Network network, int nLinks, double distanceMultiplier, double maxDistance, Map<String, Set<String>> routingAssignment) {
+	public LinkCandidateCreatorStandard(TransitSchedule schedule, Network network, int nLinks, double distanceMultiplier, double maxDistance, Map<String, Set<String>> transportModeAssignments) {
 		this.schedule = schedule;
 		this.network = network;
 		this.nLinks = nLinks;
 		this.distanceMultiplier = distanceMultiplier;
 		this.maxDistance = maxDistance;
-		this.routingAssignment = routingAssignment;
+		this.transportModeAssignments = transportModeAssignments;
 
 		load();
 	}
@@ -101,7 +101,14 @@ public class LinkCandidateCreatorStandard implements LinkCandidateCreator {
 		for(TransitLine transitLine : schedule.getTransitLines().values()) {
 			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {
 				String scheduleTransportMode = transitRoute.getTransportMode();
-				Set<String> networkModes = routingAssignment.get(scheduleTransportMode);
+				Set<String> networkModes = transportModeAssignments.get(scheduleTransportMode);
+
+				// If no transportModes have been defined in the config, no links should be found by findClosestLink (which requires an empty set)
+				if(networkModes == null) {
+					log.warn("No transportModeAssignment found for schedule mode " + scheduleTransportMode);
+					networkModes = new HashSet<>();
+					transportModeAssignments.put(scheduleTransportMode, networkModes);
+				}
 
 				TransitRouteStop previousRouteStop = transitRoute.getStops().get(0);
 

--- a/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/ArtificialLinkImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/ArtificialLinkImpl.java
@@ -48,12 +48,12 @@ public class ArtificialLinkImpl implements ArtificialLink {
 	private Set<String> transportModes = PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE_AS_SET;
 	private Attributes attributes = new Attributes();
 
-	public ArtificialLinkImpl(LinkCandidate fromLinkCandidate, LinkCandidate toLinkCandidate, double freespeed, double linklength) {
+	public ArtificialLinkImpl(LinkCandidate fromLinkCandidate, LinkCandidate toLinkCandidate, double freespeed, double linkLength) {
 		this.id = PTMapperTools.createArtificialLinkId(fromLinkCandidate, toLinkCandidate);
 		this.fromNodeId = fromLinkCandidate.getLink().getToNode().getId();
 		this.toNodeId = toLinkCandidate.getLink().getFromNode().getId();
 		this.freespeed = freespeed;
-		this.linkLength = linklength;
+		this.linkLength = Math.max(1, linkLength);
 
 		this.fromNode = fromLinkCandidate.getLink().getToNode();
 		this.toNode = toLinkCandidate.getLink().getFromNode();

--- a/src/main/java/org/matsim/pt2matsim/tools/PTMapperTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/PTMapperTools.java
@@ -24,8 +24,8 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.network.NetworkFactory;
 import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.utils.geometry.CoordUtils;
@@ -262,19 +262,10 @@ public final class PTMapperTools {
 		if(dummyLink != null) {
 			return dummyLink;
 		} else {
-			NetworkFactory networkFactory = network.getFactory();
-
-			Coord coord = stopFacility.getCoord();
-
-			Node dummyNode = networkFactory.createNode(Id.createNodeId(prefix + stopFacility.getId()), coord);
-			dummyLink = networkFactory.createLink(dummyLinkId, dummyNode, dummyNode);
-
-			dummyLink.setAllowedModes(transportModes);
-			dummyLink.setLength(10);
-			dummyLink.setFreespeed(freespeed);
-			dummyLink.setCapacity(9999);
-
+			Node dummyNode = NetworkUtils.createNode(Id.createNodeId(prefix + stopFacility.getId()), stopFacility.getCoord());
 			network.addNode(dummyNode);
+			dummyLink = NetworkUtils.createLink(dummyLinkId, dummyNode, dummyNode, network, 10, freespeed, 9999, 1);
+			dummyLink.setAllowedModes(transportModes);
 			network.addLink(dummyLink);
 
 			return dummyLink;

--- a/src/test/java/org/matsim/pt2matsim/tools/NetworkToolsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/tools/NetworkToolsTest.java
@@ -245,4 +245,21 @@ public class NetworkToolsTest {
 		Assert.assertEquals(80.0, NetworkTools.calcRouteLength(seq, true), 0.0001);
 	}
 
+	@Test
+	public void findClosestLinks() {
+		Node node = network.getNodes().get(Id.createNodeId("G"));
+		Coord coordToLookFrom = new Coord(node.getCoord().getX() + 2, node.getCoord().getY() + 2);
+
+		Map<Double, Set<Link>> cars = NetworkTools.findClosestLinks(network, coordToLookFrom, 3, Collections.singleton("car"));
+		Assert.assertEquals(1, cars.keySet().size());
+		Assert.assertEquals(4, cars.get(2.0).size());
+
+		Map<Double, Set<Link>> nullTransportModes = NetworkTools.findClosestLinks(network, coordToLookFrom, 3, null);
+		Assert.assertEquals(1, nullTransportModes.keySet().size());
+		Assert.assertEquals(4, nullTransportModes.get(2.0).size());
+
+	}
+
+
+
 }

--- a/src/test/java/org/matsim/pt2matsim/tools/NetworkToolsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/tools/NetworkToolsTest.java
@@ -10,6 +10,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.NetworkFactory;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.utils.geometry.CoordUtils;
 
 import java.util.*;
 
@@ -138,7 +139,8 @@ public class NetworkToolsTest {
 			for(Node toNode : net.getNodes().values()) {
 				String strId = fromNode.getId().toString() + toNode.getId().toString();
 				if(linksToCreate.contains(strId)) {
-					NetworkUtils.createAndAddLink(net, Id.createLinkId(strId), fromNode, toNode, 20, 1, 1, 1);
+					double dist = CoordUtils.calcEuclideanDistance(fromNode.getCoord(), toNode.getCoord());
+					NetworkUtils.createAndAddLink(net, Id.createLinkId(strId), fromNode, toNode, dist, 1, 1, 1);
 				}
 			}
 		}

--- a/src/test/java/org/matsim/pt2matsim/tools/ScheduleToolsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/tools/ScheduleToolsTest.java
@@ -254,6 +254,13 @@ public class ScheduleToolsTest {
 		Network network = NetworkToolsTest.initNetwork();
 		Network baseNetwork = NetworkToolsTest.initNetwork();
 
+		for(Link link : network.getLinks().values()) {
+			link.setFreespeed(0.1);
+		}
+		for(Link link : baseNetwork.getLinks().values()) {
+			link.setFreespeed(0.1);
+		}
+
 		Set<Id<Link>> linksUsedBySchedule = new HashSet<>();
 		for(TransitLine transitLine : schedule.getTransitLines().values()) {
 			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {


### PR DESCRIPTION
With this PR, the linkCandidateCreator finds no links if no transportRouteAssignment is configured (for the given schedule transport mode). Before, using `null` lead to all links being considered. Some tests are added/fixed along the way. Prompted by #70.