### PR TITLE
osm config loader fix

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/config/OsmConverterConfigGroup.java
+++ b/src/main/java/org/matsim/pt2matsim/config/OsmConverterConfigGroup.java
@@ -103,7 +103,7 @@ public class OsmConverterConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	public static OsmConverterConfigGroup loadConfig(String configFile) {
-		Config configAll = ConfigUtils.loadConfig(configFile, new PublicTransitMappingConfigGroup());
+		Config configAll = ConfigUtils.loadConfig(configFile, new OsmConverterConfigGroup());
 		return ConfigUtils.addOrGetModule(configAll, OsmConverterConfigGroup.GROUP_NAME, OsmConverterConfigGroup.class);
 	}
 


### PR DESCRIPTION
when loading the config it was taking PublicTransitMappingConfigGroup instead of the
OsmConverterConfigGroup, which caused that the parameter sets were not loaded from the config file