### PR TITLE
bugfix: most dead-end roads were removed from the network

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
@@ -171,7 +171,7 @@ public class OsmMultimodalNetworkConverter {
 
 				double length = 0.0;
 				Osm.Node lastNode = way.getNodes().get(0);
-				for(int i = 1; i < way.getNodes().size(); i++) {
+				for(int i = 1; i < way.getNodes().size() - 1; i++) {
 					Osm.Node node = way.getNodes().get(i);
 					if(node.getWays().size() > 1) {
 						length = 0.0;

--- a/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
+++ b/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
@@ -246,6 +246,14 @@ public class OsmMultimodalNetworkConverterTest {
 		assertMaxspeed("second speed limit is ignored", links, 40);
 	}
 	
+	@Test
+	public void testDeadEndStreetsAreContainedInNetwork() {
+		assertEquals(2, osmid2link.get(22971704L).size());
+		assertEquals(2, osmid2link.get(153227314L).size());
+		assertEquals(2, osmid2link.get(95142433L).size());
+		assertEquals(2, osmid2link.get(95142441L).size());
+	}
+	
 	private static void assertLanes(Set<Link> links, double expectedLanes) {
 		assertLanes("", links, expectedLanes);
 	}


### PR DESCRIPTION
do not consider the last node of a way as candidate for deletion when simplifying the geometry