### PR TITLE
#98 Allow a schedule to be created from hafas for a particular date

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/ECKDATENReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/ECKDATENReader.java
@@ -1,0 +1,50 @@
+package org.matsim.pt2matsim.hafas.lib;
+
+import org.apache.log4j.Logger;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+
+import java.io.*;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class ECKDATENReader {
+
+    protected static Logger log = Logger.getLogger(ECKDATENReader.class);
+    private static final String ECKDATEN = "ECKDATEN";
+    /*
+        1 1−10 CHAR Fahrplanstart im Format TT.MM.JJJJ
+        2 1−10 CHAR Fahrplanende im Format TT.MM.JJJJ
+        3 1ff CHAR Fahrplanbezeichnung
+     */
+    public static LocalDate getFahrPlanStart(String pathToHafasFolder) throws IOException {
+        if (new File(pathToHafasFolder, ECKDATEN).exists()) {
+            BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(pathToHafasFolder + ECKDATEN), "utf-8"));
+            LocalDate startDate = getDate(readsLines.readLine());
+            readsLines.close();
+            return startDate;
+        } else {
+            log.error("    ECKDATEN does not exist!");
+            return null;
+        }
+    }
+
+    public static LocalDate getFahrPlanEnd(String pathToHafasFolder) throws IOException {
+        if (new File(pathToHafasFolder, ECKDATEN).exists()) {
+            BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(pathToHafasFolder + ECKDATEN), "utf-8"));
+            readsLines.readLine();
+            LocalDate endDate = getDate(readsLines.readLine());
+
+            readsLines.close();
+            return endDate;
+        } else {
+            log.error("    ECKDATEN does not exist!");
+            return null;
+        }
+    }
+
+    public static LocalDate getDate(String s) throws DateTimeParseException {
+        return LocalDate.parse(s, DateTimeFormatter.ofPattern("d.MM.yyyy"));
+    }
+
+}

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANReader.java
@@ -56,6 +56,11 @@ public class FPLANReader {
 
 			Counter counter = new Counter("FPLAN line # ");
 			BufferedReader readsLines = new BufferedReader(new InputStreamReader(new FileInputStream(FPLANfile), "utf-8"));
+//			while (counter.getCounter() < 13873677) {
+//				readsLines.readLine();
+//				counter.incCounter();
+//			}
+
 			String newLine = readsLines.readLine();
 			while(newLine != null) {
 				if(newLine.charAt(0) == '*') {

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANRoute.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANRoute.java
@@ -189,9 +189,13 @@ public class FPLANRoute {
 			}
 
 			TransitStopFacility stopFacility = schedule.getFacilities().get(stopFacilityId);
-			TransitRouteStop routeStop = scheduleFactory.createTransitRouteStop(stopFacility, arrivalDelay, departureDelay);
-			routeStop.setAwaitDepartureTime(true); // Only *T-Lines (currently not implemented) would have this as false...
-			transitRouteStops.add(routeStop);
+			if (stopFacility == null) {
+				log.warn("StopFacility " + stopFacilityId + " not defined, not adding stop" + fahrtNummer);
+			} else {
+				TransitRouteStop routeStop = scheduleFactory.createTransitRouteStop(stopFacility, arrivalDelay, departureDelay);
+				routeStop.setAwaitDepartureTime(true); // Only *T-Lines (currently not implemented) would have this as false...
+				transitRouteStops.add(routeStop);
+			}
 		}
 
 		return transitRouteStops;

--- a/src/main/java/org/matsim/pt2matsim/run/Hafas2TransitSchedule.java
+++ b/src/main/java/org/matsim/pt2matsim/run/Hafas2TransitSchedule.java
@@ -31,6 +31,7 @@ import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.Vehicles;
 
 import java.io.IOException;
+import java.time.LocalDate;
 
 /**
  * Run class to convert (Swiss) HAFAS data to
@@ -52,12 +53,15 @@ public final class Hafas2TransitSchedule {
 	 *             [1] outputCoordinateSystem. Use <tt>null</tt> if no transformation should be applied.<br/>
 	 *             [2] outputScheduleFile<br/>
 	 *             [3] outputVehicleFile<br/>
+	 *             [4] (optional) chosenDate for which to build schedule.<br/>
 	 */
 	public static void main(String[] args) throws IOException {
 		if(args.length == 4) {
-			run(args[0], args[1], args[2], args[3]);
+			run(args[0], args[1], args[2], args[3], null);
+		} else if (args.length == 5) {
+			run(args[0], args[1], args[2], args[3], args[4]);
 		} else {
-			throw new IllegalArgumentException(args.length + " instead of 4 arguments given");
+			throw new IllegalArgumentException(args.length + " instead of 5 arguments given");
 		}
 	}
 
@@ -65,13 +69,13 @@ public final class Hafas2TransitSchedule {
 	 * Converts all files in <tt>hafasFolder</tt> and writes the output schedule and vehicles to the respective
 	 * files. Stop Facility coordinates are transformed from WGS84 to <tt>outputCoordinateSystem</tt>.
 	 */
-	public static void run(String hafasFolder, String outputCoordinateSystem, String outputScheduleFile, String outputVehicleFile) throws IOException {
+	public static void run(String hafasFolder, String outputCoordinateSystem, String outputScheduleFile, String outputVehicleFile, String chosenDateString) throws IOException {
 		TransitSchedule schedule = ScheduleTools.createSchedule();
 		Vehicles vehicles = VehicleUtils.createVehiclesContainer();
 		CoordinateTransformation transformation = !outputCoordinateSystem.equals("null") ?
 				TransformationFactory.getCoordinateTransformation("WGS84", outputCoordinateSystem) : new IdentityTransformation();
 
-		HafasConverter.run(hafasFolder, schedule, transformation, vehicles);
+		HafasConverter.run(hafasFolder, schedule, transformation, vehicles, chosenDateString);
 
 		ScheduleTools.writeTransitSchedule(schedule, outputScheduleFile);
 		ScheduleTools.writeVehicles(vehicles, outputVehicleFile);

--- a/src/main/java/org/matsim/pt2matsim/tools/VehicleTypeDefaults.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/VehicleTypeDefaults.java
@@ -40,6 +40,7 @@ public final class VehicleTypeDefaults {
 		BAT	("BAT",	RouteType.FERRY,	true,	50,		6,		0.5,	0.5,	VehicleType.DoorOperationMode.serial,	250,	0,		7.1,	false,	"Ship"),
 		BAV	("BAV",	RouteType.FERRY,	true,	50,		6,		0.5,	0.5,	VehicleType.DoorOperationMode.serial,	250,	0,		7.1,	false,	"Steam ship"),
 		BEX ("BEX",	RouteType.RAIL,		true,	150,	2.8,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	240,	0,		20.4,	false,	"Bernina Express"),
+		B	("BUS",	RouteType.BUS,		true,	18,		2.5,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	70,		0,		2.8,	true,	"Bus"),
 		BUS	("BUS",	RouteType.BUS,		true,	18,		2.5,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	70,		0,		2.8,	true,	"Bus"),
 		CNL ("CNL",	RouteType.RAIL,		true,	200,	2.8,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	400,	0,		27.1,	false,	"CityNightLine"),
 		D   ("D",	RouteType.RAIL,		true,	150,	2.8,	0.25,	0.25,	VehicleType.DoorOperationMode.serial,	400,	0,		20.4,	false,	"Fast train"),

--- a/src/main/java/org/matsim/pt2matsim/tools/debug/ScheduleCleaner.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/debug/ScheduleCleaner.java
@@ -83,6 +83,9 @@ public final class ScheduleCleaner {
 		for(TransitLine line : schedule.getTransitLines().values()) {
 			for(TransitRoute route : line.getRoutes().values()) {
 				for(TransitRouteStop stop : route.getStops()) {
+					if(stop == null || stop.getStopFacility() == null) {
+						log.error("Stop does not exist");
+					}
 					usedStopFacilities.add(stop.getStopFacility().getId());
 				}
 			}


### PR DESCRIPTION
Fix for issue #98, also solves a todo in the hafasConverter

- a chosen date can now be included as a 5th parameter to the hafas convertor (optional)
- if provided, the dayNr is calculated and validated against the fahrplan start/end from the ECKDATEN