### PR TITLE
Making sure that an empty GTFS file does lead to exceptions (but warnings of course)

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
@@ -135,10 +135,10 @@ public class PTMapper {
 		PTMapperTools.setLogLevels();
 
 		if(schedule.getTransitLines().size() == 0) {
-			throw new IllegalArgumentException("No transit lines available in schedule");
+			log.warn("No transit lines available in schedule");
 		}
 		if(schedule.getFacilities().size() == 0) {
-			throw new IllegalArgumentException("No stop facilities available in schedule");
+			log.warn("No stop facilities available in schedule");
 		}
 
 		log.info("======================================");

--- a/src/main/java/org/matsim/pt2matsim/plausibility/StopFacilityHistogram.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/StopFacilityHistogram.java
@@ -95,7 +95,9 @@ public class StopFacilityHistogram {
 			i++;
 		}
 
-		histNr = new double[new ArrayList<>(histNrMap.keySet()).get(histNrMap.size()-1)];
+		ArrayList<Integer> list = new ArrayList<>(histNrMap.keySet());
+		int arraySize = list.isEmpty() ? 0 : list.get(histNrMap.size()-1);
+		histNr = new double[arraySize];
 		i=0;
 		for(Map.Entry<Integer, Integer> e : histNrMap.entrySet()) {
 			histNr[i] = e.getValue()-1;
@@ -104,11 +106,17 @@ public class StopFacilityHistogram {
 	}
 
 	public double median() {
+		if(hist.length == 0)
+			return Double.NaN;
+		
 		int m = hist.length / 2;
 		return hist[m];
 	}
 
 	public double average() {
+		if(hist.length == 0)
+			return Double.NaN;
+		
 		double sum = 0;
 		for(double m : hist) {
 			sum += m;
@@ -117,6 +125,9 @@ public class StopFacilityHistogram {
 	}
 
 	public double max() {
+		if(hist.length == 0)
+			return Double.NaN;
+		
 		return hist[hist.length - 1];
 	}
 

--- a/src/test/java/org/matsim/pt2matsim/run/MergeNetworkWithGtfsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/run/MergeNetworkWithGtfsTest.java
@@ -1,0 +1,93 @@
+package org.matsim.pt2matsim.run;
+
+import static org.matsim.pt2matsim.gtfs.GtfsConverter.DAY_WITH_MOST_TRIPS;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt2matsim.config.OsmConverterConfigGroup;
+import org.matsim.pt2matsim.config.PublicTransitMappingConfigGroup;
+import org.matsim.pt2matsim.gtfs.GtfsConverter;
+import org.matsim.pt2matsim.gtfs.GtfsFeed;
+import org.matsim.pt2matsim.gtfs.GtfsFeedImpl;
+import org.matsim.pt2matsim.mapping.PTMapper;
+import org.matsim.pt2matsim.osm.OsmMultimodalNetworkConverter;
+import org.matsim.pt2matsim.osm.lib.AllowedTagsFilter;
+import org.matsim.pt2matsim.osm.lib.Osm;
+import org.matsim.pt2matsim.osm.lib.OsmData;
+import org.matsim.pt2matsim.osm.lib.OsmDataImpl;
+import org.matsim.pt2matsim.osm.lib.OsmFileReader;
+import org.matsim.pt2matsim.tools.ScheduleTools;
+import org.matsim.vehicles.VehicleUtils;
+import org.matsim.vehicles.Vehicles;
+
+public class MergeNetworkWithGtfsTest {
+
+	static final String COORDINATE_SYTEM = "EPSG:31256";
+
+	static final String OSM_FILE = "test/osm/GerasdorfArtificialLanesAndMaxspeed.osm";
+	static final String GTFS_FEED = "test/gtfs-feed";
+	static final String GTFS_FEED_EMPTY = "test/gtfs-feed-empty";
+
+	@Test
+	public void testGtfsFeed() {
+		Network network = prepareMatsimnetworkFromOsm(OSM_FILE);
+		prepareTransitScheduleFromGtfs(network, GTFS_FEED);
+		// expect no exception
+	}
+
+	/**
+	 * Test that merging the network even works for empty GTFS files. This may be
+	 * useful because PTMapper.mapScheduleToNetwork does not only merge the GTFS but
+	 * also cleans the network afterwards.
+	 * <p>
+	 * This way you can reliably create a car (+ bike,..) network with the same
+	 * cleaning steps as when creating a car (+ bike,..) + pt network
+	 */
+	@Test
+	public void testEmptyGtfsFeed() {
+		Network network = prepareMatsimnetworkFromOsm(OSM_FILE);
+		prepareTransitScheduleFromGtfs(network, GTFS_FEED_EMPTY);
+		// expect no exception
+	}
+
+	public static Network prepareMatsimnetworkFromOsm(String osmFile) {
+		OsmConverterConfigGroup config = OsmConverterConfigGroup.createDefaultConfig();
+
+		AllowedTagsFilter filter = new AllowedTagsFilter();
+		filter.add(Osm.ElementType.WAY, Osm.Key.HIGHWAY, null);
+		filter.add(Osm.ElementType.WAY, Osm.Key.RAILWAY, null);
+
+		OsmData osmData = new OsmDataImpl(filter);
+		new OsmFileReader(osmData).readFile(osmFile);
+
+		OsmMultimodalNetworkConverter converter = new OsmMultimodalNetworkConverter(osmData);
+		converter.convert(config);
+
+		return converter.getNetwork();
+	}
+
+	private static void prepareTransitScheduleFromGtfs(Network network, String gtfsFeed) {
+		PublicTransitMappingConfigGroup config = PublicTransitMappingConfigGroup.createDefaultConfig();
+
+		TransitSchedule transitSchedule = prepareTransitSchedule(gtfsFeed);
+		Vehicles transitVehicles = VehicleUtils.createVehiclesContainer();
+		ScheduleTools.createVehicles(transitSchedule, transitVehicles);
+
+		PTMapper.mapScheduleToNetwork(transitSchedule, network, config);
+	}
+
+	private static TransitSchedule prepareTransitSchedule(String gtfsDir) {
+		String param = DAY_WITH_MOST_TRIPS;
+
+		// load gtfs files
+		GtfsFeed gtfsFeed = new GtfsFeedImpl(gtfsDir);
+
+		// convert to transit schedule
+		GtfsConverter converter = new GtfsConverter(gtfsFeed);
+		converter.convert(param, COORDINATE_SYTEM);
+
+		return converter.getSchedule();
+	}
+
+}

--- a/test/gtfs-feed-empty/agency.txt
+++ b/test/gtfs-feed-empty/agency.txt
@@ -1,0 +1,1 @@
+agency_id,agency_name,agency_url,agency_timezone,agency_lang

--- a/test/gtfs-feed-empty/calendar.txt
+++ b/test/gtfs-feed-empty/calendar.txt
@@ -1,0 +1,1 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date

--- a/test/gtfs-feed-empty/calendar_dates.txt
+++ b/test/gtfs-feed-empty/calendar_dates.txt
@@ -1,0 +1,1 @@
+service_id,date,exception_type

--- a/test/gtfs-feed-empty/routes.txt
+++ b/test/gtfs-feed-empty/routes.txt
@@ -1,0 +1,1 @@
+agency_id,route_id,route_short_name,route_long_name,route_type

--- a/test/gtfs-feed-empty/stop_times.txt
+++ b/test/gtfs-feed-empty/stop_times.txt
@@ -1,0 +1,1 @@
+trip_id,stop_id,arrival_time,departure_time,stop_sequence,pickup_type,drop_off_type,departure_buffer

--- a/test/gtfs-feed-empty/stops.txt
+++ b/test/gtfs-feed-empty/stops.txt
@@ -1,0 +1,1 @@
+stop_id,stop_name,stop_lat,stop_lon

--- a/test/gtfs-feed-empty/trips.txt
+++ b/test/gtfs-feed-empty/trips.txt
@@ -1,0 +1,1 @@
+route_id,trip_id,service_id,trip_short_name,trip_headsign,block_id,peak_offpeak


### PR DESCRIPTION
I made some more adjustments so that merging a network with an emtpy schedule (with `PTMapper.mapScheduleToNetwork` does not throw an exception.

The rationale behind this: This way you can reliably create a car (+ bike,..) network with the same cleaning steps as when creating a car (+ bike,..) + pt network.