### PR TITLE
re-add geotools dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.matsim</groupId>
     <artifactId>pt2matsim</artifactId>
-    <version>21.1</version>
+    <version>21.4-SNAPSHOT</version>
 
     <name>PT2MATSim</name>
     <description>Public Transport to MATSim</description>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </repositories>
 
 	<properties>
-		<geotools.version>20.2</geotools.version>
+		<geotools.version>24.2</geotools.version>
 	</properties>
 
     <dependencies>
@@ -63,6 +63,16 @@
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
             <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+            <version>${geotools.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
+++ b/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
@@ -13,10 +13,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.network.algorithms.MultimodalNetworkCleaner;
 import org.matsim.pt2matsim.config.OsmConverterConfigGroup;
 import org.matsim.pt2matsim.osm.lib.OsmData;
 import org.matsim.pt2matsim.osm.lib.OsmDataImpl;
 import org.matsim.pt2matsim.osm.lib.OsmFileReader;
+import org.matsim.pt2matsim.run.Osm2MultimodalNetwork;
 
 /**
  * @author polettif
@@ -301,9 +303,13 @@ public class OsmMultimodalNetworkConverterTest {
 	public void convertEPSG() {
 		OsmConverterConfigGroup osmConfig = OsmConverterConfigGroup.createDefaultConfig();
 		osmConfig.setOutputCoordinateSystem("EPSG:8682"); // not the acutal epsg code for the area
-		osmConfig.setOsmFile("test/osm/WaterlooCityCentre.osm");
+		osmConfig.setOsmFile("test/osm/Belgrade.osm");
 
-		new OsmFileReader(new OsmDataImpl()).readFile(osmConfig.getOsmFile());
+		OsmData osm = new OsmDataImpl();
+		new OsmFileReader(osm).readFile(osmConfig.getOsmFile());
+
+		OsmMultimodalNetworkConverter converter = new OsmMultimodalNetworkConverter(osm);
+		converter.convert(osmConfig);
 	}
 
 }

--- a/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
+++ b/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
@@ -13,12 +13,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.core.network.algorithms.MultimodalNetworkCleaner;
 import org.matsim.pt2matsim.config.OsmConverterConfigGroup;
 import org.matsim.pt2matsim.osm.lib.OsmData;
 import org.matsim.pt2matsim.osm.lib.OsmDataImpl;
 import org.matsim.pt2matsim.osm.lib.OsmFileReader;
-import org.matsim.pt2matsim.run.Osm2MultimodalNetwork;
 
 /**
  * @author polettif
@@ -302,7 +300,7 @@ public class OsmMultimodalNetworkConverterTest {
 	@Test
 	public void convertEPSG() {
 		OsmConverterConfigGroup osmConfig = OsmConverterConfigGroup.createDefaultConfig();
-		osmConfig.setOutputCoordinateSystem("EPSG:8682"); // not the acutal epsg code for the area
+		osmConfig.setOutputCoordinateSystem("EPSG:8682");
 		osmConfig.setOsmFile("test/osm/Belgrade.osm");
 
 		OsmData osm = new OsmDataImpl();

--- a/test/osm/Belgrade.osm
+++ b/test/osm/Belgrade.osm
@@ -1,0 +1,14691 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="Overpass API 0.7.56.9 76e5016d">
+<note>The data included in this document is from www.openstreetmap.org. The data is made available under ODbL.</note>
+<meta osm_base="2021-04-01T06:48:28Z"/>
+
+  <bounds minlat="44.8140900" minlon="20.4599700" maxlat="44.8160400" maxlon="20.4629700"/>
+
+  <node id="36471163" lat="44.8038102" lon="20.4659883" version="8" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic">
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="highway" v="traffic_signals"/>
+    <tag k="traffic_signals" v="signal"/>
+  </node>
+  <node id="248917064" lat="44.8171540" lon="20.4576959" version="5" timestamp="2018-11-18T22:21:40Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="248917515" lat="44.8157339" lon="20.4593594" version="6" timestamp="2018-11-18T22:21:41Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="248920238" lat="44.8168201" lon="20.4591748" version="6" timestamp="2018-06-28T15:36:34Z" changeset="60252938" uid="6225925" user="Aleksa Marinski"/>
+  <node id="248920239" lat="44.8164293" lon="20.4596574" version="6" timestamp="2018-06-28T15:36:34Z" changeset="60252938" uid="6225925" user="Aleksa Marinski"/>
+  <node id="248920240" lat="44.8167247" lon="20.4601328" version="7" timestamp="2018-06-28T15:36:34Z" changeset="60252938" uid="6225925" user="Aleksa Marinski"/>
+  <node id="248920241" lat="44.8171155" lon="20.4596502" version="6" timestamp="2018-06-28T15:36:34Z" changeset="60252938" uid="6225925" user="Aleksa Marinski"/>
+  <node id="249024039" lat="44.8157260" lon="20.4623037" version="14" timestamp="2021-03-23T12:52:44Z" changeset="101575695" uid="733709" user="dizajnmario">
+    <tag k="button_operated" v="yes"/>
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="crossing:island" v="no"/>
+    <tag k="crossing_ref" v="zebra"/>
+    <tag k="highway" v="crossing"/>
+    <tag k="traffic_signals:arrow" v="yes"/>
+    <tag k="traffic_signals:minimap" v="yes"/>
+    <tag k="traffic_signals:sound" v="yes"/>
+    <tag k="traffic_signals:vibration" v="yes"/>
+  </node>
+  <node id="249024413" lat="44.8164806" lon="20.4609047" version="5" timestamp="2017-12-25T19:45:59Z" changeset="54914490" uid="6225925" user="Aleksa Marinski"/>
+  <node id="249024418" lat="44.8164244" lon="20.4609174" version="4" timestamp="2017-10-21T11:16:48Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="249024491" lat="44.8165608" lon="20.4609969" version="3" timestamp="2017-10-21T11:16:48Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="249024494" lat="44.8166620" lon="20.4613689" version="4" timestamp="2017-10-21T11:16:48Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="249024495" lat="44.8166363" lon="20.4611851" version="2" timestamp="2017-10-21T11:16:48Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="249024633" lat="44.8166172" lon="20.4614962" version="5" timestamp="2017-10-21T11:16:48Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="249024695" lat="44.8160200" lon="20.4614364" version="8" timestamp="2019-06-09T22:58:26Z" changeset="71082705" uid="6225925" user="Aleksa Marinski"/>
+  <node id="249026854" lat="44.8161157" lon="20.4623298" version="12" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="249027867" lat="44.8145738" lon="20.4602178" version="5" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="249342979" lat="44.8144985" lon="20.4627443" version="10" timestamp="2019-06-18T23:14:32Z" changeset="71382762" uid="8578206" user="Goatosm"/>
+  <node id="249343033" lat="44.8145668" lon="20.4630016" version="7" timestamp="2017-10-19T21:26:46Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="249343037" lat="44.8150188" lon="20.4639546" version="4" timestamp="2019-03-11T17:52:31Z" changeset="68032434" uid="9414390" user="Gr8fulDead">
+    <tag k="crossing" v="uncontrolled"/>
+    <tag k="crossing_ref" v="zebra"/>
+    <tag k="highway" v="crossing"/>
+  </node>
+  <node id="250438341" lat="44.8158188" lon="20.4601742" version="5" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="250438342" lat="44.8154951" lon="20.4596431" version="7" timestamp="2018-07-15T14:29:13Z" changeset="60733367" uid="6225925" user="Aleksa Marinski"/>
+  <node id="250438343" lat="44.8150149" lon="20.4600313" version="6" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="250438346" lat="44.8156140" lon="20.4604960" version="8" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="256222808" lat="44.8142813" lon="20.4626481" version="6" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="256222810" lat="44.8141622" lon="20.4588522" version="10" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="256368843" lat="44.8144260" lon="20.4622474" version="7" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="256411914" lat="44.8200046" lon="20.4532091" version="3" timestamp="2016-01-25T17:34:53Z" changeset="36801304" uid="2886645" user="nikicam"/>
+  <node id="256411982" lat="44.8198510" lon="20.4534061" version="2" timestamp="2016-01-25T17:34:53Z" changeset="36801304" uid="2886645" user="nikicam"/>
+  <node id="256769331" lat="44.8148311" lon="20.4626119" version="10" timestamp="2019-06-18T23:14:32Z" changeset="71382762" uid="8578206" user="Goatosm"/>
+  <node id="256769332" lat="44.8146538" lon="20.4625624" version="8" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="256769333" lat="44.8145350" lon="20.4624698" version="7" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="256769334" lat="44.8144846" lon="20.4623904" version="7" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="257726488" lat="44.8157410" lon="20.4605608" version="10" timestamp="2019-04-04T09:19:59Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="257726629" lat="44.8143895" lon="20.4603899" version="6" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="257726631" lat="44.8150320" lon="20.4603391" version="8" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="257802664" lat="44.8146828" lon="20.4596665" version="4" timestamp="2016-01-25T20:43:37Z" changeset="36804760" uid="2886645" user="nikicam"/>
+  <node id="319621245" lat="44.8141736" lon="20.4627712" version="5" timestamp="2019-06-18T23:14:32Z" changeset="71382762" uid="8578206" user="Goatosm"/>
+  <node id="319621282" lat="44.8141912" lon="20.4623979" version="1" timestamp="2008-12-17T23:05:43Z" changeset="466048" uid="72572" user="tomic"/>
+  <node id="428987363" lat="44.8190526" lon="20.4558188" version="5" timestamp="2019-09-22T13:45:39Z" changeset="74772319" uid="6225925" user="Aleksa Marinski">
+    <tag k="entrance" v="yes"/>
+  </node>
+  <node id="430923108" lat="44.8165588" lon="20.4556044" version="4" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="430923111" lat="44.8165115" lon="20.4555795" version="4" timestamp="2018-01-21T14:13:55Z" changeset="55628891" uid="6225925" user="Aleksa Marinski"/>
+  <node id="430923133" lat="44.8163937" lon="20.4560149" version="3" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="430923140" lat="44.8164433" lon="20.4560410" version="4" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="430927119" lat="44.8160610" lon="20.4572003" version="3" timestamp="2016-01-30T22:08:27Z" changeset="36906878" uid="2886645" user="nikicam"/>
+  <node id="430927120" lat="44.8158017" lon="20.4578130" version="3" timestamp="2016-01-30T22:08:27Z" changeset="36906878" uid="2886645" user="nikicam"/>
+  <node id="430927121" lat="44.8156741" lon="20.4577057" version="3" timestamp="2016-01-30T22:08:27Z" changeset="36906878" uid="2886645" user="nikicam"/>
+  <node id="430927122" lat="44.8156966" lon="20.4576526" version="3" timestamp="2016-01-30T22:08:27Z" changeset="36906878" uid="2886645" user="nikicam"/>
+  <node id="430927123" lat="44.8154743" lon="20.4574656" version="3" timestamp="2016-01-30T22:08:27Z" changeset="36906878" uid="2886645" user="nikicam"/>
+  <node id="454733033" lat="44.8192891" lon="20.4545810" version="6" timestamp="2019-03-05T22:43:05Z" changeset="67824357" uid="6225925" user="Aleksa Marinski"/>
+  <node id="456123317" lat="44.8144711" lon="20.4597055" version="2" timestamp="2014-08-03T16:03:40Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="456123325" lat="44.8147050" lon="20.4600010" version="2" timestamp="2014-08-03T16:03:40Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="456123337" lat="44.8139817" lon="20.4601517" version="2" timestamp="2014-08-03T16:03:40Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="456123338" lat="44.8139777" lon="20.4600960" version="2" timestamp="2014-08-03T16:03:40Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="456123342" lat="44.8139517" lon="20.4603001" version="2" timestamp="2014-08-03T16:03:40Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="456123414" lat="44.8146875" lon="20.4583438" version="2" timestamp="2016-01-29T21:49:23Z" changeset="36888702" uid="2886645" user="nikicam"/>
+  <node id="456123415" lat="44.8145039" lon="20.4585842" version="2" timestamp="2016-01-29T21:49:23Z" changeset="36888702" uid="2886645" user="nikicam"/>
+  <node id="456123418" lat="44.8144207" lon="20.4586995" version="3" timestamp="2014-08-03T16:03:40Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="456863695" lat="44.8181101" lon="20.4566363" version="4" timestamp="2018-03-20T20:03:26Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="456863697" lat="44.8179480" lon="20.4569518" version="1" timestamp="2009-08-05T12:39:56Z" changeset="2045317" uid="148407" user="grecko"/>
+  <node id="456863745" lat="44.8190723" lon="20.4558744" version="3" timestamp="2016-01-30T22:49:24Z" changeset="36907467" uid="2886645" user="nikicam"/>
+  <node id="456920115" lat="44.8193794" lon="20.4544024" version="4" timestamp="2019-03-05T22:43:06Z" changeset="67824357" uid="6225925" user="Aleksa Marinski"/>
+  <node id="458976886" lat="44.8179096" lon="20.4574180" version="2" timestamp="2019-05-20T09:48:52Z" changeset="70433495" uid="4688028" user="andreiSk"/>
+  <node id="471048376" lat="44.8198244" lon="20.4534750" version="2" timestamp="2016-01-25T17:52:35Z" changeset="36801671" uid="2886645" user="nikicam"/>
+  <node id="486262465" lat="44.8173883" lon="20.4574097" version="3" timestamp="2019-08-31T14:05:36Z" changeset="73950388" uid="6225925" user="Aleksa Marinski"/>
+  <node id="488443811" lat="44.8166579" lon="20.4582785" version="2" timestamp="2018-11-18T22:21:43Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="488447970" lat="44.8144820" lon="20.4602266" version="5" timestamp="2019-06-29T17:08:25Z" changeset="71740102" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="taxi"/>
+    <tag k="name" v="Теразије"/>
+    <tag k="name:sr" v="Теразије"/>
+    <tag k="name:sr-Latn" v="Terazije"/>
+  </node>
+  <node id="501541433" lat="44.8164534" lon="20.4585245" version="3" timestamp="2018-11-18T22:21:43Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="503888394" lat="44.8155861" lon="20.4629673" version="5" timestamp="2016-02-01T22:56:21Z" changeset="36948042" uid="2886645" user="nikicam"/>
+  <node id="503888396" lat="44.8151961" lon="20.4627730" version="5" timestamp="2016-02-17T15:39:24Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="503889005" lat="44.8143162" lon="20.4626422" version="2" timestamp="2009-09-23T18:08:39Z" changeset="2597706" uid="168004" user="Nikola Smolenski"/>
+  <node id="503889009" lat="44.8146333" lon="20.4623621" version="2" timestamp="2017-10-19T21:26:47Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="503889012" lat="44.8144995" lon="20.4629605" version="2" timestamp="2009-09-23T18:06:04Z" changeset="2597706" uid="168004" user="Nikola Smolenski"/>
+  <node id="503889013" lat="44.8146213" lon="20.4628614" version="2" timestamp="2017-10-19T21:26:46Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="503889015" lat="44.8146700" lon="20.4628845" version="2" timestamp="2017-10-19T21:26:46Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="503889017" lat="44.8150126" lon="20.4625931" version="3" timestamp="2017-10-19T21:26:46Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="503889018" lat="44.8151150" lon="20.4625478" version="3" timestamp="2017-10-19T21:26:47Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="503889025" lat="44.8142424" lon="20.4624668" version="2" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario"/>
+  <node id="503889027" lat="44.8144738" lon="20.4629942" version="3" timestamp="2017-10-15T21:48:45Z" changeset="52967221" uid="2065166" user="suff"/>
+  <node id="503889032" lat="44.8147003" lon="20.4627065" version="2" timestamp="2017-10-19T21:26:46Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="503894437" lat="44.8151078" lon="20.4620499" version="1" timestamp="2009-09-21T09:35:20Z" changeset="2554993" uid="168004" user="Nikola Smolenski">
+    <tag k="amenity" v="parking"/>
+  </node>
+  <node id="503894440" lat="44.8148387" lon="20.4618504" version="3" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="503894441" lat="44.8152600" lon="20.4619109" version="2" timestamp="2019-05-14T10:17:20Z" changeset="70226215" uid="3207276" user="Armin Gheorghina"/>
+  <node id="503894443" lat="44.8152890" lon="20.4614818" version="2" timestamp="2015-03-09T21:42:11Z" changeset="29372361" uid="251068" user="misabrzi"/>
+  <node id="503894444" lat="44.8152600" lon="20.4622302" version="1" timestamp="2009-09-21T09:35:21Z" changeset="2554993" uid="168004" user="Nikola Smolenski"/>
+  <node id="503894445" lat="44.8152690" lon="20.4624355" version="8" timestamp="2019-06-18T23:14:32Z" changeset="71382762" uid="8578206" user="Goatosm"/>
+  <node id="503894446" lat="44.8139304" lon="20.4617840" version="3" timestamp="2020-12-01T13:44:09Z" changeset="95097857" uid="733709" user="dizajnmario"/>
+  <node id="503894447" lat="44.8140757" lon="20.4616613" version="3" timestamp="2020-12-01T13:44:09Z" changeset="95097857" uid="733709" user="dizajnmario"/>
+  <node id="503894448" lat="44.8145129" lon="20.4616860" version="2" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="503894449" lat="44.8149860" lon="20.4610886" version="1" timestamp="2009-09-21T09:35:22Z" changeset="2554993" uid="168004" user="Nikola Smolenski"/>
+  <node id="503894450" lat="44.8148947" lon="20.4610371" version="1" timestamp="2009-09-21T09:35:22Z" changeset="2554993" uid="168004" user="Nikola Smolenski"/>
+  <node id="503894451" lat="44.8150162" lon="20.4604211" version="3" timestamp="2019-05-14T10:17:20Z" changeset="70226215" uid="3207276" user="Armin Gheorghina"/>
+  <node id="504918664" lat="44.8148651" lon="20.4610203" version="1" timestamp="2009-09-22T07:45:56Z" changeset="2566044" uid="168004" user="Nikola Smolenski"/>
+  <node id="504918665" lat="44.8149086" lon="20.4608499" version="3" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina"/>
+  <node id="504918666" lat="44.8148953" lon="20.4601311" version="2" timestamp="2009-09-23T18:27:25Z" changeset="2597860" uid="168004" user="Nikola Smolenski"/>
+  <node id="504918667" lat="44.8149403" lon="20.4599728" version="4" timestamp="2014-06-27T01:07:49Z" changeset="23204315" uid="2145201" user="OSM_Popler"/>
+  <node id="504918668" lat="44.8148162" lon="20.4599080" version="2" timestamp="2009-09-23T18:27:22Z" changeset="2597860" uid="168004" user="Nikola Smolenski"/>
+  <node id="504918669" lat="44.8148405" lon="20.4599680" version="2" timestamp="2009-09-23T18:27:25Z" changeset="2597860" uid="168004" user="Nikola Smolenski"/>
+  <node id="504918671" lat="44.8146764" lon="20.4599302" version="1" timestamp="2009-09-22T07:45:58Z" changeset="2566044" uid="168004" user="Nikola Smolenski"/>
+  <node id="504918672" lat="44.8146520" lon="20.4599474" version="1" timestamp="2009-09-22T07:45:58Z" changeset="2566044" uid="168004" user="Nikola Smolenski"/>
+  <node id="504918674" lat="44.8147963" lon="20.4604812" version="2" timestamp="2017-10-21T11:16:47Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="504918675" lat="44.8147308" lon="20.4604737" version="2" timestamp="2017-10-21T11:16:47Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="504918677" lat="44.8147248" lon="20.4600625" version="2" timestamp="2009-09-23T18:27:23Z" changeset="2597860" uid="168004" user="Nikola Smolenski"/>
+  <node id="504918678" lat="44.8148405" lon="20.4604229" version="2" timestamp="2009-09-23T18:27:26Z" changeset="2597860" uid="168004" user="Nikola Smolenski"/>
+  <node id="504918679" lat="44.8148632" lon="20.4604919" version="3" timestamp="2017-10-21T11:16:47Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="504918682" lat="44.8150158" lon="20.4605286" version="3" timestamp="2019-05-14T10:17:20Z" changeset="70226215" uid="3207276" user="Armin Gheorghina"/>
+  <node id="504918683" lat="44.8150622" lon="20.4605430" version="2" timestamp="2017-10-21T11:16:46Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="504918685" lat="44.8148393" lon="20.4598335" version="3" timestamp="2014-08-03T16:03:41Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="506286705" lat="44.8145177" lon="20.4629347" version="1" timestamp="2009-09-23T18:06:04Z" changeset="2597706" uid="168004" user="Nikola Smolenski"/>
+  <node id="506286707" lat="44.8145587" lon="20.4627195" version="3" timestamp="2017-10-19T21:26:46Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="506286708" lat="44.8145056" lon="20.4629090" version="2" timestamp="2009-09-23T18:08:39Z" changeset="2597706" uid="168004" user="Nikola Smolenski"/>
+  <node id="506287630" lat="44.8144629" lon="20.4625743" version="1" timestamp="2009-09-23T18:08:39Z" changeset="2597706" uid="168004" user="Nikola Smolenski"/>
+  <node id="506287631" lat="44.8143341" lon="20.4626259" version="6" timestamp="2019-09-09T21:06:35Z" changeset="74281386" uid="6225925" user="Aleksa Marinski">
+    <tag k="access" v="yes"/>
+    <tag k="amenity" v="toilets"/>
+    <tag k="fee" v="yes"/>
+    <tag k="level" v="-1"/>
+    <tag k="wheelchair" v="no"/>
+  </node>
+  <node id="506294580" lat="44.8146645" lon="20.4602041" version="6" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="506294581" lat="44.8147608" lon="20.4599581" version="2" timestamp="2009-09-23T18:29:13Z" changeset="2597860" uid="168004" user="Nikola Smolenski"/>
+  <node id="506294583" lat="44.8148172" lon="20.4601105" version="2" timestamp="2014-06-27T00:31:06Z" changeset="23204123" uid="2145201" user="OSM_Popler"/>
+  <node id="506294586" lat="44.8148771" lon="20.4601397" version="1" timestamp="2009-09-23T18:27:25Z" changeset="2597860" uid="168004" user="Nikola Smolenski"/>
+  <node id="506294587" lat="44.8148953" lon="20.4600625" version="1" timestamp="2009-09-23T18:27:25Z" changeset="2597860" uid="168004" user="Nikola Smolenski"/>
+  <node id="506294588" lat="44.8149014" lon="20.4600281" version="1" timestamp="2009-09-23T18:27:25Z" changeset="2597860" uid="168004" user="Nikola Smolenski"/>
+  <node id="506295156" lat="44.8149150" lon="20.4605021" version="2" timestamp="2017-10-21T11:16:47Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="506297358" lat="44.8166443" lon="20.4582945" version="2" timestamp="2018-11-18T22:21:44Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="506297363" lat="44.8167924" lon="20.4581214" version="2" timestamp="2018-11-18T22:21:44Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="506297385" lat="44.8163401" lon="20.4586652" version="4" timestamp="2018-11-18T22:21:44Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="583586884" lat="44.8140529" lon="20.4629055" version="7" timestamp="2019-06-18T23:14:32Z" changeset="71382762" uid="8578206" user="Goatosm"/>
+  <node id="583586885" lat="44.8153982" lon="20.4647307" version="3" timestamp="2019-03-11T18:02:26Z" changeset="68032833" uid="9414390" user="Gr8fulDead">
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="crossing_ref" v="zebra"/>
+    <tag k="highway" v="traffic_signals"/>
+  </node>
+  <node id="760422969" lat="44.8162224" lon="20.4618759" version="8" timestamp="2016-02-17T15:22:53Z" changeset="37269359" uid="2886645" user="nikicam"/>
+  <node id="760422970" lat="44.8162753" lon="20.4617205" version="6" timestamp="2020-10-29T10:36:35Z" changeset="93230281" uid="6225925" user="Aleksa Marinski"/>
+  <node id="760422971" lat="44.8165558" lon="20.4617491" version="5" timestamp="2020-10-29T10:36:35Z" changeset="93230281" uid="6225925" user="Aleksa Marinski"/>
+  <node id="760422972" lat="44.8165624" lon="20.4616206" version="5" timestamp="2016-02-17T15:22:53Z" changeset="37269359" uid="2886645" user="nikicam"/>
+  <node id="760422974" lat="44.8158744" lon="20.4617257" version="3" timestamp="2017-10-19T21:26:47Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="760425380" lat="44.8162139" lon="20.4615237" version="4" timestamp="2019-08-30T23:31:35Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1039025161" lat="44.8200828" lon="20.4533089" version="4" timestamp="2018-06-19T11:00:24Z" changeset="59974188" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1119932696" lat="44.8158222" lon="20.4593016" version="6" timestamp="2018-11-18T22:21:44Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1119942190" lat="44.8153551" lon="20.4604132" version="24" timestamp="2021-02-23T12:24:13Z" changeset="99825911" uid="733709" user="dizajnmario">
+    <tag k="bench" v="yes"/>
+    <tag k="bus" v="yes"/>
+    <tag k="gtfs:stop_id" v="532"/>
+    <tag k="highway" v="bus_stop"/>
+    <tag k="name" v="Трг Републике"/>
+    <tag k="name:en" v="Trg Republike"/>
+    <tag k="name:sr" v="Трг Републике"/>
+    <tag k="name:sr-Latn" v="Trg Republike"/>
+    <tag k="name:zh" v="共和国广场"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="passenger_information_display" v="yes"/>
+    <tag k="public_transport" v="platform"/>
+    <tag k="ref" v="532"/>
+    <tag k="shelter" v="yes"/>
+  </node>
+  <node id="1123392469" lat="44.8151327" lon="20.4606854" version="3" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123392471" lat="44.8155717" lon="20.4610700" version="4" timestamp="2019-09-27T18:54:38Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392472" lat="44.8156986" lon="20.4608968" version="4" timestamp="2019-09-27T18:54:39Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392481" lat="44.8157146" lon="20.4610729" version="4" timestamp="2019-09-27T18:54:39Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392483" lat="44.8157173" lon="20.4609930" version="4" timestamp="2019-09-27T18:54:39Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392485" lat="44.8155648" lon="20.4609973" version="4" timestamp="2019-09-27T18:54:40Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392486" lat="44.8156962" lon="20.4614636" version="3" timestamp="2016-01-24T10:23:05Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="1123392487" lat="44.8156765" lon="20.4608456" version="4" timestamp="2019-09-27T18:54:40Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392488" lat="44.8155422" lon="20.4609680" version="3" timestamp="2019-09-27T18:54:40Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392489" lat="44.8152726" lon="20.4605934" version="2" timestamp="2016-01-24T01:32:04Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123392491" lat="44.8155625" lon="20.4614578" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123392492" lat="44.8152028" lon="20.4608971" version="2" timestamp="2016-01-24T01:32:04Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123392493" lat="44.8153344" lon="20.4608675" version="3" timestamp="2019-09-27T18:54:41Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392494" lat="44.8153166" lon="20.4609491" version="2" timestamp="2016-01-24T01:32:04Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123392495" lat="44.8153873" lon="20.4606503" version="3" timestamp="2019-09-27T18:54:41Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392496" lat="44.8151626" lon="20.4605373" version="4" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina"/>
+  <node id="1123392502" lat="44.8152403" lon="20.4607320" version="3" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123392504" lat="44.8155942" lon="20.4607552" version="4" timestamp="2019-09-27T18:54:41Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123392505" lat="44.8155712" lon="20.4610317" version="5" timestamp="2019-09-27T18:54:41Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1123395374" lat="44.8150800" lon="20.4609097" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395375" lat="44.8151095" lon="20.4607714" version="3" timestamp="2017-02-01T13:37:55Z" changeset="45716879" uid="4785399" user="PhaMer"/>
+  <node id="1123395379" lat="44.8150988" lon="20.4606688" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395380" lat="44.8150808" lon="20.4607594" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395381" lat="44.8149843" lon="20.4606273" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395382" lat="44.8149255" lon="20.4607097" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395383" lat="44.8151467" lon="20.4609378" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395384" lat="44.8151776" lon="20.4607921" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395386" lat="44.8148984" lon="20.4608468" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395387" lat="44.8149702" lon="20.4604617" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395388" lat="44.8151110" lon="20.4607639" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395389" lat="44.8149409" lon="20.4606102" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1123395390" lat="44.8149649" lon="20.4607252" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1124731538" lat="44.8164024" lon="20.4559819" version="3" timestamp="2019-05-11T16:27:01Z" changeset="70141688" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1124731539" lat="44.8164690" lon="20.4556321" version="3" timestamp="2019-05-11T16:27:01Z" changeset="70141688" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1124731540" lat="44.8163280" lon="20.4557002" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731541" lat="44.8163862" lon="20.4559434" version="3" timestamp="2018-07-16T15:10:50Z" changeset="60768508" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1124731542" lat="44.8163181" lon="20.4558611" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731543" lat="44.8163471" lon="20.4556671" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731544" lat="44.8165022" lon="20.4556146" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731545" lat="44.8163643" lon="20.4559316" version="2" timestamp="2016-01-24T19:54:03Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731547" lat="44.8163151" lon="20.4557395" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731549" lat="44.8163435" lon="20.4559075" version="2" timestamp="2016-01-24T19:54:03Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731551" lat="44.8164133" lon="20.4556226" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731553" lat="44.8163796" lon="20.4559708" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731554" lat="44.8164421" lon="20.4556244" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731556" lat="44.8163090" lon="20.4558007" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731557" lat="44.8163833" lon="20.4556324" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1124731558" lat="44.8164773" lon="20.4556015" version="2" timestamp="2016-01-24T19:54:02Z" changeset="36783238" uid="2886645" user="nikicam"/>
+  <node id="1145157627" lat="44.8142635" lon="20.4594521" version="2" timestamp="2017-10-15T21:09:23Z" changeset="52966258" uid="2065166" user="suff"/>
+  <node id="1145306367" lat="44.8143481" lon="20.4625315" version="5" timestamp="2014-06-26T22:56:02Z" changeset="23203372" uid="2145201" user="OSM_Popler"/>
+  <node id="1309564697" lat="44.8160106" lon="20.4615617" version="3" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1344306016" lat="44.8174871" lon="20.4583620" version="3" timestamp="2012-03-17T07:32:29Z" changeset="11005151" uid="168004" user="Nikola Smolenski"/>
+  <node id="1344306021" lat="44.8170759" lon="20.4588621" version="3" timestamp="2012-03-17T07:32:29Z" changeset="11005151" uid="168004" user="Nikola Smolenski"/>
+  <node id="1344306022" lat="44.8173611" lon="20.4593198" version="2" timestamp="2011-06-30T08:52:51Z" changeset="8588185" uid="168004" user="Nikola Smolenski"/>
+  <node id="1344306040" lat="44.8172189" lon="20.4590956" version="3" timestamp="2012-03-17T07:32:30Z" changeset="11005151" uid="168004" user="Nikola Smolenski"/>
+  <node id="1344306046" lat="44.8173537" lon="20.4585293" version="3" timestamp="2012-03-17T07:32:30Z" changeset="11005151" uid="168004" user="Nikola Smolenski"/>
+  <node id="1344306049" lat="44.8172326" lon="20.4586756" version="3" timestamp="2012-03-17T07:32:31Z" changeset="11005151" uid="168004" user="Nikola Smolenski"/>
+  <node id="1576346227" lat="44.8143196" lon="20.4613726" version="3" timestamp="2012-04-17T20:27:56Z" changeset="11337375" uid="441816" user="kmilos">
+    <tag k="name" v="Рале"/>
+    <tag k="name:sr" v="Рале"/>
+    <tag k="name:sr-Latn" v="Rale"/>
+    <tag k="shop" v="hairdresser"/>
+  </node>
+  <node id="1618643087" lat="44.8153708" lon="20.4624512" version="15" timestamp="2021-01-26T20:44:49Z" changeset="98183352" uid="95504" user="Branko Kokanovic">
+    <tag k="bus" v="yes"/>
+    <tag k="gtfs:stop_id" v="358"/>
+    <tag k="highway" v="bus_stop"/>
+    <tag k="name" v="Дом Омладине"/>
+    <tag k="name:sr" v="Дом Омладине"/>
+    <tag k="name:sr-Latn" v="Dom Omladine"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport" v="platform"/>
+    <tag k="ref" v="358"/>
+    <tag k="shelter" v="yes"/>
+  </node>
+  <node id="1629299609" lat="44.8155571" lon="20.4620998" version="6" timestamp="2019-07-07T18:58:11Z" changeset="71989292" uid="6459761" user="rf8791">
+    <tag k="addr:housenumber" v="2"/>
+    <tag k="addr:postcode" v="11000"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="amenity" v="restaurant"/>
+    <tag k="cuisine" v="local"/>
+    <tag k="name" v="Морнар"/>
+    <tag k="name:en" v="Mornar"/>
+    <tag k="name:sr" v="Морнар"/>
+    <tag k="name:sr-Latn" v="Mornar"/>
+    <tag k="phone" v="+38111 32 55 514"/>
+  </node>
+  <node id="1629299610" lat="44.8153987" lon="20.4625850" version="5" timestamp="2017-09-27T22:24:03Z" changeset="52427414" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="restaurant"/>
+    <tag k="cuisine" v="regional"/>
+    <tag k="name" v="Сунце"/>
+    <tag k="name:sr" v="Сунце"/>
+    <tag k="name:sr-Latn" v="Sunce"/>
+  </node>
+  <node id="1629299611" lat="44.8151386" lon="20.4626001" version="4" timestamp="2016-02-17T15:39:23Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="1629299612" lat="44.8152230" lon="20.4627549" version="2" timestamp="2016-01-24T01:32:05Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="1629299613" lat="44.8152650" lon="20.4629049" version="4" timestamp="2016-02-17T15:39:23Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="1677964946" lat="44.8150992" lon="20.4625007" version="9" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="1744761051" lat="44.8153229" lon="20.4646302" version="2" timestamp="2018-08-24T10:28:37Z" changeset="61949979" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1801912953" lat="44.8190979" lon="20.4549124" version="4" timestamp="2019-03-05T22:43:08Z" changeset="67824357" uid="6225925" user="Aleksa Marinski"/>
+  <node id="1806315518" lat="44.8151331" lon="20.4600528" version="2" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="1806315519" lat="44.8151362" lon="20.4601096" version="2" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="1806315520" lat="44.8151870" lon="20.4602653" version="4" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="1806315530" lat="44.8152121" lon="20.4601397" version="3" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="1806315532" lat="44.8152670" lon="20.4601615" version="2" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315534" lat="44.8152855" lon="20.4600986" version="2" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315536" lat="44.8153421" lon="20.4598820" version="2" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="1806315538" lat="44.8153242" lon="20.4597784" version="2" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="1806315540" lat="44.8153484" lon="20.4598372" version="2" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="1806315542" lat="44.8153585" lon="20.4602016" version="2" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315544" lat="44.8153765" lon="20.4598311" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315546" lat="44.8153736" lon="20.4601502" version="2" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315548" lat="44.8154000" lon="20.4598821" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315550" lat="44.8154416" lon="20.4598362" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315552" lat="44.8154580" lon="20.4604132" version="2" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315553" lat="44.8154760" lon="20.4598745" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315554" lat="44.8154814" lon="20.4599050" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315555" lat="44.8154940" lon="20.4599611" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315556" lat="44.8154966" lon="20.4602825" version="2" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315558" lat="44.8155139" lon="20.4600147" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315559" lat="44.8155220" lon="20.4601854" version="3" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315560" lat="44.8155411" lon="20.4600580" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315569" lat="44.8155601" lon="20.4604688" version="3" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315571" lat="44.8155718" lon="20.4600962" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315572" lat="44.8156025" lon="20.4601192" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315573" lat="44.8156297" lon="20.4601370" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315574" lat="44.8156258" lon="20.4602529" version="2" timestamp="2016-08-20T15:55:59Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315575" lat="44.8156604" lon="20.4601982" version="1" timestamp="2012-06-29T17:19:52Z" changeset="12058684" uid="168004" user="Nikola Smolenski"/>
+  <node id="1806315576" lat="44.8157544" lon="20.4601804" version="1" timestamp="2012-06-29T17:19:53Z" changeset="12058684" uid="168004" user="Nikola Smolenski">
+    <tag k="amenity" v="cafe"/>
+  </node>
+  <node id="1963120010" lat="44.8146005" lon="20.4630697" version="8" timestamp="2019-03-11T17:52:31Z" changeset="68032434" uid="9414390" user="Gr8fulDead">
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="crossing_ref" v="zebra"/>
+    <tag k="highway" v="crossing"/>
+  </node>
+  <node id="2934858754" lat="44.8142378" lon="20.4627009" version="2" timestamp="2017-10-19T21:26:46Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="2934913745" lat="44.8149511" lon="20.4601302" version="1" timestamp="2014-06-27T01:07:49Z" changeset="23204315" uid="2145201" user="OSM_Popler"/>
+  <node id="2934913746" lat="44.8149602" lon="20.4602356" version="3" timestamp="2018-08-22T09:49:33Z" changeset="61882092" uid="6225925" user="Aleksa Marinski"/>
+  <node id="2934914879" lat="44.8147659" lon="20.4600843" version="1" timestamp="2014-06-27T00:31:00Z" changeset="23204123" uid="2145201" user="OSM_Popler"/>
+  <node id="2934914880" lat="44.8146532" lon="20.4601293" version="2" timestamp="2017-10-21T11:16:46Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="2934914881" lat="44.8148423" lon="20.4602440" version="4" timestamp="2019-03-26T19:08:37Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="2934914883" lat="44.8147330" lon="20.4602098" version="3" timestamp="2019-03-26T19:08:37Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="2934914885" lat="44.8147010" lon="20.4603141" version="5" timestamp="2019-03-26T19:08:37Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="2934914890" lat="44.8162049" lon="20.4608520" version="5" timestamp="2019-04-04T09:19:59Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="2934914900" lat="44.8154725" lon="20.4605459" version="7" timestamp="2019-08-30T23:31:35Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="2994328323" lat="44.8131166" lon="20.4611886" version="2" timestamp="2017-10-21T11:16:47Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="2994328342" lat="44.8139413" lon="20.4601575" version="1" timestamp="2014-08-03T16:03:34Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328343" lat="44.8140953" lon="20.4599262" version="2" timestamp="2016-11-21T20:59:20Z" changeset="43856775" uid="168004" user="Nikola Smolenski"/>
+  <node id="2994328344" lat="44.8141077" lon="20.4600757" version="2" timestamp="2016-11-21T20:59:20Z" changeset="43856775" uid="168004" user="Nikola Smolenski"/>
+  <node id="2994328345" lat="44.8141622" lon="20.4599151" version="3" timestamp="2016-11-21T20:59:20Z" changeset="43856775" uid="168004" user="Nikola Smolenski"/>
+  <node id="2994328346" lat="44.8141703" lon="20.4600126" version="3" timestamp="2016-11-21T20:59:20Z" changeset="43856775" uid="168004" user="Nikola Smolenski"/>
+  <node id="2994328347" lat="44.8141672" lon="20.4598808" version="1" timestamp="2014-08-03T16:03:34Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328348" lat="44.8141816" lon="20.4602616" version="2" timestamp="2016-02-12T09:23:40Z" changeset="37163693" uid="2886645" user="nikicam"/>
+  <node id="2994328349" lat="44.8141857" lon="20.4600105" version="1" timestamp="2014-08-03T16:03:35Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328355" lat="44.8142963" lon="20.4598044" version="1" timestamp="2014-08-03T16:03:35Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328357" lat="44.8143291" lon="20.4599230" version="1" timestamp="2014-08-03T16:03:35Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328358" lat="44.8143455" lon="20.4598356" version="1" timestamp="2014-08-03T16:03:35Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328360" lat="44.8143633" lon="20.4599049" version="1" timestamp="2014-08-03T16:03:35Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328361" lat="44.8143769" lon="20.4597491" version="1" timestamp="2014-08-03T16:03:35Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328362" lat="44.8143783" lon="20.4601583" version="1" timestamp="2014-08-03T16:03:35Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328363" lat="44.8143895" lon="20.4598098" version="1" timestamp="2014-08-03T16:03:35Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328365" lat="44.8144610" lon="20.4601141" version="1" timestamp="2014-08-03T16:03:35Z" changeset="24518920" uid="230942" user="dkiselev"/>
+  <node id="2994328366" lat="44.8145225" lon="20.4600747" version="3" timestamp="2018-01-21T14:13:55Z" changeset="55628891" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="cafe"/>
+  </node>
+  <node id="2994328367" lat="44.8145746" lon="20.4603209" version="3" timestamp="2019-03-26T19:08:37Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="3805634805" lat="44.8144132" lon="20.4601254" version="5" timestamp="2020-08-14T15:10:09Z" changeset="89418447" uid="5569366" user="TXBG">
+    <tag k="addr:city" v="Београд"/>
+    <tag k="addr:housenumber" v="3"/>
+    <tag k="addr:postcode" v="11000"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="name" v="WinWin"/>
+    <tag k="opening_hours" v="Mo-Fr 08:00-22:00; Sa 09:00-21:00; Su 12:00-19:00"/>
+    <tag k="phone" v="+381 11 36 10 138"/>
+    <tag k="shop" v="electronics"/>
+    <tag k="website" v="https://www.winwin.rs/"/>
+  </node>
+  <node id="3885525300" lat="44.8024355" lon="20.4656004" version="3" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="3959208061" lat="44.8158868" lon="20.4625227" version="2" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3959208062" lat="44.8157901" lon="20.4625158" version="3" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3959208063" lat="44.8157765" lon="20.4627127" version="3" timestamp="2016-11-23T08:16:01Z" changeset="43889297" uid="168004" user="Nikola Smolenski"/>
+  <node id="3959208064" lat="44.8159342" lon="20.4627263" version="1" timestamp="2016-01-22T09:59:50Z" changeset="36735327" uid="2886645" user="nikicam"/>
+  <node id="3959208065" lat="44.8159421" lon="20.4625493" version="1" timestamp="2016-01-22T09:59:50Z" changeset="36735327" uid="2886645" user="nikicam"/>
+  <node id="3959208066" lat="44.8158855" lon="20.4625425" version="2" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3959208067" lat="44.8157979" lon="20.4624298" version="1" timestamp="2016-01-22T09:59:50Z" changeset="36735327" uid="2886645" user="nikicam"/>
+  <node id="3959208068" lat="44.8158246" lon="20.4624120" version="2" timestamp="2016-11-23T08:16:01Z" changeset="43889297" uid="168004" user="Nikola Smolenski"/>
+  <node id="3959208069" lat="44.8160462" lon="20.4624159" version="1" timestamp="2016-01-22T09:59:50Z" changeset="36735327" uid="2886645" user="nikicam"/>
+  <node id="3959208070" lat="44.8160770" lon="20.4624515" version="1" timestamp="2016-01-22T09:59:50Z" changeset="36735327" uid="2886645" user="nikicam"/>
+  <node id="3959208071" lat="44.8160977" lon="20.4625772" version="3" timestamp="2019-09-28T18:28:33Z" changeset="75046301" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3959208072" lat="44.8160267" lon="20.4625867" version="2" timestamp="2019-09-28T18:28:34Z" changeset="75046301" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3959208073" lat="44.8160117" lon="20.4625316" version="2" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3959247469" lat="44.8161321" lon="20.4627864" version="2" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3959247471" lat="44.8159873" lon="20.4626967" version="1" timestamp="2016-01-22T10:24:32Z" changeset="36735766" uid="2886645" user="nikicam"/>
+  <node id="3959247472" lat="44.8160194" lon="20.4626859" version="2" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3959247473" lat="44.8160041" lon="20.4625899" version="1" timestamp="2016-01-22T10:24:32Z" changeset="36735766" uid="2886645" user="nikicam"/>
+  <node id="3959247474" lat="44.8161681" lon="20.4630101" version="2" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3959247475" lat="44.8160393" lon="20.4630480" version="3" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3959247476" lat="44.8160027" lon="20.4628108" version="3" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3961392921" lat="44.8166610" lon="20.4612686" version="2" timestamp="2017-10-21T11:16:48Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="3961392922" lat="44.8166015" lon="20.4610875" version="2" timestamp="2017-10-21T11:16:48Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="3961392923" lat="44.8165261" lon="20.4609376" version="4" timestamp="2017-12-25T19:46:01Z" changeset="54914490" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3961392924" lat="44.8158518" lon="20.4619591" version="5" timestamp="2019-08-18T10:39:12Z" changeset="73460704" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3962695733" lat="44.8140411" lon="20.4626856" version="2" timestamp="2016-01-24T10:23:05Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3962695738" lat="44.8147962" lon="20.4622487" version="1" timestamp="2016-01-24T01:31:58Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="3962695739" lat="44.8146755" lon="20.4622973" version="1" timestamp="2016-01-24T01:31:58Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="3962695740" lat="44.8146175" lon="20.4619880" version="1" timestamp="2016-01-24T01:31:58Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="3962695741" lat="44.8142085" lon="20.4621493" version="1" timestamp="2016-01-24T01:31:58Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="3962695742" lat="44.8141803" lon="20.4621161" version="1" timestamp="2016-01-24T01:31:58Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="3962695743" lat="44.8142070" lon="20.4620764" version="1" timestamp="2016-01-24T01:31:58Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="3962695744" lat="44.8141866" lon="20.4620057" version="1" timestamp="2016-01-24T01:31:58Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="3962695745" lat="44.8142978" lon="20.4619195" version="1" timestamp="2016-01-24T01:31:58Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="3962695746" lat="44.8146900" lon="20.4617490" version="2" timestamp="2016-01-24T10:23:05Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3962695751" lat="44.8162234" lon="20.4618539" version="2" timestamp="2016-02-17T15:22:53Z" changeset="37269359" uid="2886645" user="nikicam"/>
+  <node id="3962695752" lat="44.8159755" lon="20.4618492" version="2" timestamp="2016-02-17T15:22:53Z" changeset="37269359" uid="2886645" user="nikicam"/>
+  <node id="3962695756" lat="44.8163427" lon="20.4621763" version="4" timestamp="2017-10-21T11:16:50Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="3962695758" lat="44.8158357" lon="20.4621254" version="2" timestamp="2017-10-19T21:26:47Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="3962695759" lat="44.8159648" lon="20.4619754" version="5" timestamp="2019-08-18T10:39:12Z" changeset="73460704" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3962695760" lat="44.8159597" lon="20.4620461" version="3" timestamp="2017-10-19T21:26:47Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="3962695761" lat="44.8163431" lon="20.4620815" version="4" timestamp="2020-10-29T10:36:35Z" changeset="93230281" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3962695773" lat="44.8157572" lon="20.4629601" version="2" timestamp="2016-02-07T11:02:33Z" changeset="37057215" uid="2886645" user="nikicam"/>
+  <node id="3962695774" lat="44.8159232" lon="20.4629748" version="2" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695775" lat="44.8157391" lon="20.4631639" version="2" timestamp="2016-02-07T11:02:33Z" changeset="37057215" uid="2886645" user="nikicam"/>
+  <node id="3962695776" lat="44.8159275" lon="20.4631772" version="2" timestamp="2016-02-17T15:39:21Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695777" lat="44.8159380" lon="20.4629761" version="1" timestamp="2016-01-24T01:31:59Z" changeset="36768738" uid="2886645" user="nikicam"/>
+  <node id="3962695818" lat="44.8147283" lon="20.4632135" version="2" timestamp="2016-02-17T15:39:23Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695822" lat="44.8146288" lon="20.4629874" version="3" timestamp="2016-02-17T15:39:23Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695823" lat="44.8148482" lon="20.4628043" version="2" timestamp="2016-02-17T15:39:23Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695824" lat="44.8148930" lon="20.4629200" version="3" timestamp="2016-02-17T15:39:23Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695825" lat="44.8148179" lon="20.4629858" version="2" timestamp="2016-02-17T15:39:24Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695826" lat="44.8148654" lon="20.4630936" version="2" timestamp="2016-02-17T15:39:23Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695827" lat="44.8149305" lon="20.4627407" version="3" timestamp="2016-02-17T15:39:24Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695828" lat="44.8149925" lon="20.4629172" version="3" timestamp="2016-02-17T15:39:24Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695829" lat="44.8149124" lon="20.4629702" version="2" timestamp="2016-02-17T15:39:24Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695830" lat="44.8151380" lon="20.4625983" version="3" timestamp="2016-02-17T15:39:24Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3962695831" lat="44.8151965" lon="20.4627747" version="2" timestamp="2016-02-17T15:39:24Z" changeset="37269695" uid="2886645" user="nikicam"/>
+  <node id="3963848566" lat="44.8156842" lon="20.4616427" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848567" lat="44.8155893" lon="20.4616317" version="2" timestamp="2019-08-17T15:12:46Z" changeset="73445166" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3963848568" lat="44.8155919" lon="20.4615733" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848569" lat="44.8153404" lon="20.4615440" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848570" lat="44.8153501" lon="20.4614333" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848571" lat="44.8156767" lon="20.4617307" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848572" lat="44.8153248" lon="20.4616734" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848573" lat="44.8154504" lon="20.4615568" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848574" lat="44.8154470" lon="20.4616151" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848575" lat="44.8156605" lon="20.4619293" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848576" lat="44.8155721" lon="20.4619260" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848577" lat="44.8155805" lon="20.4617858" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848578" lat="44.8153937" lon="20.4617635" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848579" lat="44.8153864" lon="20.4618855" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848580" lat="44.8153126" lon="20.4618767" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848581" lat="44.8156466" lon="20.4621345" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848582" lat="44.8155479" lon="20.4621785" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848583" lat="44.8155205" lon="20.4619928" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848584" lat="44.8155704" lon="20.4619717" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848585" lat="44.8154514" lon="20.4622068" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848586" lat="44.8154117" lon="20.4619377" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848587" lat="44.8154678" lon="20.4619212" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848588" lat="44.8154801" lon="20.4620046" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848589" lat="44.8153348" lon="20.4622420" version="1" timestamp="2016-01-24T10:22:58Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848590" lat="44.8153232" lon="20.4621541" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848591" lat="44.8152294" lon="20.4621785" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848592" lat="44.8152019" lon="20.4620422" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848593" lat="44.8153763" lon="20.4619782" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848594" lat="44.8153902" lon="20.4620759" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848595" lat="44.8154312" lon="20.4620695" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848596" lat="44.8148984" lon="20.4623112" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848597" lat="44.8148333" lon="20.4619886" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848598" lat="44.8150423" lon="20.4619048" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848599" lat="44.8150799" lon="20.4620911" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848600" lat="44.8140525" lon="20.4618903" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848601" lat="44.8141334" lon="20.4618056" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848602" lat="44.8142190" lon="20.4619806" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848603" lat="44.8139906" lon="20.4617463" version="2" timestamp="2020-12-01T13:44:09Z" changeset="95097857" uid="733709" user="dizajnmario"/>
+  <node id="3963848604" lat="44.8140823" lon="20.4616707" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848605" lat="44.8141384" lon="20.4614513" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848608" lat="44.8141609" lon="20.4615679" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848611" lat="44.8140057" lon="20.4615455" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848623" lat="44.8147752" lon="20.4604251" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848624" lat="44.8147603" lon="20.4606304" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848625" lat="44.8149056" lon="20.4606624" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848626" lat="44.8149126" lon="20.4605991" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848627" lat="44.8146644" lon="20.4604390" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848628" lat="44.8145732" lon="20.4604607" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848629" lat="44.8145816" lon="20.4608660" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848630" lat="44.8146602" lon="20.4608621" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848631" lat="44.8143628" lon="20.4605695" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848632" lat="44.8143839" lon="20.4606703" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848633" lat="44.8144147" lon="20.4606624" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848634" lat="44.8144231" lon="20.4609689" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848635" lat="44.8145802" lon="20.4609511" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848636" lat="44.8145805" lon="20.4608106" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848637" lat="44.8145031" lon="20.4608146" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848638" lat="44.8144975" lon="20.4606367" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848639" lat="44.8145768" lon="20.4606307" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848640" lat="44.8141090" lon="20.4607751" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848641" lat="44.8141581" lon="20.4608937" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848642" lat="44.8143923" lon="20.4607178" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848643" lat="44.8140332" lon="20.4608403" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963848644" lat="44.8140669" lon="20.4609491" version="1" timestamp="2016-01-24T10:22:59Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849019" lat="44.8143231" lon="20.4621907" version="1" timestamp="2016-01-24T10:24:16Z" changeset="36772898" uid="2886645" user="nikicam"/>
+  <node id="3963849020" lat="44.8142150" lon="20.4622194" version="1" timestamp="2016-01-24T10:24:16Z" changeset="36772898" uid="2886645" user="nikicam"/>
+  <node id="3963849021" lat="44.8142432" lon="20.4623917" version="1" timestamp="2016-01-24T10:24:16Z" changeset="36772898" uid="2886645" user="nikicam"/>
+  <node id="3963849022" lat="44.8143294" lon="20.4624823" version="1" timestamp="2016-01-24T10:24:16Z" changeset="36772898" uid="2886645" user="nikicam"/>
+  <node id="3963849023" lat="44.8143498" lon="20.4623431" version="1" timestamp="2016-01-24T10:24:16Z" changeset="36772898" uid="2886645" user="nikicam"/>
+  <node id="3963849165" lat="44.8141379" lon="20.4624444" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849166" lat="44.8139989" lon="20.4624878" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849167" lat="44.8141674" lon="20.4626401" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849168" lat="44.8141070" lon="20.4622507" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849169" lat="44.8140173" lon="20.4623317" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849170" lat="44.8140503" lon="20.4624718" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849171" lat="44.8139962" lon="20.4620431" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849172" lat="44.8139345" lon="20.4621498" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849173" lat="44.8139093" lon="20.4621716" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849174" lat="44.8138910" lon="20.4621162" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849215" lat="44.8157049" lon="20.4610442" version="3" timestamp="2018-06-19T11:00:25Z" changeset="59974188" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="2"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building:levels" v="6"/>
+  </node>
+  <node id="3963849216" lat="44.8154866" lon="20.4611293" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849217" lat="44.8152640" lon="20.4610730" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849218" lat="44.8151841" lon="20.4614056" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849219" lat="44.8152678" lon="20.4614619" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849220" lat="44.8152868" lon="20.4613761" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849221" lat="44.8152640" lon="20.4613627" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849222" lat="44.8152906" lon="20.4612581" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849223" lat="44.8154714" lon="20.4613090" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849227" lat="44.8142923" lon="20.4617169" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849228" lat="44.8142847" lon="20.4618510" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849229" lat="44.8146622" lon="20.4606630" version="1" timestamp="2016-01-24T10:23:00Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849230" lat="44.8147580" lon="20.4606515" version="1" timestamp="2016-01-24T10:23:01Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849231" lat="44.8141157" lon="20.4611270" version="1" timestamp="2016-01-24T10:23:01Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849232" lat="44.8141885" lon="20.4611042" version="1" timestamp="2016-01-24T10:23:01Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849233" lat="44.8141388" lon="20.4609072" version="1" timestamp="2016-01-24T10:23:01Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849238" lat="44.8141566" lon="20.4616653" version="1" timestamp="2016-01-24T10:23:01Z" changeset="36772879" uid="2886645" user="nikicam"/>
+  <node id="3963849241" lat="44.8140516" lon="20.4605474" version="3" timestamp="2019-03-26T19:08:38Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="3963849553" lat="44.8151709" lon="20.4609532" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963849554" lat="44.8150102" lon="20.4615535" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963849555" lat="44.8149174" lon="20.4615042" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963849556" lat="44.8150575" lon="20.4609809" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963864357" lat="44.8151008" lon="20.4610039" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963864358" lat="44.8151214" lon="20.4609269" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963864359" lat="44.8152525" lon="20.4616602" version="2" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3963864360" lat="44.8149496" lon="20.4615992" version="2" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3963864361" lat="44.8149246" lon="20.4618430" version="3" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3963864362" lat="44.8152290" lon="20.4618926" version="3" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3963864363" lat="44.8145801" lon="20.4610132" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963864364" lat="44.8144203" lon="20.4610397" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963864365" lat="44.8144313" lon="20.4613380" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963864366" lat="44.8145911" lon="20.4613225" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam"/>
+  <node id="3963967028" lat="44.8143952" lon="20.4629041" version="2" timestamp="2016-02-01T21:56:29Z" changeset="36947099" uid="2886645" user="nikicam"/>
+  <node id="3963967029" lat="44.8142799" lon="20.4629327" version="1" timestamp="2016-01-24T10:58:10Z" changeset="36773494" uid="2886645" user="nikicam"/>
+  <node id="3963967030" lat="44.8143619" lon="20.4631147" version="2" timestamp="2016-02-01T21:56:29Z" changeset="36947099" uid="2886645" user="nikicam"/>
+  <node id="3963967031" lat="44.8144319" lon="20.4630123" version="1" timestamp="2016-01-24T10:58:10Z" changeset="36773494" uid="2886645" user="nikicam"/>
+  <node id="3963996872" lat="44.8141639" lon="20.4629659" version="1" timestamp="2016-01-24T11:16:13Z" changeset="36773844" uid="2886645" user="nikicam"/>
+  <node id="3963996873" lat="44.8141888" lon="20.4630738" version="2" timestamp="2016-02-01T21:56:29Z" changeset="36947099" uid="2886645" user="nikicam"/>
+  <node id="3963996874" lat="44.8142109" lon="20.4630631" version="1" timestamp="2016-01-24T11:16:13Z" changeset="36773844" uid="2886645" user="nikicam"/>
+  <node id="3963996875" lat="44.8142313" lon="20.4631271" version="1" timestamp="2016-01-24T11:16:13Z" changeset="36773844" uid="2886645" user="nikicam"/>
+  <node id="3963996876" lat="44.8143172" lon="20.4630208" version="2" timestamp="2016-02-01T21:56:29Z" changeset="36947099" uid="2886645" user="nikicam"/>
+  <node id="3963996879" lat="44.8142078" lon="20.4631558" version="1" timestamp="2016-01-24T11:16:13Z" changeset="36773844" uid="2886645" user="nikicam"/>
+  <node id="3963996881" lat="44.8140902" lon="20.4629857" version="1" timestamp="2016-01-24T11:16:13Z" changeset="36773844" uid="2886645" user="nikicam"/>
+  <node id="3963996882" lat="44.8141592" lon="20.4632066" version="1" timestamp="2016-01-24T11:16:13Z" changeset="36773844" uid="2886645" user="nikicam"/>
+  <node id="3964043129" lat="44.8155665" lon="20.4631503" version="2" timestamp="2016-02-01T22:56:21Z" changeset="36948042" uid="2886645" user="nikicam"/>
+  <node id="3964043130" lat="44.8153106" lon="20.4631002" version="3" timestamp="2016-02-07T11:02:33Z" changeset="37057215" uid="2886645" user="nikicam"/>
+  <node id="3964043131" lat="44.8153297" lon="20.4629182" version="1" timestamp="2016-01-24T11:43:16Z" changeset="36774298" uid="2886645" user="nikicam"/>
+  <node id="3964043142" lat="44.8146995" lon="20.4631480" version="3" timestamp="2016-02-17T15:39:23Z" changeset="37269695" uid="2886645" user="nikicam">
+    <tag k="addr:housenumber" v="15"/>
+    <tag k="addr:street" v="Нушићева"/>
+  </node>
+  <node id="3964043143" lat="44.8149680" lon="20.4627145" version="3" timestamp="2016-02-17T15:39:24Z" changeset="37269695" uid="2886645" user="nikicam">
+    <tag k="addr:housenumber" v="3"/>
+    <tag k="addr:street" v="Дечанска"/>
+  </node>
+  <node id="3964812025" lat="44.8161823" lon="20.4569494" version="2" timestamp="2016-01-30T22:08:26Z" changeset="36906878" uid="2886645" user="nikicam"/>
+  <node id="3964812028" lat="44.8161353" lon="20.4570926" version="3" timestamp="2019-05-04T20:03:26Z" changeset="69888562" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3964812029" lat="44.8162165" lon="20.4568363" version="2" timestamp="2016-01-30T22:08:26Z" changeset="36906878" uid="2886645" user="nikicam"/>
+  <node id="3964812032" lat="44.8162668" lon="20.4566477" version="3" timestamp="2016-02-19T14:00:30Z" changeset="37309150" uid="2886645" user="nikicam"/>
+  <node id="3964812039" lat="44.8163257" lon="20.4562848" version="2" timestamp="2019-04-08T17:37:05Z" changeset="69016611" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3964812040" lat="44.8162724" lon="20.4560980" version="2" timestamp="2019-04-08T17:37:06Z" changeset="69016611" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3964812043" lat="44.8162292" lon="20.4559479" version="1" timestamp="2016-01-24T19:50:54Z" changeset="36783179" uid="2886645" user="nikicam"/>
+  <node id="3964812051" lat="44.8161495" lon="20.4557867" version="1" timestamp="2016-01-24T19:50:54Z" changeset="36783179" uid="2886645" user="nikicam"/>
+  <node id="3964869591" lat="44.8185221" lon="20.4559153" version="1" timestamp="2016-01-24T20:39:05Z" changeset="36784064" uid="2886645" user="nikicam"/>
+  <node id="3964869593" lat="44.8189839" lon="20.4558386" version="2" timestamp="2019-09-22T13:45:39Z" changeset="74772319" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3964869598" lat="44.8186501" lon="20.4557006" version="1" timestamp="2016-01-24T20:39:05Z" changeset="36784064" uid="2886645" user="nikicam"/>
+  <node id="3964869599" lat="44.8187394" lon="20.4555437" version="1" timestamp="2016-01-24T20:39:05Z" changeset="36784064" uid="2886645" user="nikicam"/>
+  <node id="3964869602" lat="44.8188852" lon="20.4552941" version="1" timestamp="2016-01-24T20:39:05Z" changeset="36784064" uid="2886645" user="nikicam"/>
+  <node id="3966684325" lat="44.8188536" lon="20.4526059" version="2" timestamp="2018-11-04T16:09:02Z" changeset="64170298" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3966774683" lat="44.8181890" lon="20.4565396" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3966774684" lat="44.8181928" lon="20.4565010" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3966774685" lat="44.8182682" lon="20.4563662" version="1" timestamp="2016-01-25T19:12:27Z" changeset="36803105" uid="2886645" user="nikicam"/>
+  <node id="3966774686" lat="44.8184813" lon="20.4559840" version="1" timestamp="2016-01-25T19:12:27Z" changeset="36803105" uid="2886645" user="nikicam"/>
+  <node id="3966774694" lat="44.8182636" lon="20.4566220" version="3" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="6"/>
+    <tag k="addr:street" v="Вука Караџића"/>
+  </node>
+  <node id="3966809469" lat="44.8185510" lon="20.4571431" version="3" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Вука Караџића"/>
+  </node>
+  <node id="3966809474" lat="44.8178545" lon="20.4571659" version="1" timestamp="2016-01-25T19:32:35Z" changeset="36803476" uid="2886645" user="nikicam"/>
+  <node id="3966809475" lat="44.8179689" lon="20.4573448" version="1" timestamp="2016-01-25T19:32:35Z" changeset="36803476" uid="2886645" user="nikicam"/>
+  <node id="3966809478" lat="44.8177271" lon="20.4576563" version="2" timestamp="2019-10-09T16:49:04Z" changeset="75474717" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3966809480" lat="44.8176399" lon="20.4579907" version="3" timestamp="2019-10-09T16:49:04Z" changeset="75474717" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3966809484" lat="44.8175897" lon="20.4581842" version="1" timestamp="2016-01-25T19:32:35Z" changeset="36803476" uid="2886645" user="nikicam"/>
+  <node id="3966851740" lat="44.8163425" lon="20.4563524" version="3" timestamp="2019-04-08T17:37:07Z" changeset="69016611" uid="6225925" user="Aleksa Marinski"/>
+  <node id="3966851741" lat="44.8163357" lon="20.4563248" version="3" timestamp="2019-04-08T17:37:07Z" changeset="69016611" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Топличин венац"/>
+  </node>
+  <node id="3966888336" lat="44.8170210" lon="20.4593354" version="2" timestamp="2016-08-20T15:56:00Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="3966888337" lat="44.8168799" lon="20.4591116" version="2" timestamp="2016-08-20T15:56:00Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="3966888338" lat="44.8170169" lon="20.4589399" version="2" timestamp="2016-08-20T15:56:00Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="3966888339" lat="44.8171580" lon="20.4591635" version="2" timestamp="2016-08-20T15:56:00Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="3966888340" lat="44.8173025" lon="20.4594024" version="3" timestamp="2019-08-20T14:55:10Z" changeset="73544468" uid="733709" user="dizajnmario"/>
+  <node id="3966888341" lat="44.8171661" lon="20.4595695" version="3" timestamp="2019-08-20T14:55:10Z" changeset="73544468" uid="733709" user="dizajnmario"/>
+  <node id="3966888345" lat="44.8156848" lon="20.4603490" version="2" timestamp="2019-08-20T11:53:13Z" changeset="73535677" uid="733709" user="dizajnmario">
+    <tag k="addr:housenumber" v="2"/>
+    <tag k="addr:street" v="Коларчева"/>
+  </node>
+  <node id="3966888346" lat="44.8152415" lon="20.4598460" version="4" timestamp="2020-09-11T16:38:23Z" changeset="90769023" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="4"/>
+    <tag k="addr:street" v="Кнеза Михаила"/>
+  </node>
+  <node id="3966888347" lat="44.8152494" lon="20.4602978" version="3" timestamp="2016-08-20T15:55:58Z" changeset="41578473" uid="168004" user="Nikola Smolenski">
+    <tag k="addr:housenumber" v="8"/>
+    <tag k="addr:street" v="Коларчева"/>
+  </node>
+  <node id="3966888348" lat="44.8147800" lon="20.4597527" version="1" timestamp="2016-01-25T20:43:37Z" changeset="36804760" uid="2886645" user="nikicam"/>
+  <node id="3966915788" lat="44.8145588" lon="20.4596635" version="2" timestamp="2016-02-12T09:23:41Z" changeset="37163693" uid="2886645" user="nikicam">
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Сремска"/>
+  </node>
+  <node id="3974463431" lat="44.8158425" lon="20.4620552" version="4" timestamp="2019-08-18T10:39:12Z" changeset="73460704" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="7"/>
+    <tag k="addr:street" v="Македонска"/>
+  </node>
+  <node id="3974463432" lat="44.8158614" lon="20.4618602" version="4" timestamp="2019-08-18T10:39:13Z" changeset="73460704" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="3"/>
+    <tag k="addr:street" v="Македонска"/>
+  </node>
+  <node id="3974463433" lat="44.8159323" lon="20.4616573" version="3" timestamp="2019-04-17T11:53:26Z" changeset="69306269" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Македонска"/>
+  </node>
+  <node id="3976968084" lat="44.8150426" lon="20.4578555" version="1" timestamp="2016-01-29T21:49:20Z" changeset="36888702" uid="2886645" user="nikicam"/>
+  <node id="3976968085" lat="44.8151783" lon="20.4576571" version="1" timestamp="2016-01-29T21:49:20Z" changeset="36888702" uid="2886645" user="nikicam"/>
+  <node id="3976968088" lat="44.8149283" lon="20.4580134" version="1" timestamp="2016-01-29T21:49:20Z" changeset="36888702" uid="2886645" user="nikicam"/>
+  <node id="3976968090" lat="44.8147823" lon="20.4582117" version="1" timestamp="2016-01-29T21:49:20Z" changeset="36888702" uid="2886645" user="nikicam"/>
+  <node id="3976968093" lat="44.8148600" lon="20.4581064" version="1" timestamp="2016-01-29T21:49:20Z" changeset="36888702" uid="2886645" user="nikicam"/>
+  <node id="3976968100" lat="44.8153250" lon="20.4573736" version="1" timestamp="2016-01-29T21:49:20Z" changeset="36888702" uid="2886645" user="nikicam"/>
+  <node id="3976968255" lat="44.8152297" lon="20.4575645" version="1" timestamp="2016-01-29T21:51:03Z" changeset="36888735" uid="2886645" user="nikicam"/>
+  <node id="4002208526" lat="44.8141747" lon="20.4600645" version="2" timestamp="2016-11-21T20:59:20Z" changeset="43856775" uid="168004" user="Nikola Smolenski"/>
+  <node id="4002208527" lat="44.8153722" lon="20.4603629" version="2" timestamp="2016-08-20T15:55:58Z" changeset="41578473" uid="168004" user="Nikola Smolenski">
+    <tag k="addr:housenumber" v="6"/>
+    <tag k="addr:street" v="Коларчева"/>
+  </node>
+  <node id="4014618798" lat="44.8182252" lon="20.4564424" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="38"/>
+    <tag k="addr:street" v="Вука Караџића"/>
+  </node>
+  <node id="4176309405" lat="44.8161738" lon="20.4557997" version="2" timestamp="2017-08-26T16:25:05Z" changeset="51462692" uid="6225925" user="Aleksa Marinski"/>
+  <node id="4192047810" lat="44.8152424" lon="20.4605929" version="1" timestamp="2016-05-17T17:19:30Z" changeset="39382443" uid="3974218" user="Authentic Belgrade Centre Hostel">
+    <tag k="name" v="Authentic Belgrade Centre Hostel"/>
+    <tag k="tourism" v="hostel"/>
+  </node>
+  <node id="4359064371" lat="44.8156332" lon="20.4604163" version="1" timestamp="2016-08-20T15:55:54Z" changeset="41578473" uid="168004" user="Nikola Smolenski"/>
+  <node id="4359064376" lat="44.8158948" lon="20.4610313" version="7" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4424764644" lat="44.8154365" lon="20.4622099" version="2" timestamp="2020-03-13T08:24:20Z" changeset="82151357" uid="875800" user="Komadinovic Vanja">
+    <tag k="amenity" v="atm"/>
+    <tag k="brand" v="Sberbank"/>
+    <tag k="brand:wikidata" v="Q205012"/>
+    <tag k="name" v="Sberbank"/>
+    <tag k="name:sr-Latn" v="Sberbank"/>
+    <tag k="website" v="https://www.sberbank.rs/"/>
+  </node>
+  <node id="4461639868" lat="44.8153299" lon="20.4598523" version="1" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="4461639870" lat="44.8150286" lon="20.4601810" version="1" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="4461639871" lat="44.8150173" lon="20.4600474" version="1" timestamp="2016-10-24T11:37:32Z" changeset="43120542" uid="182327" user="Милан Јелисавчић"/>
+  <node id="4709053332" lat="44.8177542" lon="20.4584427" version="1" timestamp="2017-02-27T22:59:08Z" changeset="46454024" uid="3582297" user="sivanovic"/>
+  <node id="4709053333" lat="44.8178733" lon="20.4586459" version="1" timestamp="2017-02-27T22:59:08Z" changeset="46454024" uid="3582297" user="sivanovic"/>
+  <node id="4709053334" lat="44.8176283" lon="20.4585859" version="1" timestamp="2017-02-27T22:59:08Z" changeset="46454024" uid="3582297" user="sivanovic"/>
+  <node id="4709053335" lat="44.8176730" lon="20.4586541" version="1" timestamp="2017-02-27T22:59:08Z" changeset="46454024" uid="3582297" user="sivanovic"/>
+  <node id="4709053336" lat="44.8177688" lon="20.4588032" version="1" timestamp="2017-02-27T22:59:08Z" changeset="46454024" uid="3582297" user="sivanovic"/>
+  <node id="4785337757" lat="44.8134744" lon="20.4605155" version="3" timestamp="2021-02-20T06:14:14Z" changeset="99626882" uid="7009309" user="Mengesh">
+    <tag k="button_operated" v="no"/>
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="crossing:island" v="no"/>
+    <tag k="crossing_ref" v="zebra"/>
+    <tag k="highway" v="crossing"/>
+    <tag k="tactile_paving" v="no"/>
+  </node>
+  <node id="4785337759" lat="44.8138462" lon="20.4603833" version="1" timestamp="2017-04-10T01:49:51Z" changeset="47607436" uid="3350518" user="sve_je_uzalud"/>
+  <node id="4785337760" lat="44.8141933" lon="20.4603100" version="2" timestamp="2017-10-21T11:16:46Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="4785337761" lat="44.8146857" lon="20.4600344" version="1" timestamp="2017-04-10T01:49:51Z" changeset="47607436" uid="3350518" user="sve_je_uzalud"/>
+  <node id="4896022021" lat="44.8150302" lon="20.4606858" version="1" timestamp="2017-06-04T21:12:47Z" changeset="49251901" uid="6122880" user="Electr0">
+    <tag k="email" v="info@downtowncentralhostel.com"/>
+    <tag k="internet_access" v="wlan"/>
+    <tag k="name:en" v="Downtown Central Hostel"/>
+    <tag k="opening_hours" v="24/7"/>
+    <tag k="phone" v="+381 11 4073861"/>
+    <tag k="tourism" v="hostel"/>
+    <tag k="website" v="http://downtowncentralhostel.com"/>
+  </node>
+  <node id="4938882589" lat="44.7937366" lon="20.4529733" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882599" lat="44.7943180" lon="20.4533722" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882600" lat="44.7948966" lon="20.4543063" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882601" lat="44.7955595" lon="20.4562041" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882602" lat="44.7967273" lon="20.4587542" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882603" lat="44.8022084" lon="20.4655002" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882604" lat="44.8030816" lon="20.4658856" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882605" lat="44.8038390" lon="20.4656781" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882606" lat="44.8087789" lon="20.4629802" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882607" lat="44.8107427" lon="20.4618859" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882608" lat="44.8144113" lon="20.4607486" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882609" lat="44.8153399" lon="20.4608774" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="4938882610" lat="44.8162942" lon="20.4610590" version="3" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938890548" lat="44.8051147" lon="20.4774963" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893389" lat="44.8052066" lon="20.4772539" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893390" lat="44.8052619" lon="20.4766098" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893391" lat="44.8054572" lon="20.4759468" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893392" lat="44.8062943" lon="20.4738344" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893393" lat="44.8074514" lon="20.4713409" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893394" lat="44.8091543" lon="20.4685924" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893395" lat="44.8103994" lon="20.4665988" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893396" lat="44.8112642" lon="20.4653080" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893397" lat="44.8125444" lon="20.4636927" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893398" lat="44.8148689" lon="20.4628476" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893399" lat="44.8151358" lon="20.4626917" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938893400" lat="44.8155284" lon="20.4621637" version="2" timestamp="2019-09-17T08:28:26Z" changeset="74564683" uid="7436199" user="aleksaJov"/>
+  <node id="4938899494" lat="44.8166616" lon="20.4613259" version="2" timestamp="2017-10-21T11:16:48Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="4995950024" lat="44.8142752" lon="20.4600915" version="1" timestamp="2017-07-27T04:01:42Z" changeset="50606751" uid="6374692" user="rosenkra">
+    <tag k="name" v="Deloitte"/>
+    <tag k="name:en" v="Deloitte"/>
+    <tag k="name:sr" v="Deloitte"/>
+    <tag k="office" v="lawyer"/>
+  </node>
+  <node id="4995950025" lat="44.8152075" lon="20.4602559" version="2" timestamp="2018-11-14T14:05:53Z" changeset="64484989" uid="6877782" user="GrumpyJohn">
+    <tag k="amenity" v="fast_food"/>
+    <tag k="name:en" v="Domino Pizza"/>
+  </node>
+  <node id="4995950026" lat="44.8150569" lon="20.4601590" version="2" timestamp="2017-08-16T18:45:40Z" changeset="51183686" uid="6225925" user="Aleksa Marinski">
+    <tag k="name" v="МаксМара"/>
+    <tag k="name:en" v="MaxMara"/>
+    <tag k="shop" v="clothes"/>
+  </node>
+  <node id="4995950030" lat="44.8153034" lon="20.4603021" version="6" timestamp="2019-11-25T09:01:07Z" changeset="77509659" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="6-8"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="name" v="Скроз добра пекара"/>
+    <tag k="name:sr" v="Скроз добра пекара"/>
+    <tag k="name:sr-Latn" v="Skroz dobra pekara"/>
+    <tag k="shop" v="bakery"/>
+  </node>
+  <node id="5009467621" lat="44.8155534" lon="20.4611283" version="2" timestamp="2018-06-19T11:00:26Z" changeset="59974188" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="4"/>
+    <tag k="addr:postcode" v="11103"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="amenity" v="bar"/>
+    <tag k="internet_access" v="wlan"/>
+    <tag k="name:en" v="Wurst platz bar"/>
+    <tag k="opening_hours" v="Mo-Sa 08:00-03:00; Su 08:00-00:00"/>
+    <tag k="phone" v="062262212"/>
+  </node>
+  <node id="5024979830" lat="44.8155473" lon="20.4624596" version="4" timestamp="2019-03-26T19:08:38Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5024979831" lat="44.8153150" lon="20.4625486" version="1" timestamp="2017-08-09T19:06:45Z" changeset="50981474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5024979832" lat="44.8156120" lon="20.4626017" version="1" timestamp="2017-08-09T19:06:45Z" changeset="50981474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028769613" lat="44.8191798" lon="20.4531720" version="1" timestamp="2017-08-11T13:48:26Z" changeset="51035051" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028769614" lat="44.8192721" lon="20.4533214" version="1" timestamp="2017-08-11T13:48:26Z" changeset="51035051" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028769615" lat="44.8193662" lon="20.4534664" version="1" timestamp="2017-08-11T13:48:26Z" changeset="51035051" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028769617" lat="44.8194543" lon="20.4535957" version="2" timestamp="2017-08-27T18:06:22Z" changeset="51488666" uid="5569366" user="TXBG"/>
+  <node id="5028769620" lat="44.8196056" lon="20.4537996" version="1" timestamp="2017-08-11T13:48:26Z" changeset="51035051" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771231" lat="44.8194440" lon="20.4544860" version="2" timestamp="2019-03-05T22:43:10Z" changeset="67824357" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771246" lat="44.8187740" lon="20.4561952" version="1" timestamp="2017-08-11T13:48:26Z" changeset="51035051" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771247" lat="44.8186819" lon="20.4562049" version="1" timestamp="2017-08-11T13:48:26Z" changeset="51035051" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771248" lat="44.8187774" lon="20.4563110" version="1" timestamp="2017-08-11T13:48:26Z" changeset="51035051" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771249" lat="44.8188464" lon="20.4562481" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771250" lat="44.8190742" lon="20.4565077" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771251" lat="44.8191878" lon="20.4568135" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771252" lat="44.8192480" lon="20.4567182" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771253" lat="44.8191264" lon="20.4565728" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771254" lat="44.8183431" lon="20.4567091" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771257" lat="44.8182489" lon="20.4567943" version="1" timestamp="2017-08-11T13:48:26Z" changeset="51035051" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="3"/>
+    <tag k="addr:street" v="Вука Караџића"/>
+  </node>
+  <node id="5028771258" lat="44.8184650" lon="20.4568458" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771259" lat="44.8183575" lon="20.4569185" version="1" timestamp="2017-08-11T13:48:27Z" changeset="51035051" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771260" lat="44.8186349" lon="20.4570377" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771261" lat="44.8187864" lon="20.4574122" version="2" timestamp="2018-03-20T20:03:27Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5028771262" lat="44.8188558" lon="20.4573072" version="1" timestamp="2017-08-11T13:48:27Z" changeset="51035051" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5060514013" lat="44.8196420" lon="20.4539793" version="1" timestamp="2017-08-26T16:25:02Z" changeset="51462692" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5060514015" lat="44.8199321" lon="20.4535244" version="1" timestamp="2017-08-26T16:25:02Z" changeset="51462692" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5060514020" lat="44.8200461" lon="20.4537012" version="1" timestamp="2017-08-26T16:25:02Z" changeset="51462692" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5062600382" lat="44.8188881" lon="20.4527136" version="2" timestamp="2019-05-11T22:09:26Z" changeset="70148234" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5062600383" lat="44.8189287" lon="20.4527813" version="1" timestamp="2017-08-27T18:06:21Z" changeset="51488666" uid="5569366" user="TXBG">
+    <tag k="addr:housenumber" v="22"/>
+    <tag k="addr:street" v="Рајићева"/>
+  </node>
+  <node id="5062600384" lat="44.8190039" lon="20.4529032" version="1" timestamp="2017-08-27T18:06:21Z" changeset="51488666" uid="5569366" user="TXBG">
+    <tag k="addr:housenumber" v="20"/>
+    <tag k="addr:street" v="Рајићева"/>
+  </node>
+  <node id="5062600385" lat="44.8190683" lon="20.4530060" version="1" timestamp="2017-08-27T18:06:21Z" changeset="51488666" uid="5569366" user="TXBG"/>
+  <node id="5077391384" lat="44.8028325" lon="20.4665981" version="1" timestamp="2017-09-03T16:46:51Z" changeset="51697215" uid="5569366" user="TXBG"/>
+  <node id="5077708883" lat="44.8198972" lon="20.4539139" version="2" timestamp="2018-05-20T14:12:56Z" changeset="59124016" uid="6225925" user="Aleksa Marinski">
+    <tag k="entrance" v="main"/>
+  </node>
+  <node id="5095890353" lat="44.8183084" lon="20.4529941" version="1" timestamp="2017-09-10T19:30:07Z" changeset="51917920" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5095890354" lat="44.8183915" lon="20.4529947" version="1" timestamp="2017-09-10T19:30:07Z" changeset="51917920" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5095890355" lat="44.8183918" lon="20.4530292" version="1" timestamp="2017-09-10T19:30:07Z" changeset="51917920" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5095890356" lat="44.8185186" lon="20.4530290" version="1" timestamp="2017-09-10T19:30:07Z" changeset="51917920" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5095890357" lat="44.8185186" lon="20.4529928" version="1" timestamp="2017-09-10T19:30:07Z" changeset="51917920" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5095890358" lat="44.8185983" lon="20.4529939" version="1" timestamp="2017-09-10T19:30:07Z" changeset="51917920" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5095890379" lat="44.8176046" lon="20.4545208" version="2" timestamp="2018-05-23T17:01:35Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5105387142" lat="44.8184139" lon="20.4533897" version="2" timestamp="2018-05-28T02:06:14Z" changeset="59325727" uid="5569366" user="TXBG"/>
+  <node id="5105387147" lat="44.8182630" lon="20.4542413" version="2" timestamp="2019-03-11T21:19:17Z" changeset="68038844" uid="8600365" user="spuddy93"/>
+  <node id="5105387156" lat="44.8187594" lon="20.4527447" version="1" timestamp="2017-09-14T13:55:23Z" changeset="52038495" uid="5569366" user="TXBG"/>
+  <node id="5105387159" lat="44.8198926" lon="20.4533540" version="2" timestamp="2017-10-22T14:20:56Z" changeset="53152989" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5105387162" lat="44.8199138" lon="20.4533249" version="2" timestamp="2017-10-15T22:39:36Z" changeset="52968251" uid="2065166" user="suff"/>
+  <node id="5111771470" lat="44.8181875" lon="20.4543152" version="1" timestamp="2017-09-17T21:06:29Z" changeset="52127588" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5111771478" lat="44.8182953" lon="20.4542595" version="2" timestamp="2019-03-11T21:19:17Z" changeset="68038844" uid="8600365" user="spuddy93"/>
+  <node id="5111771480" lat="44.8184361" lon="20.4541655" version="1" timestamp="2017-09-17T21:06:29Z" changeset="52127588" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5111771482" lat="44.8186971" lon="20.4538857" version="2" timestamp="2019-03-11T21:19:17Z" changeset="68038844" uid="8600365" user="spuddy93"/>
+  <node id="5111771486" lat="44.8187015" lon="20.4538088" version="2" timestamp="2019-03-11T21:19:17Z" changeset="68038844" uid="8600365" user="spuddy93"/>
+  <node id="5115562451" lat="44.8142439" lon="20.4626236" version="1" timestamp="2017-09-19T15:43:05Z" changeset="52184464" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5133996568" lat="44.8155934" lon="20.4625253" version="4" timestamp="2019-03-26T19:08:38Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5133996592" lat="44.8183508" lon="20.4533003" version="4" timestamp="2019-02-05T21:59:11Z" changeset="66945960" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5153992282" lat="44.8195095" lon="20.4545687" version="1" timestamp="2017-10-07T18:17:57Z" changeset="52714484" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5153992299" lat="44.8194570" lon="20.4546565" version="1" timestamp="2017-10-07T18:17:57Z" changeset="52714484" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5153992301" lat="44.8194157" lon="20.4547244" version="2" timestamp="2019-03-05T22:43:11Z" changeset="67824357" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751130" lat="44.8144015" lon="20.4587448" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751131" lat="44.8142821" lon="20.4589353" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751134" lat="44.8142326" lon="20.4589322" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751135" lat="44.8142670" lon="20.4595111" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751140" lat="44.8143572" lon="20.4595039" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751142" lat="44.8144363" lon="20.4595394" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751145" lat="44.8144815" lon="20.4595976" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751146" lat="44.8145779" lon="20.4596797" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751147" lat="44.8146273" lon="20.4597621" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751148" lat="44.8146464" lon="20.4597479" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751149" lat="44.8147212" lon="20.4598810" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751165" lat="44.8150323" lon="20.4601138" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751166" lat="44.8150291" lon="20.4602026" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751167" lat="44.8145780" lon="20.4600544" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751168" lat="44.8146609" lon="20.4600025" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751169" lat="44.8147151" lon="20.4599598" version="1" timestamp="2017-10-09T10:09:32Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5156751170" lat="44.8147299" lon="20.4599220" version="1" timestamp="2017-10-09T10:09:33Z" changeset="52754474" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5170025144" lat="44.8146354" lon="20.4630296" version="2" timestamp="2017-10-19T21:26:46Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170804" lat="44.8141987" lon="20.4626689" version="2" timestamp="2018-11-10T14:05:08Z" changeset="64351730" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5177170805" lat="44.8141024" lon="20.4627360" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170806" lat="44.8132480" lon="20.4630590" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170807" lat="44.8154495" lon="20.4623698" version="4" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="5177170809" lat="44.8132806" lon="20.4632259" version="2" timestamp="2020-08-21T16:48:52Z" changeset="89756372" uid="427807" user="Tungmar"/>
+  <node id="5177170811" lat="44.8139082" lon="20.4629799" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170812" lat="44.8142139" lon="20.4628762" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170813" lat="44.8142933" lon="20.4628518" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170814" lat="44.8143437" lon="20.4628396" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170815" lat="44.8143827" lon="20.4628396" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170816" lat="44.8144086" lon="20.4628640" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170818" lat="44.8147011" lon="20.4628514" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170819" lat="44.8148060" lon="20.4627667" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170820" lat="44.8149634" lon="20.4626619" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170821" lat="44.8150771" lon="20.4625972" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170822" lat="44.8151719" lon="20.4625521" version="2" timestamp="2020-12-01T13:44:09Z" changeset="95097857" uid="733709" user="dizajnmario"/>
+  <node id="5177170823" lat="44.8153066" lon="20.4624940" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170824" lat="44.8155382" lon="20.4624046" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170825" lat="44.8155978" lon="20.4623855" version="2" timestamp="2019-03-26T19:08:38Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5177170826" lat="44.8151311" lon="20.4625489" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170827" lat="44.8151444" lon="20.4625622" version="2" timestamp="2020-12-01T13:44:09Z" changeset="95097857" uid="733709" user="dizajnmario"/>
+  <node id="5177170828" lat="44.8151392" lon="20.4625552" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170829" lat="44.8151231" lon="20.4625469" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170830" lat="44.8156125" lon="20.4621768" version="3" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5177170831" lat="44.8156168" lon="20.4623098" version="5" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="5177170833" lat="44.8157850" lon="20.4624477" version="2" timestamp="2019-03-26T19:08:39Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5177170834" lat="44.8157111" lon="20.4624439" version="6" timestamp="2021-03-23T12:52:44Z" changeset="101575695" uid="733709" user="dizajnmario">
+    <tag k="button_operated" v="yes"/>
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="crossing:island" v="no"/>
+    <tag k="crossing_ref" v="zebra"/>
+    <tag k="highway" v="crossing"/>
+    <tag k="traffic_signals:arrow" v="yes"/>
+    <tag k="traffic_signals:minimap" v="yes"/>
+    <tag k="traffic_signals:sound" v="yes"/>
+    <tag k="traffic_signals:vibration" v="yes"/>
+  </node>
+  <node id="5177170835" lat="44.8156211" lon="20.4624503" version="2" timestamp="2019-03-26T19:08:39Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5177170836" lat="44.8156448" lon="20.4624000" version="2" timestamp="2019-03-26T19:08:39Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5177170837" lat="44.8158469" lon="20.4621730" version="4" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5177170838" lat="44.8158361" lon="20.4623136" version="6" timestamp="2021-03-23T12:52:44Z" changeset="101575695" uid="733709" user="dizajnmario">
+    <tag k="button_operated" v="yes"/>
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="crossing:island" v="no"/>
+    <tag k="crossing_ref" v="zebra"/>
+    <tag k="highway" v="crossing"/>
+    <tag k="traffic_signals:arrow" v="yes"/>
+    <tag k="traffic_signals:minimap" v="yes"/>
+    <tag k="traffic_signals:sound" v="yes"/>
+    <tag k="traffic_signals:vibration" v="yes"/>
+  </node>
+  <node id="5177170839" lat="44.8158302" lon="20.4623890" version="3" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5177170840" lat="44.8158136" lon="20.4623929" version="3" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5177170841" lat="44.8157936" lon="20.4624164" version="2" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="5177170842" lat="44.8152605" lon="20.4622935" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170843" lat="44.8148893" lon="20.4624008" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170844" lat="44.8147584" lon="20.4624288" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170845" lat="44.8147236" lon="20.4624241" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170846" lat="44.8146839" lon="20.4624101" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5177170847" lat="44.8145760" lon="20.4625246" version="3" timestamp="2019-03-26T19:08:39Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5177170848" lat="44.8146093" lon="20.4624213" version="1" timestamp="2017-10-19T21:26:45Z" changeset="53082796" uid="2065166" user="suff"/>
+  <node id="5179720376" lat="44.8157702" lon="20.4605810" version="4" timestamp="2019-04-04T09:20:00Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179720379" lat="44.8141432" lon="20.4603973" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720380" lat="44.8144197" lon="20.4602710" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720381" lat="44.8151549" lon="20.4603843" version="3" timestamp="2019-03-26T19:08:39Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5179720382" lat="44.8142099" lon="20.4604736" version="2" timestamp="2019-03-26T19:08:39Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5179720383" lat="44.8149757" lon="20.4605150" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720384" lat="44.8136250" lon="20.4609191" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720385" lat="44.8137900" lon="20.4608272" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720386" lat="44.8139765" lon="20.4607038" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720387" lat="44.8142087" lon="20.4605697" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720388" lat="44.8143685" lon="20.4604838" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720389" lat="44.8145264" lon="20.4604114" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720390" lat="44.8146292" lon="20.4603819" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720391" lat="44.8147374" lon="20.4603739" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720392" lat="44.8148822" lon="20.4603900" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720393" lat="44.8151638" lon="20.4604785" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720396" lat="44.8157087" lon="20.4607578" version="2" timestamp="2019-08-22T13:18:25Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179720399" lat="44.8136618" lon="20.4608986" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720400" lat="44.8150790" lon="20.4605368" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720401" lat="44.8151117" lon="20.4604997" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720402" lat="44.8151277" lon="20.4604645" version="1" timestamp="2017-10-21T11:16:36Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179720403" lat="44.8150497" lon="20.4602701" version="2" timestamp="2018-08-22T09:49:33Z" changeset="61882092" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179720404" lat="44.8151722" lon="20.4603214" version="2" timestamp="2018-08-22T09:49:33Z" changeset="61882092" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179720405" lat="44.8152919" lon="20.4603731" version="2" timestamp="2018-08-22T09:49:33Z" changeset="61882092" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179720413" lat="44.8160615" lon="20.4609167" version="4" timestamp="2019-04-04T09:20:00Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179720419" lat="44.8159378" lon="20.4614326" version="2" timestamp="2019-05-26T14:49:49Z" changeset="70634423" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179720420" lat="44.8158837" lon="20.4615472" version="2" timestamp="2019-08-30T23:31:36Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724921" lat="44.8158631" lon="20.4616262" version="2" timestamp="2019-08-30T23:31:37Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724924" lat="44.8158194" lon="20.4621168" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724925" lat="44.8158224" lon="20.4621584" version="3" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724926" lat="44.8159055" lon="20.4614892" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724927" lat="44.8157357" lon="20.4608068" version="3" timestamp="2019-06-04T21:51:18Z" changeset="70939054" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724928" lat="44.8157522" lon="20.4608637" version="2" timestamp="2019-06-04T21:51:19Z" changeset="70939054" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724929" lat="44.8157590" lon="20.4609522" version="2" timestamp="2019-06-04T21:51:19Z" changeset="70939054" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724936" lat="44.8156771" lon="20.4621172" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724937" lat="44.8156652" lon="20.4621472" version="2" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724944" lat="44.8163672" lon="20.4608874" version="2" timestamp="2019-08-22T13:18:25Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724945" lat="44.8164065" lon="20.4608508" version="2" timestamp="2019-08-22T13:18:25Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724946" lat="44.8164358" lon="20.4608329" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724947" lat="44.8164769" lon="20.4608360" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724948" lat="44.8164887" lon="20.4608407" version="2" timestamp="2019-08-22T13:18:26Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724949" lat="44.8165195" lon="20.4608668" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724950" lat="44.8165476" lon="20.4609140" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724951" lat="44.8164526" lon="20.4608300" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724953" lat="44.8161820" lon="20.4611234" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724962" lat="44.8166786" lon="20.4614334" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724963" lat="44.8165933" lon="20.4610037" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724964" lat="44.8166331" lon="20.4611018" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724965" lat="44.8166613" lon="20.4611812" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724966" lat="44.8166811" lon="20.4612606" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724967" lat="44.8166861" lon="20.4613213" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724968" lat="44.8166204" lon="20.4622254" version="1" timestamp="2017-10-21T11:16:37Z" changeset="53125364" uid="2065166" user="suff"/>
+  <node id="5179724969" lat="44.8166675" lon="20.4615745" version="2" timestamp="2019-08-30T23:31:37Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5179724976" lat="44.8166219" lon="20.4621977" version="2" timestamp="2019-03-26T19:08:39Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5179725005" lat="44.8165261" lon="20.4622212" version="2" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="5179985232" lat="44.8160719" lon="20.4623939" version="2" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="5195043687" lat="44.8159705" lon="20.4608590" version="4" timestamp="2019-04-04T09:20:00Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5198571366" lat="44.7946510" lon="20.4539098" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="5220315680" lat="44.8155957" lon="20.4624932" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5220315682" lat="44.8155669" lon="20.4624521" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5289996158" lat="44.8142890" lon="20.4625884" version="2" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario"/>
+  <node id="5289996159" lat="44.8142802" lon="20.4625674" version="2" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario"/>
+  <node id="5289996160" lat="44.8142389" lon="20.4624615" version="2" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario"/>
+  <node id="5289996161" lat="44.8142385" lon="20.4624689" version="2" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario"/>
+  <node id="5289996162" lat="44.8143121" lon="20.4626447" version="1" timestamp="2017-12-17T16:19:23Z" changeset="54707084" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5303620707" lat="44.8165043" lon="20.4609166" version="1" timestamp="2017-12-25T19:45:58Z" changeset="54914490" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5303620708" lat="44.8164503" lon="20.4609016" version="1" timestamp="2017-12-25T19:45:58Z" changeset="54914490" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5312456220" lat="44.8157619" lon="20.4624777" version="1" timestamp="2017-12-30T19:23:23Z" changeset="55042946" uid="6225925" user="Aleksa Marinski">
+    <tag k="information" v="board"/>
+    <tag k="tourism" v="information"/>
+  </node>
+  <node id="5312459621" lat="44.8156767" lon="20.4624718" version="1" timestamp="2017-12-30T19:23:23Z" changeset="55042946" uid="6225925" user="Aleksa Marinski">
+    <tag k="information" v="board"/>
+    <tag k="tourism" v="information"/>
+  </node>
+  <node id="5312459622" lat="44.8156917" lon="20.4621374" version="1" timestamp="2017-12-30T19:23:23Z" changeset="55042946" uid="6225925" user="Aleksa Marinski">
+    <tag k="information" v="board"/>
+    <tag k="tourism" v="information"/>
+  </node>
+  <node id="5352677732" lat="44.8165350" lon="20.4555425" version="1" timestamp="2018-01-21T14:13:54Z" changeset="55628891" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5377749945" lat="44.8182659" lon="20.4530547" version="6" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="5377749946" lat="44.8188927" lon="20.4526422" version="3" timestamp="2019-08-31T14:05:37Z" changeset="73950388" uid="6225925" user="Aleksa Marinski">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="5465460771" lat="44.8152484" lon="20.4604246" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5487265735" lat="44.8160284" lon="20.4615899" version="1" timestamp="2018-03-18T21:12:47Z" changeset="57301186" uid="3124436" user="Mali Taus">
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="amenity" v="school"/>
+    <tag k="name:en" v="Tambao Salsa School"/>
+    <tag k="phone" v="+381668488000"/>
+    <tag k="website" v="http://timbaocubano.com"/>
+  </node>
+  <node id="5492010675" lat="44.8190712" lon="20.4566449" version="1" timestamp="2018-03-20T20:03:26Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5492010676" lat="44.8186735" lon="20.4572698" version="1" timestamp="2018-03-20T20:03:26Z" changeset="57364118" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5501138347" lat="44.8142765" lon="20.4620603" version="1" timestamp="2018-03-24T12:30:31Z" changeset="57483900" uid="5569366" user="TXBG">
+    <tag k="addr:housenumber" v="8a"/>
+    <tag k="addr:street" v="Дечанска"/>
+  </node>
+  <node id="5501138348" lat="44.8140429" lon="20.4616511" version="1" timestamp="2018-03-24T12:30:31Z" changeset="57483900" uid="5569366" user="TXBG"/>
+  <node id="5638025290" lat="44.8178152" lon="20.4545627" version="1" timestamp="2018-05-23T17:01:34Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5638025303" lat="44.8176637" lon="20.4546257" version="1" timestamp="2018-05-23T17:01:35Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5638025315" lat="44.8181127" lon="20.4538276" version="1" timestamp="2018-05-23T17:01:35Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5638025320" lat="44.8181056" lon="20.4540612" version="1" timestamp="2018-05-23T17:01:35Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5638026321" lat="44.8181436" lon="20.4541800" version="1" timestamp="2018-05-23T17:01:35Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5638026325" lat="44.8180568" lon="20.4539207" version="1" timestamp="2018-05-23T17:01:35Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5638026329" lat="44.8179026" lon="20.4545040" version="1" timestamp="2018-05-23T17:01:35Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5638026331" lat="44.8180829" lon="20.4543839" version="1" timestamp="2018-05-23T17:01:35Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5638026338" lat="44.8171571" lon="20.4551121" version="1" timestamp="2018-05-23T17:01:35Z" changeset="59217941" uid="5569366" user="TXBG"/>
+  <node id="5646679895" lat="44.8182221" lon="20.4531171" version="2" timestamp="2019-02-05T21:59:11Z" changeset="66945960" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5702072554" lat="44.8157120" lon="20.4609438" version="2" timestamp="2019-09-27T18:54:42Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5702072555" lat="44.8156474" lon="20.4608023" version="2" timestamp="2019-09-27T18:54:43Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5709691985" lat="44.8181973" lon="20.4540605" version="2" timestamp="2019-08-20T11:53:13Z" changeset="73535677" uid="733709" user="dizajnmario">
+    <tag k="addr:housenumber" v="4"/>
+    <tag k="addr:street" v="Николе Спасића"/>
+  </node>
+  <node id="5761790605" lat="44.8176821" lon="20.4570523" version="1" timestamp="2018-07-15T14:29:13Z" changeset="60733367" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5761790614" lat="44.8154802" lon="20.4595305" version="2" timestamp="2018-11-18T22:21:48Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5764020731" lat="44.8160886" lon="20.4571980" version="2" timestamp="2019-05-04T20:03:38Z" changeset="69888562" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5832766080" lat="44.8165808" lon="20.4599012" version="1" timestamp="2018-08-14T17:50:04Z" changeset="61665456" uid="6225925" user="Aleksa Marinski">
+    <tag k="entrance" v="exit"/>
+  </node>
+  <node id="5850035178" lat="44.8161769" lon="20.4609953" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850035179" lat="44.8161988" lon="20.4609733" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850035181" lat="44.8158237" lon="20.4615191" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850035182" lat="44.8158505" lon="20.4614633" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850035183" lat="44.8158922" lon="20.4614056" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036492" lat="44.8162023" lon="20.4610142" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036493" lat="44.8161557" lon="20.4610132" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036494" lat="44.8160900" lon="20.4610401" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036495" lat="44.8160589" lon="20.4610411" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036496" lat="44.8160179" lon="20.4610331" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036497" lat="44.8159748" lon="20.4610142" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036498" lat="44.8159395" lon="20.4609923" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036499" lat="44.8158978" lon="20.4609484" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036500" lat="44.8158597" lon="20.4608907" version="1" timestamp="2018-08-22T23:37:29Z" changeset="61904807" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036513" lat="44.8161506" lon="20.4610245" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="5850036514" lat="44.8158073" lon="20.4609119" version="3" timestamp="2019-08-22T13:18:28Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036515" lat="44.8157643" lon="20.4615366" version="2" timestamp="2019-06-04T21:51:20Z" changeset="70939054" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036516" lat="44.8157878" lon="20.4616184" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5850036517" lat="44.8158054" lon="20.4610203" version="3" timestamp="2019-08-22T13:18:28Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036518" lat="44.8157812" lon="20.4607540" version="2" timestamp="2019-06-04T21:51:21Z" changeset="70939054" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036519" lat="44.8157563" lon="20.4607128" version="2" timestamp="2019-06-04T21:51:21Z" changeset="70939054" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5850036520" lat="44.8157305" lon="20.4606835" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5850036521" lat="44.8157035" lon="20.4606657" version="3" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5850036522" lat="44.8157040" lon="20.4605406" version="3" timestamp="2019-04-23T17:01:40Z" changeset="69497145" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5866002416" lat="44.8156509" lon="20.4605607" version="3" timestamp="2019-08-30T23:31:43Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5866002417" lat="44.8156742" lon="20.4605258" version="4" timestamp="2019-08-31T14:05:38Z" changeset="73950388" uid="6225925" user="Aleksa Marinski">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="5866002418" lat="44.8167421" lon="20.4601607" version="2" timestamp="2019-04-04T09:20:01Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5866599807" lat="44.8154139" lon="20.4605952" version="10" timestamp="2021-03-26T16:26:36Z" changeset="101804028" uid="733709" user="dizajnmario">
+    <tag k="bench" v="yes"/>
+    <tag k="bus" v="yes"/>
+    <tag k="gtfs:stop_id" v="533"/>
+    <tag k="highway" v="bus_stop"/>
+    <tag k="name" v="Трг Републике"/>
+    <tag k="name:en" v="Trg Republike"/>
+    <tag k="name:sr" v="Трг Републике"/>
+    <tag k="name:sr-Latn" v="Trg Republike"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport" v="platform"/>
+    <tag k="ref" v="533"/>
+    <tag k="shelter" v="yes"/>
+  </node>
+  <node id="5866599809" lat="44.8157518" lon="20.4616790" version="10" timestamp="2021-02-23T13:29:49Z" changeset="99830866" uid="733709" user="dizajnmario">
+    <tag k="bench" v="yes"/>
+    <tag k="bus" v="yes"/>
+    <tag k="gtfs:stop_id" v="3031"/>
+    <tag k="highway" v="bus_stop"/>
+    <tag k="name" v="Трг Републике"/>
+    <tag k="name:en" v="Trg Republike"/>
+    <tag k="name:sr" v="Трг Републике"/>
+    <tag k="name:sr-Latn" v="Trg Republike"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport" v="platform"/>
+    <tag k="ref" v="3031"/>
+    <tag k="shelter" v="yes"/>
+    <tag k="trolleybus" v="yes"/>
+  </node>
+  <node id="5923527036" lat="44.8158199" lon="20.4624372" version="2" timestamp="2018-09-23T16:07:38Z" changeset="62854886" uid="6225925" user="Aleksa Marinski">
+    <tag k="name" v="ЛУЛУ пекаре"/>
+    <tag k="name:sr" v="ЛУЛУ пекаре"/>
+    <tag k="name:sr-Latn" v="LULU pekare"/>
+    <tag k="opening_hours" v="Mo-Sa 07:00-21:00"/>
+    <tag k="shop" v="bakery"/>
+    <tag k="website" v="http://www.pekaralulu.com/"/>
+  </node>
+  <node id="5924238954" lat="44.8146166" lon="20.4629784" version="1" timestamp="2018-09-23T16:07:36Z" changeset="62854886" uid="6225925" user="Aleksa Marinski"/>
+  <node id="5924238957" lat="44.8155933" lon="20.4623979" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5924238958" lat="44.8156185" lon="20.4624249" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5924238959" lat="44.8156053" lon="20.4624038" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5924238960" lat="44.8156120" lon="20.4624125" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5924238962" lat="44.8145469" lon="20.4627809" version="2" timestamp="2019-03-26T19:08:40Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="5973507034" lat="44.8166347" lon="20.4554729" version="1" timestamp="2018-10-10T23:35:18Z" changeset="63397609" uid="733709" user="dizajnmario"/>
+  <node id="5973507038" lat="44.8154414" lon="20.4624829" version="2" timestamp="2019-03-17T21:51:57Z" changeset="68240778" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bicycle_parking"/>
+    <tag k="bicycle_parking" v="stands"/>
+    <tag k="capacity" v="5"/>
+    <tag k="fee" v="no"/>
+    <tag k="ref" v="8"/>
+  </node>
+  <node id="6051047716" lat="44.8142007" lon="20.4627407" version="2" timestamp="2019-06-18T23:14:32Z" changeset="71382762" uid="8578206" user="Goatosm"/>
+  <node id="6051259663" lat="44.8029772" lon="20.4664756" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259666" lat="44.8029624" lon="20.4663204" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259667" lat="44.8028962" lon="20.4662602" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259668" lat="44.8030029" lon="20.4663416" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259669" lat="44.8030829" lon="20.4663318" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259886" lat="44.8209606" lon="20.4542768" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259891" lat="44.8179109" lon="20.4587144" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259892" lat="44.8142536" lon="20.4603976" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259893" lat="44.8135205" lon="20.4607550" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259895" lat="44.8196058" lon="20.4562227" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259896" lat="44.8192838" lon="20.4567588" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259897" lat="44.8183955" lon="20.4580803" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259898" lat="44.8167781" lon="20.4601967" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259899" lat="44.8163240" lon="20.4607766" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259900" lat="44.8161870" lon="20.4609439" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259901" lat="44.8161651" lon="20.4609659" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259902" lat="44.8161439" lon="20.4609838" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259903" lat="44.8160828" lon="20.4610101" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259904" lat="44.8160519" lon="20.4610120" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259905" lat="44.8160158" lon="20.4610063" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259906" lat="44.8159832" lon="20.4609933" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259907" lat="44.8159500" lon="20.4609720" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259908" lat="44.8159122" lon="20.4609304" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259909" lat="44.8158716" lon="20.4608698" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259910" lat="44.8158326" lon="20.4607913" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259911" lat="44.8157867" lon="20.4607124" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259912" lat="44.8157189" lon="20.4606496" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259913" lat="44.8155665" lon="20.4605735" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259914" lat="44.8151691" lon="20.4603606" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259915" lat="44.8150256" lon="20.4603081" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259916" lat="44.8147892" lon="20.4602601" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259917" lat="44.8146567" lon="20.4602465" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259918" lat="44.8145321" lon="20.4602530" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259919" lat="44.8142722" lon="20.4603885" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259920" lat="44.8110065" lon="20.4619809" version="1" timestamp="2018-11-10T16:07:53Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259921" lat="44.8084495" lon="20.4634138" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259924" lat="44.8084760" lon="20.4635026" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259925" lat="44.8110666" lon="20.4620919" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259926" lat="44.8142838" lon="20.4604142" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259927" lat="44.8145430" lon="20.4602859" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259928" lat="44.8146336" lon="20.4602747" version="3" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259929" lat="44.8147801" lon="20.4602823" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6051259930" lat="44.8150156" lon="20.4603739" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259931" lat="44.8151549" lon="20.4604277" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259932" lat="44.8155553" lon="20.4606374" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259933" lat="44.8157040" lon="20.4607125" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259934" lat="44.8157594" lon="20.4607603" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259935" lat="44.8157998" lon="20.4608276" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259936" lat="44.8158464" lon="20.4609145" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259937" lat="44.8158847" lon="20.4609702" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259938" lat="44.8159289" lon="20.4610158" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259939" lat="44.8159651" lon="20.4610386" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259940" lat="44.8160209" lon="20.4610595" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259941" lat="44.8160669" lon="20.4610694" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259942" lat="44.8160985" lon="20.4610678" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259943" lat="44.8161688" lon="20.4610399" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259944" lat="44.8161900" lon="20.4610220" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259945" lat="44.8162119" lon="20.4610000" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259946" lat="44.8163489" lon="20.4608327" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259947" lat="44.8168030" lon="20.4602528" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259948" lat="44.8184203" lon="20.4581363" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259949" lat="44.8193087" lon="20.4568148" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259950" lat="44.8196307" lon="20.4562788" version="1" timestamp="2018-11-10T16:07:54Z" changeset="64355756" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6051259951" lat="44.8209932" lon="20.4543025" version="2" timestamp="2021-03-04T11:36:55Z" changeset="100419197" uid="12771584" user="pPetrovic"/>
+  <node id="6055687105" lat="44.8067272" lon="20.4644343" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6055687106" lat="44.8066787" lon="20.4644582" version="2" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="6055687107" lat="44.8066289" lon="20.4643932" version="1" timestamp="2018-11-12T19:35:27Z" changeset="64418940" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6055687108" lat="44.8066727" lon="20.4643684" version="1" timestamp="2018-11-12T19:35:27Z" changeset="64418940" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6060747672" lat="44.8154042" lon="20.4603552" version="3" timestamp="2019-02-05T21:59:13Z" changeset="66945960" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="6"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="amenity" v="cinema"/>
+    <tag k="name" v="Дворана Културног центра Београда"/>
+    <tag k="name:sr" v="Дворана Културног центра Београда"/>
+    <tag k="name:sr-Latn" v="Dvorana Kulturnog centra Beograda"/>
+    <tag k="phone" v="+381 11 2621174"/>
+  </node>
+  <node id="6060771837" lat="44.8155625" lon="20.4628824" version="2" timestamp="2018-11-14T22:28:17Z" changeset="64505753" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="22"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="amenity" v="library"/>
+    <tag k="amenity_1" v="community_centre"/>
+    <tag k="name" v="Амерички кутак Београд"/>
+    <tag k="name:en" v="American Corner Belgrade"/>
+    <tag k="name:sr" v="Амерички кутак Београд"/>
+    <tag k="name:sr-Latn" v="Američki kutak Beograd"/>
+    <tag k="operator" v="Embassy of the United States - Serbia"/>
+  </node>
+  <node id="6071746090" lat="44.8149795" lon="20.4598957" version="1" timestamp="2018-11-18T22:21:39Z" changeset="64633104" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6244650663" lat="44.8141502" lon="20.4622207" version="1" timestamp="2019-01-29T15:33:13Z" changeset="66742097" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6244650664" lat="44.8140291" lon="20.4620066" version="1" timestamp="2019-01-29T15:33:13Z" changeset="66742097" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6260774685" lat="44.8143207" lon="20.4601559" version="1" timestamp="2019-02-05T21:59:03Z" changeset="66945960" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="8"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="email" v="shopterazije@istyle.rs"/>
+    <tag k="name" v="iSTYLE"/>
+    <tag k="opening_hours" v="Mo-Sa 09:00-22:00; Su 10:00-18:00"/>
+    <tag k="phone" v="+381 62 8004051"/>
+    <tag k="shop" v="electronics"/>
+    <tag k="website" v="https://www.istyle.rs/"/>
+  </node>
+  <node id="6260774785" lat="44.8182778" lon="20.4531964" version="2" timestamp="2019-08-20T11:53:13Z" changeset="73535677" uid="733709" user="dizajnmario">
+    <tag k="addr:housenumber" v="10a"/>
+    <tag k="addr:street" v="Краља Петра"/>
+  </node>
+  <node id="6279644388" lat="44.7954263" lon="20.4558227" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="6279644395" lat="44.7950789" lon="20.4548282" version="2" timestamp="2019-09-14T18:08:09Z" changeset="74481263" uid="5569366" user="TXBG"/>
+  <node id="6295883086" lat="44.8175954" lon="20.4545329" version="1" timestamp="2019-02-22T15:32:39Z" changeset="67470276" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6297848186" lat="44.8159182" lon="20.4602196" version="3" timestamp="2019-08-30T23:32:00Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6317125635" lat="44.8196489" lon="20.4561608" version="1" timestamp="2019-03-04T22:25:05Z" changeset="67784526" uid="6877782" user="GrumpyJohn"/>
+  <node id="6317265698" lat="44.8141796" lon="20.4605493" version="2" timestamp="2019-03-05T02:57:56Z" changeset="67788837" uid="6877782" user="GrumpyJohn">
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6317265699" lat="44.8141508" lon="20.4605642" version="2" timestamp="2019-03-05T02:57:56Z" changeset="67788837" uid="6877782" user="GrumpyJohn">
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6317265700" lat="44.8141181" lon="20.4605811" version="2" timestamp="2019-03-05T02:57:56Z" changeset="67788837" uid="6877782" user="GrumpyJohn">
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6317265701" lat="44.8140901" lon="20.4605956" version="2" timestamp="2019-03-05T02:57:56Z" changeset="67788837" uid="6877782" user="GrumpyJohn">
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6317265704" lat="44.8145769" lon="20.4603741" version="1" timestamp="2019-03-05T01:02:44Z" changeset="67787262" uid="6877782" user="GrumpyJohn">
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6317265705" lat="44.8145013" lon="20.4603943" version="1" timestamp="2019-03-05T01:02:44Z" changeset="67787262" uid="6877782" user="GrumpyJohn">
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6317265706" lat="44.8144267" lon="20.4604217" version="1" timestamp="2019-03-05T01:02:44Z" changeset="67787262" uid="6877782" user="GrumpyJohn">
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6317265707" lat="44.8140944" lon="20.4603525" version="1" timestamp="2019-03-05T01:02:44Z" changeset="67787262" uid="6877782" user="GrumpyJohn">
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6319505585" lat="44.8195112" lon="20.4541891" version="1" timestamp="2019-03-05T22:43:01Z" changeset="67824357" uid="6225925" user="Aleksa Marinski">
+    <tag k="entrance" v="yes"/>
+  </node>
+  <node id="6319505789" lat="44.8191884" lon="20.4547555" version="2" timestamp="2019-08-20T11:53:13Z" changeset="73535677" uid="733709" user="dizajnmario">
+    <tag k="addr:housenumber" v="50"/>
+    <tag k="addr:street" v="Кнеза Михаила"/>
+  </node>
+  <node id="6336272373" lat="44.8156496" lon="20.4630263" version="2" timestamp="2019-03-26T19:08:41Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6336272374" lat="44.8158909" lon="20.4623196" version="3" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="6336366328" lat="44.8152602" lon="20.4621705" version="1" timestamp="2019-03-13T20:45:04Z" changeset="68113933" uid="8759590" user="daFisch"/>
+  <node id="6336366329" lat="44.8152594" lon="20.4620211" version="1" timestamp="2019-03-13T20:45:04Z" changeset="68113933" uid="8759590" user="daFisch"/>
+  <node id="6338207812" lat="44.8139317" lon="20.4605044" version="1" timestamp="2019-03-14T17:17:20Z" changeset="68144742" uid="8759590" user="daFisch"/>
+  <node id="6338428692" lat="44.8138558" lon="20.4606402" version="2" timestamp="2019-03-26T19:08:41Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6343774955" lat="44.8149772" lon="20.4601566" version="2" timestamp="2020-01-14T05:29:13Z" changeset="79544247" uid="7009309" user="Mengesh">
+    <tag k="amenity" v="bicycle_parking"/>
+    <tag k="bicycle_parking" v="stands"/>
+    <tag k="capacity" v="3"/>
+    <tag k="covered" v="no"/>
+    <tag k="fee" v="no"/>
+    <tag k="ref" v="12"/>
+  </node>
+  <node id="6357050689" lat="44.8148120" lon="20.4603197" version="2" timestamp="2019-03-26T19:08:41Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6357050690" lat="44.8148216" lon="20.4600975" version="1" timestamp="2019-03-23T21:21:22Z" changeset="68455666" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6357050788" lat="44.8148349" lon="20.4602679" version="1" timestamp="2019-03-23T21:21:21Z" changeset="68455666" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6357050789" lat="44.8147644" lon="20.4600697" version="1" timestamp="2019-03-23T21:21:22Z" changeset="68455666" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6357050790" lat="44.8147106" lon="20.4600856" version="1" timestamp="2019-03-23T21:21:23Z" changeset="68455666" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6357050988" lat="44.8148478" lon="20.4601605" version="2" timestamp="2019-04-14T13:02:13Z" changeset="69201798" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6357050989" lat="44.8148577" lon="20.4601527" version="1" timestamp="2019-03-23T21:21:22Z" changeset="68455666" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6363316597" lat="44.8145605" lon="20.4624928" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316598" lat="44.8145876" lon="20.4625162" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316610" lat="44.8156157" lon="20.4624177" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316612" lat="44.8156564" lon="20.4624183" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316613" lat="44.8142684" lon="20.4608513" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316615" lat="44.8142332" lon="20.4604013" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316618" lat="44.8142213" lon="20.4601693" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316619" lat="44.8143193" lon="20.4625913" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316623" lat="44.8143754" lon="20.4619127" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316626" lat="44.8142907" lon="20.4611074" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316629" lat="44.8144839" lon="20.4603504" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316630" lat="44.8146185" lon="20.4625417" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316632" lat="44.8145153" lon="20.4628153" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316633" lat="44.8146380" lon="20.4603155" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316634" lat="44.8147065" lon="20.4625860" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316637" lat="44.8145048" lon="20.4624251" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316639" lat="44.8141966" lon="20.4597053" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316641" lat="44.8142475" lon="20.4606139" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316643" lat="44.8143374" lon="20.4615614" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316646" lat="44.8155975" lon="20.4623987" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316648" lat="44.8143735" lon="20.4624787" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316649" lat="44.8156184" lon="20.4623821" version="1" timestamp="2019-03-26T19:08:35Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316651" lat="44.8141747" lon="20.4592855" version="1" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316652" lat="44.8156627" lon="20.4624441" version="1" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316656" lat="44.8143963" lon="20.4624143" version="1" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6363316658" lat="44.8156209" lon="20.4624363" version="1" timestamp="2019-03-26T19:08:36Z" changeset="68559829" uid="5569366" user="TXBG"/>
+  <node id="6382904787" lat="44.8158836" lon="20.4607208" version="1" timestamp="2019-04-04T09:19:57Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382912486" lat="44.8161889" lon="20.4608690" version="1" timestamp="2019-04-04T09:19:55Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382912487" lat="44.8159898" lon="20.4608792" version="1" timestamp="2019-04-04T09:19:55Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382912488" lat="44.8158517" lon="20.4606703" version="1" timestamp="2019-04-04T09:19:58Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382912489" lat="44.8158272" lon="20.4606370" version="1" timestamp="2019-04-04T09:19:58Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382928788" lat="44.8160240" lon="20.4609041" version="1" timestamp="2019-04-04T09:19:55Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382928789" lat="44.8161389" lon="20.4609054" version="1" timestamp="2019-04-04T09:19:56Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382928790" lat="44.8157988" lon="20.4606068" version="1" timestamp="2019-04-04T09:19:58Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382932286" lat="44.8161694" lon="20.4608866" version="1" timestamp="2019-04-04T09:19:56Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382932585" lat="44.8161000" lon="20.4609163" version="1" timestamp="2019-04-04T09:19:56Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6382932586" lat="44.8159522" lon="20.4608354" version="1" timestamp="2019-04-04T09:19:57Z" changeset="68873615" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6388121894" lat="44.8153891" lon="20.4574131" version="1" timestamp="2019-04-06T19:48:58Z" changeset="68960510" uid="6225925" user="Aleksa Marinski">
+    <tag k="barrier" v="block"/>
+  </node>
+  <node id="6391576486" lat="44.8163344" lon="20.4563826" version="1" timestamp="2019-04-08T17:37:02Z" changeset="69016611" uid="6225925" user="Aleksa Marinski">
+    <tag k="historic" v="memorial"/>
+    <tag k="memorial" v="plaque"/>
+    <tag k="name" v="Спомен-плоча жртвама Специјалне полиције"/>
+    <tag k="name:sr" v="Спомен-плоча жртвама Специјалне полиције"/>
+    <tag k="name:sr-Latn" v="Spomen-ploča žrtvama Specijalne policije"/>
+  </node>
+  <node id="6404069987" lat="44.8147386" lon="20.4600872" version="1" timestamp="2019-04-14T13:02:11Z" changeset="69201798" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6404069988" lat="44.8147912" lon="20.4600920" version="1" timestamp="2019-04-14T13:02:11Z" changeset="69201798" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6404076786" lat="44.8148509" lon="20.4602001" version="1" timestamp="2019-04-14T13:02:12Z" changeset="69201798" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6404076885" lat="44.8146957" lon="20.4601033" version="1" timestamp="2019-04-14T13:02:10Z" changeset="69201798" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6404076886" lat="44.8146103" lon="20.4601699" version="1" timestamp="2019-04-14T13:02:10Z" changeset="69201798" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6404076887" lat="44.8148334" lon="20.4601288" version="1" timestamp="2019-04-14T13:02:11Z" changeset="69201798" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6423895085" lat="44.8161197" lon="20.4599649" version="2" timestamp="2019-08-30T23:32:00Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6448526090" lat="44.8160679" lon="20.4572043" version="1" timestamp="2019-05-04T20:03:16Z" changeset="69888562" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6448526091" lat="44.8160940" lon="20.4571907" version="1" timestamp="2019-05-04T20:03:17Z" changeset="69888562" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6448531491" lat="44.8160825" lon="20.4572025" version="1" timestamp="2019-05-04T20:03:16Z" changeset="69888562" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6448531885" lat="44.8160753" lon="20.4572050" version="1" timestamp="2019-05-04T20:03:16Z" changeset="69888562" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6463896387" lat="44.8153450" lon="20.4614918" version="1" timestamp="2019-05-10T08:51:50Z" changeset="70101044" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6466736285" lat="44.8162236" lon="20.4557432" version="2" timestamp="2021-03-15T23:36:50Z" changeset="101078878" uid="5569366" user="TXBG"/>
+  <node id="6466736385" lat="44.8165004" lon="20.4558253" version="1" timestamp="2019-05-11T16:26:57Z" changeset="70141688" uid="6225925" user="Aleksa Marinski">
+    <tag k="entrance" v="main"/>
+  </node>
+  <node id="6467091488" lat="44.8188605" lon="20.4525961" version="1" timestamp="2019-05-11T22:09:24Z" changeset="70148234" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6467099985" lat="44.8189160" lon="20.4526757" version="1" timestamp="2019-05-11T22:09:24Z" changeset="70148234" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6472254613" lat="44.8150990" lon="20.4605121" version="1" timestamp="2019-05-14T10:17:19Z" changeset="70226215" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6472254614" lat="44.8150056" lon="20.4604753" version="1" timestamp="2019-05-14T10:17:19Z" changeset="70226215" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6472254615" lat="44.8149298" lon="20.4608562" version="1" timestamp="2019-05-14T10:17:19Z" changeset="70226215" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6476564987" lat="44.8150120" lon="20.4625933" version="1" timestamp="2019-05-15T20:49:42Z" changeset="70293595" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bicycle_parking"/>
+    <tag k="bicycle_parking" v="stands"/>
+    <tag k="capacity" v="3"/>
+    <tag k="fee" v="no"/>
+  </node>
+  <node id="6476564988" lat="44.8146342" lon="20.4629052" version="1" timestamp="2019-05-15T20:49:42Z" changeset="70293595" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bicycle_parking"/>
+    <tag k="bicycle_parking" v="stands"/>
+    <tag k="capacity" v="4"/>
+    <tag k="fee" v="no"/>
+  </node>
+  <node id="6485350481" lat="44.8183508" lon="20.4581388" version="1" timestamp="2019-05-20T09:48:52Z" changeset="70433495" uid="4688028" user="andreiSk"/>
+  <node id="6485379808" lat="44.8189952" lon="20.4550967" version="2" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="6487824761" lat="44.8149359" lon="20.4607138" version="1" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6487824762" lat="44.8149555" lon="20.4606159" version="1" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6487824763" lat="44.8149565" lon="20.4607219" version="1" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6487824764" lat="44.8149760" lon="20.4606240" version="1" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6487824765" lat="44.8147713" lon="20.4604783" version="1" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6487824766" lat="44.8147250" lon="20.4606555" version="1" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6487824767" lat="44.8147337" lon="20.4604303" version="1" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina"/>
+  <node id="6516190885" lat="44.8158128" lon="20.4604411" version="2" timestamp="2019-06-02T13:36:51Z" changeset="70857096" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="genus" v="Acer"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+    <tag k="start_date" v="2019-6-2"/>
+  </node>
+  <node id="6516190886" lat="44.8159759" lon="20.4607003" version="2" timestamp="2019-06-02T13:36:51Z" changeset="70857096" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="genus" v="Acer"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+    <tag k="start_date" v="2019-6-2"/>
+  </node>
+  <node id="6516190887" lat="44.8160305" lon="20.4607864" version="2" timestamp="2019-06-02T13:36:52Z" changeset="70857096" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="genus" v="Acer"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+    <tag k="start_date" v="2019-6-2"/>
+  </node>
+  <node id="6516190889" lat="44.8158673" lon="20.4603732" version="2" timestamp="2019-06-02T13:36:53Z" changeset="70857096" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="genus" v="Acer"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+    <tag k="start_date" v="2019-6-2"/>
+  </node>
+  <node id="6516190986" lat="44.8158671" lon="20.4605277" version="2" timestamp="2019-06-02T13:36:54Z" changeset="70857096" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="genus" v="Acer"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+    <tag k="start_date" v="2019-6-2"/>
+  </node>
+  <node id="6516190987" lat="44.8159215" lon="20.4606138" version="2" timestamp="2019-06-02T13:36:54Z" changeset="70857096" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="genus" v="Acer"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+    <tag k="start_date" v="2019-6-2"/>
+  </node>
+  <node id="6516190988" lat="44.8160304" lon="20.4606324" version="2" timestamp="2019-06-02T13:36:55Z" changeset="70857096" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="genus" v="Acer"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+    <tag k="start_date" v="2019-6-2"/>
+  </node>
+  <node id="6516190989" lat="44.8159760" lon="20.4605460" version="2" timestamp="2019-06-02T13:36:55Z" changeset="70857096" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="genus" v="Acer"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+    <tag k="start_date" v="2019-6-2"/>
+  </node>
+  <node id="6516190990" lat="44.8159217" lon="20.4604599" version="2" timestamp="2019-06-02T13:36:55Z" changeset="70857096" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="genus" v="Acer"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+    <tag k="start_date" v="2019-6-2"/>
+  </node>
+  <node id="6522159889" lat="44.8157930" lon="20.4607744" version="5" timestamp="2021-03-24T15:20:49Z" changeset="101657870" uid="733709" user="dizajnmario">
+    <tag k="button_operated" v="no"/>
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="highway" v="traffic_signals"/>
+    <tag k="traffic_signals:sound" v="no"/>
+    <tag k="traffic_signals:vibration" v="no"/>
+  </node>
+  <node id="6522159890" lat="44.8158638" lon="20.4606894" version="1" timestamp="2019-06-04T21:51:15Z" changeset="70939054" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6522159892" lat="44.8156220" lon="20.4607744" version="2" timestamp="2019-09-27T18:54:43Z" changeset="75022852" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6522163887" lat="44.8157861" lon="20.4607827" version="1" timestamp="2019-06-04T21:51:15Z" changeset="70939054" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6522163985" lat="44.8157436" lon="20.4608338" version="1" timestamp="2019-06-04T21:51:15Z" changeset="70939054" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6536028485" lat="44.8162265" lon="20.4614570" version="1" timestamp="2019-06-09T22:58:23Z" changeset="71082705" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6536028486" lat="44.8162118" lon="20.4611902" version="1" timestamp="2019-06-09T22:58:23Z" changeset="71082705" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6536028685" lat="44.8159731" lon="20.4614394" version="1" timestamp="2019-06-09T22:58:24Z" changeset="71082705" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6536028686" lat="44.8160267" lon="20.4613727" version="1" timestamp="2019-06-09T22:58:24Z" changeset="71082705" uid="6225925" user="Aleksa Marinski">
+    <tag k="denotation" v="urban"/>
+    <tag k="leaf_cycle" v="deciduous"/>
+    <tag k="leaf_type" v="broadleaved"/>
+    <tag k="natural" v="tree"/>
+  </node>
+  <node id="6578723588" lat="44.8144818" lon="20.4602444" version="1" timestamp="2019-06-29T17:08:24Z" changeset="71740102" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6582289686" lat="44.8148029" lon="20.4627646" version="1" timestamp="2019-07-01T17:40:50Z" changeset="71793969" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="drinking_water"/>
+  </node>
+  <node id="6582289687" lat="44.8147931" lon="20.4627630" version="1" timestamp="2019-07-01T17:40:50Z" changeset="71793969" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="fountain"/>
+  </node>
+  <node id="6617607036" lat="44.8141426" lon="20.4602323" version="1" timestamp="2019-07-15T20:39:56Z" changeset="72280932" uid="7608768" user="Blyatman">
+    <tag k="amenity" v="fast_food"/>
+    <tag k="name" v="Caribic Pizza"/>
+  </node>
+  <node id="6617829451" lat="44.8144854" lon="20.4605426" version="2" timestamp="2020-12-01T13:44:09Z" changeset="95097857" uid="733709" user="dizajnmario">
+    <tag k="amenity" v="bank"/>
+    <tag k="brand" v="Crédit Agricole"/>
+    <tag k="brand:wikidata" v="Q590952"/>
+    <tag k="brand:wikipedia" v="fr:Crédit agricole"/>
+    <tag k="name" v="Crédit Agricole"/>
+  </node>
+  <node id="6710216188" lat="44.8149844" lon="20.4613101" version="1" timestamp="2019-08-14T14:26:27Z" changeset="73352509" uid="8787538" user="Chrigy">
+    <tag k="name:en" v="Ye ye vintage shop"/>
+    <tag k="shop" v="clothes"/>
+  </node>
+  <node id="6710219485" lat="44.8147523" lon="20.4619206" version="1" timestamp="2019-08-14T14:25:00Z" changeset="73352457" uid="8787538" user="Chrigy">
+    <tag k="name:en" v="Wunderkammer local designers"/>
+    <tag k="shop" v="gift"/>
+  </node>
+  <node id="6718724788" lat="44.8165679" lon="20.4603849" version="1" timestamp="2019-08-17T17:02:35Z" changeset="73447369" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6735402999" lat="44.8159659" lon="20.4613940" version="1" timestamp="2019-08-22T13:18:20Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6735403187" lat="44.8157929" lon="20.4611774" version="4" timestamp="2021-03-24T15:20:50Z" changeset="101657870" uid="733709" user="dizajnmario">
+    <tag k="button_operated" v="no"/>
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="highway" v="traffic_signals"/>
+    <tag k="traffic_signals:sound" v="yes"/>
+    <tag k="traffic_signals:vibration" v="no"/>
+  </node>
+  <node id="6735403188" lat="44.8157968" lon="20.4607809" version="1" timestamp="2019-08-22T13:18:21Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6735403189" lat="44.8158025" lon="20.4608233" version="1" timestamp="2019-08-22T13:18:21Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6735412288" lat="44.8159335" lon="20.4613534" version="4" timestamp="2021-03-24T15:20:51Z" changeset="101657870" uid="733709" user="dizajnmario">
+    <tag k="button_operated" v="no"/>
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="highway" v="traffic_signals"/>
+    <tag k="traffic_signals:sound" v="yes"/>
+    <tag k="traffic_signals:vibration" v="no"/>
+  </node>
+  <node id="6735412289" lat="44.8157483" lon="20.4611216" version="1" timestamp="2019-08-22T13:18:20Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6735412290" lat="44.8156579" lon="20.4607165" version="1" timestamp="2019-08-22T13:18:21Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6735415085" lat="44.8165082" lon="20.4608533" version="1" timestamp="2019-08-22T13:18:21Z" changeset="73624285" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6742417487" lat="44.8188151" lon="20.4573688" version="2" timestamp="2019-08-31T14:05:39Z" changeset="73950388" uid="6225925" user="Aleksa Marinski">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="6742422585" lat="44.8167031" lon="20.4554257" version="2" timestamp="2019-08-31T14:05:39Z" changeset="73950388" uid="6225925" user="Aleksa Marinski">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="6742575078" lat="44.8153775" lon="20.4603398" version="2" timestamp="2020-12-01T13:44:09Z" changeset="95097857" uid="733709" user="dizajnmario">
+    <tag k="addr:housenumber" v="6-8"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="brand" v="Women'secret"/>
+    <tag k="brand:wikidata" v="Q16648226"/>
+    <tag k="brand:wikipedia" v="es:Women'secret"/>
+    <tag k="clothes" v="underwear;women"/>
+    <tag k="name" v="Women'secret"/>
+    <tag k="opening_hours" v="Mo-Sa 09:00-22:00; Su off"/>
+    <tag k="shop" v="clothes"/>
+  </node>
+  <node id="6745620388" lat="44.8157909" lon="20.4628335" version="1" timestamp="2019-08-26T08:59:09Z" changeset="73740920" uid="10160977" user="SimonBader">
+    <tag k="name:en" v="Soul House Appartements"/>
+    <tag k="tourism" v="apartment"/>
+  </node>
+  <node id="6757247586" lat="44.8178225" lon="20.4587223" version="3" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="6757247587" lat="44.8171473" lon="20.4595995" version="3" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="6757247986" lat="44.8192159" lon="20.4567690" version="3" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="6757258285" lat="44.8173314" lon="20.4593617" version="3" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="6760758885" lat="44.8159033" lon="20.4602759" version="2" timestamp="2021-02-23T13:29:48Z" changeset="99830872" uid="733709" user="dizajnmario">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="internet_access" v="wlan"/>
+    <tag k="internet_access:fee" v="no"/>
+    <tag k="material" v="wood"/>
+  </node>
+  <node id="6760758886" lat="44.8158906" lon="20.4602923" version="1" timestamp="2019-08-30T23:31:10Z" changeset="73939817" uid="6225925" user="Aleksa Marinski">
+    <tag k="information" v="terminal"/>
+    <tag k="tourism" v="information"/>
+  </node>
+  <node id="6760758890" lat="44.8160238" lon="20.4606411" version="2" timestamp="2019-08-31T22:22:18Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760758892" lat="44.8159151" lon="20.4604686" version="2" timestamp="2019-08-31T22:22:19Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760758893" lat="44.8160371" lon="20.4607776" version="2" timestamp="2019-08-31T22:22:19Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760758894" lat="44.8159825" lon="20.4606915" version="2" timestamp="2019-08-31T22:22:20Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760758895" lat="44.8159281" lon="20.4606050" version="2" timestamp="2019-08-31T22:22:20Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760758896" lat="44.8158737" lon="20.4605189" version="2" timestamp="2019-08-31T22:22:21Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760758986" lat="44.8159283" lon="20.4604511" version="2" timestamp="2019-08-31T22:22:21Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760759085" lat="44.8158491" lon="20.4603443" version="2" timestamp="2019-08-31T22:22:21Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="internet_access" v="wlan"/>
+    <tag k="internet_access:fee" v="no"/>
+    <tag k="material" v="wood"/>
+  </node>
+  <node id="6760759086" lat="44.8159694" lon="20.4605547" version="2" timestamp="2019-08-31T22:22:22Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760759088" lat="44.8159131" lon="20.4603283" version="1" timestamp="2019-08-30T23:31:21Z" changeset="73939817" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="waste_basket"/>
+  </node>
+  <node id="6760759191" lat="44.8158607" lon="20.4603819" version="2" timestamp="2019-08-31T22:22:22Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760759193" lat="44.8159826" lon="20.4605372" version="2" timestamp="2019-08-31T22:22:23Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760759194" lat="44.8158953" lon="20.4606511" version="1" timestamp="2019-08-30T23:31:17Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6760759195" lat="44.8157541" lon="20.4604255" version="1" timestamp="2019-08-30T23:31:17Z" changeset="73939817" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6760759196" lat="44.8160370" lon="20.4606236" version="2" timestamp="2019-08-31T22:22:23Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6760759198" lat="44.8158194" lon="20.4604323" version="2" timestamp="2019-08-31T22:22:24Z" changeset="73959351" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bench"/>
+    <tag k="backrest" v="no"/>
+    <tag k="material" v="stone"/>
+  </node>
+  <node id="6761575689" lat="44.8156329" lon="20.4606291" version="1" timestamp="2019-08-31T14:05:32Z" changeset="73950388" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6761575690" lat="44.8165196" lon="20.4604470" version="1" timestamp="2019-08-31T14:05:32Z" changeset="73950388" uid="6225925" user="Aleksa Marinski">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="6761575692" lat="44.8180829" lon="20.4538772" version="1" timestamp="2019-08-31T14:05:34Z" changeset="73950388" uid="6225925" user="Aleksa Marinski">
+    <tag k="barrier" v="bollard"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="bollard" v="rising"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="foot" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="material" v="metal"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+  </node>
+  <node id="6763999291" lat="44.8166426" lon="20.4614241" version="1" timestamp="2019-09-01T13:53:46Z" changeset="73973595" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6774895116" lat="44.8149265" lon="20.4604944" version="1" timestamp="2019-09-05T14:58:29Z" changeset="74139676" uid="9047835" user="YunDi88">
+    <tag k="amenity" v="bank"/>
+    <tag k="name:en" v="Credit Agricole"/>
+  </node>
+  <node id="6774895117" lat="44.8143216" lon="20.4606730" version="3" timestamp="2020-12-01T13:44:09Z" changeset="95097857" uid="733709" user="dizajnmario">
+    <tag k="amenity" v="bank"/>
+    <tag k="brand" v="Eurobank"/>
+    <tag k="brand:wikidata" v="Q951850"/>
+    <tag k="brand:wikipedia" v="el:Eurobank"/>
+    <tag k="name" v="Eurobank"/>
+    <tag k="name:en" v="Eurobank"/>
+    <tag k="website" v="https://www.eurobank.rs/"/>
+  </node>
+  <node id="6779232786" lat="44.8156799" lon="20.4611730" version="4" timestamp="2020-02-14T03:27:14Z" changeset="80983364" uid="9451067" user="b-jazz-bot">
+    <tag k="addr:city" v="Београд"/>
+    <tag k="addr:housenumber" v="4"/>
+    <tag k="addr:postcode" v="11000"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="amenity" v="bank"/>
+    <tag k="atm" v="yes"/>
+    <tag k="name" v="Директна банка"/>
+    <tag k="name:en" v="Direktna Banka"/>
+    <tag k="name:sr" v="Директна банка"/>
+    <tag k="name:sr-Latn" v="Direktna banka"/>
+    <tag k="opening_hours" v="Mo-Fr 09:00-16:30"/>
+    <tag k="phone" v="+381 11 3039876"/>
+    <tag k="website" v="https://www.direktnabanka.rs/"/>
+  </node>
+  <node id="6779232985" lat="44.8151759" lon="20.4605618" version="3" timestamp="2020-05-29T18:54:38Z" changeset="85962587" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="5"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="amenity" v="fast_food"/>
+    <tag k="cuisine" v="gyros"/>
+    <tag k="name" v="Gyros In City"/>
+  </node>
+  <node id="6782867190" lat="44.8150397" lon="20.4627410" version="1" timestamp="2019-09-09T13:48:54Z" changeset="74264850" uid="9047835" user="YunDi88">
+    <tag k="name" v="DDG fashion"/>
+    <tag k="shop" v="clothes"/>
+  </node>
+  <node id="6782874199" lat="44.8143912" lon="20.4629441" version="1" timestamp="2019-09-09T13:48:51Z" changeset="74264850" uid="9047835" user="YunDi88">
+    <tag k="shop" v="clothes"/>
+  </node>
+  <node id="6782874201" lat="44.8151289" lon="20.4626423" version="2" timestamp="2019-09-30T17:28:02Z" changeset="75113476" uid="6225925" user="Aleksa Marinski">
+    <tag k="name" v="Lilly"/>
+    <tag k="shop" v="chemist"/>
+  </node>
+  <node id="6782874202" lat="44.8156244" lon="20.4621193" version="2" timestamp="2019-09-30T17:28:02Z" changeset="75113476" uid="6225925" user="Aleksa Marinski">
+    <tag k="name" v="Боледо"/>
+    <tag k="name:en" v="Boledo"/>
+    <tag k="name:sr" v="Боледо"/>
+    <tag k="name:sr-Latn" v="Boledo"/>
+    <tag k="shop" v="shoes"/>
+  </node>
+  <node id="6782874203" lat="44.8158757" lon="20.4620918" version="1" timestamp="2019-09-09T13:48:55Z" changeset="74264850" uid="9047835" user="YunDi88">
+    <tag k="amenity" v="bureau_de_change"/>
+  </node>
+  <node id="6782874204" lat="44.8159507" lon="20.4624511" version="1" timestamp="2019-09-09T13:48:56Z" changeset="74264850" uid="9047835" user="YunDi88">
+    <tag k="amenity" v="bureau_de_change"/>
+  </node>
+  <node id="6782874293" lat="44.8158983" lon="20.4624381" version="1" timestamp="2019-09-09T13:48:55Z" changeset="74264850" uid="9047835" user="YunDi88">
+    <tag k="amenity" v="fast_food"/>
+    <tag k="name" v="Pizza"/>
+  </node>
+  <node id="6782874685" lat="44.8147376" lon="20.4629430" version="1" timestamp="2019-09-09T13:48:53Z" changeset="74264850" uid="9047835" user="YunDi88">
+    <tag k="name" v="Roggenart"/>
+    <tag k="shop" v="bakery"/>
+  </node>
+  <node id="6807583986" lat="44.8156881" lon="20.4608725" version="2" timestamp="2019-09-27T18:54:43Z" changeset="75022852" uid="6225925" user="Aleksa Marinski">
+    <tag k="entrance" v="main"/>
+  </node>
+  <node id="6807612686" lat="44.8156517" lon="20.4608318" version="2" timestamp="2019-09-22T12:36:08Z" changeset="74771021" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="name" v="Samsung Shop &amp; Service"/>
+    <tag k="shop" v="mobile_phone"/>
+  </node>
+  <node id="6815615287" lat="44.8190183" lon="20.4557793" version="1" timestamp="2019-09-22T13:45:36Z" changeset="74772319" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6815615389" lat="44.8190849" lon="20.4558561" version="1" timestamp="2019-09-22T13:45:34Z" changeset="74772319" uid="6225925" user="Aleksa Marinski"/>
+  <node id="6831399189" lat="44.8156998" lon="20.4609468" version="1" timestamp="2019-09-27T18:54:38Z" changeset="75022852" uid="6225925" user="Aleksa Marinski">
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="clothes" v="suits"/>
+    <tag k="email" v="office@rancco.rs"/>
+    <tag k="name" v="Rancco"/>
+    <tag k="shop" v="clothes"/>
+    <tag k="website" v="http://rancco.rs/"/>
+  </node>
+  <node id="6832907887" lat="44.8159191" lon="20.4621135" version="1" timestamp="2019-09-28T15:15:12Z" changeset="75042404" uid="3904030" user="Carlos Franco">
+    <tag k="amenity" v="bar"/>
+    <tag k="name" v="Morn (The Black Turtle Pub)"/>
+  </node>
+  <node id="6832907888" lat="44.8158445" lon="20.4620373" version="1" timestamp="2019-09-28T15:15:13Z" changeset="75042404" uid="3904030" user="Carlos Franco">
+    <tag k="amenity" v="bar"/>
+    <tag k="name" v="Zora (The Black Turtle Pub)"/>
+  </node>
+  <node id="6832907986" lat="44.8158921" lon="20.4617216" version="1" timestamp="2019-09-28T15:15:13Z" changeset="75042404" uid="3904030" user="Carlos Franco">
+    <tag k="amenity" v="fast_food"/>
+    <tag k="name" v="Pizzeria Trg"/>
+  </node>
+  <node id="6832928090" lat="44.8156965" lon="20.4603225" version="1" timestamp="2019-09-28T15:38:03Z" changeset="75042890" uid="3904030" user="Carlos Franco">
+    <tag k="amenity" v="bar"/>
+    <tag k="name" v="Square Five"/>
+  </node>
+  <node id="6832928187" lat="44.8156273" lon="20.4604067" version="1" timestamp="2019-09-28T15:36:59Z" changeset="75042867" uid="3904030" user="Carlos Franco">
+    <tag k="amenity" v="nightclub"/>
+    <tag k="name" v="Kafana Trg"/>
+  </node>
+  <node id="6836128186" lat="44.8155519" lon="20.4625954" version="1" timestamp="2019-09-30T02:34:03Z" changeset="75076156" uid="3904030" user="Carlos Franco">
+    <tag k="name" v="Eventim"/>
+    <tag k="shop" v="ticket"/>
+  </node>
+  <node id="6836129786" lat="44.8156564" lon="20.4616952" version="1" timestamp="2019-09-30T02:31:57Z" changeset="75076125" uid="3904030" user="Carlos Franco">
+    <tag k="amenity" v="bank"/>
+    <tag k="name" v="AIK Banka"/>
+  </node>
+  <node id="6836133285" lat="44.8156495" lon="20.4619009" version="2" timestamp="2019-09-30T17:28:03Z" changeset="75113476" uid="6225925" user="Aleksa Marinski">
+    <tag k="name" v="Лагуна"/>
+    <tag k="name:en" v="Laguna"/>
+    <tag k="name:sr" v="Лагуна"/>
+    <tag k="name:sr-Latn" v="Laguna"/>
+    <tag k="shop" v="books"/>
+  </node>
+  <node id="6836136185" lat="44.8152402" lon="20.4621701" version="2" timestamp="2019-09-30T17:28:03Z" changeset="75113476" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="fast_food"/>
+    <tag k="cuisine" v="pasta"/>
+    <tag k="name" v="Ciao Pasta"/>
+  </node>
+  <node id="6887360591" lat="44.8142476" lon="20.4601759" version="1" timestamp="2019-10-16T23:28:29Z" changeset="75804471" uid="3341588" user="Heliotrope">
+    <tag k="addr:city" v="Београд"/>
+    <tag k="addr:housenumber" v="8/2"/>
+    <tag k="addr:postcode" v="11000"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="name" v="British Council"/>
+    <tag k="office" v="association"/>
+    <tag k="phone" v="+381 11 3023 800"/>
+    <tag k="website" v="https://www.britishcouncil.rs/"/>
+    <tag k="wikidata" v="Q45433"/>
+    <tag k="wikipedia" v="en:British Council"/>
+  </node>
+  <node id="7086976191" lat="44.8198703" lon="20.4539587" version="1" timestamp="2019-12-26T21:59:11Z" changeset="78899025" uid="10427003" user="Savo25656"/>
+  <node id="7086976207" lat="44.8199756" lon="20.4538047" version="1" timestamp="2019-12-26T21:59:11Z" changeset="78899025" uid="10427003" user="Savo25656"/>
+  <node id="7086976209" lat="44.8199386" lon="20.4538534" version="1" timestamp="2019-12-26T21:59:11Z" changeset="78899025" uid="10427003" user="Savo25656"/>
+  <node id="7086976214" lat="44.8198317" lon="20.4540118" version="1" timestamp="2019-12-26T21:59:11Z" changeset="78899025" uid="10427003" user="Savo25656"/>
+  <node id="7086976216" lat="44.8197457" lon="20.4541299" version="1" timestamp="2019-12-26T21:59:11Z" changeset="78899025" uid="10427003" user="Savo25656"/>
+  <node id="7086976219" lat="44.8197147" lon="20.4540819" version="1" timestamp="2019-12-26T21:59:11Z" changeset="78899025" uid="10427003" user="Savo25656"/>
+  <node id="7107715486" lat="44.8158232" lon="20.4620742" version="1" timestamp="2020-01-04T17:25:07Z" changeset="79195151" uid="6225925" user="Aleksa Marinski"/>
+  <node id="7107738385" lat="44.8157461" lon="20.4620692" version="2" timestamp="2021-03-23T12:52:44Z" changeset="101575695" uid="733709" user="dizajnmario">
+    <tag k="button_operated" v="yes"/>
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="crossing:island" v="no"/>
+    <tag k="crossing_ref" v="zebra"/>
+    <tag k="highway" v="crossing"/>
+    <tag k="traffic_signals:arrow" v="yes"/>
+    <tag k="traffic_signals:minimap" v="yes"/>
+    <tag k="traffic_signals:sound" v="yes"/>
+    <tag k="traffic_signals:vibration" v="yes"/>
+  </node>
+  <node id="7107738485" lat="44.8156808" lon="20.4620649" version="1" timestamp="2020-01-04T17:25:07Z" changeset="79195151" uid="6225925" user="Aleksa Marinski"/>
+  <node id="7198379685" lat="44.8150910" lon="20.4600376" version="1" timestamp="2020-02-09T19:40:17Z" changeset="80762171" uid="5780790" user="adrumillon">
+    <tag k="amenity" v="cafe"/>
+    <tag k="name:en" v="Koppa Speciality Coffee"/>
+  </node>
+  <node id="7242832685" lat="44.8144082" lon="20.4627999" version="1" timestamp="2020-02-25T15:13:45Z" changeset="81461469" uid="6225925" user="Aleksa Marinski">
+    <tag k="level" v="-1"/>
+    <tag k="name" v="иДЕА"/>
+    <tag k="name:sr" v="иДЕА"/>
+    <tag k="name:sr-Latn" v="iDEA"/>
+    <tag k="shop" v="convenience"/>
+  </node>
+  <node id="7526304276" lat="44.8200643" lon="20.4532852" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7526304277" lat="44.8183830" lon="20.4533459" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7526304278" lat="44.8172330" lon="20.4550118" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7526304279" lat="44.8167902" lon="20.4553655" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7526304281" lat="44.8152767" lon="20.4574703" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7526375187" lat="44.8144109" lon="20.4587227" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7526375190" lat="44.8146948" lon="20.4599758" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7526375191" lat="44.8146704" lon="20.4599950" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7526375192" lat="44.8146287" lon="20.4600663" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7526375193" lat="44.8149555" lon="20.4601812" version="1" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn"/>
+  <node id="7577431073" lat="44.8142867" lon="20.4604944" version="1" timestamp="2020-06-01T10:12:59Z" changeset="86040864" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="bicycle_parking"/>
+    <tag k="bicycle_parking" v="stands"/>
+    <tag k="capacity" v="4"/>
+    <tag k="fee" v="no"/>
+  </node>
+  <node id="7609370651" lat="44.8156445" lon="20.4623030" version="1" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="7609370652" lat="44.8156674" lon="20.4623017" version="1" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG"/>
+  <node id="7843762724" lat="44.8145682" lon="20.4620075" version="1" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario"/>
+  <node id="7843762725" lat="44.8145341" lon="20.4618168" version="1" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario"/>
+  <node id="7874482829" lat="44.8151010" lon="20.4621641" version="1" timestamp="2020-09-04T05:48:30Z" changeset="90393282" uid="3341588" user="Heliotrope">
+    <tag k="addr:city" v="Београд"/>
+    <tag k="addr:housenumber" v="6"/>
+    <tag k="addr:postcode" v="11000"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="amenity" v="music_school"/>
+    <tag k="name" v="Muzička škola Stanković"/>
+    <tag k="website" v="http://msstankovic.edu.rs/"/>
+  </node>
+  <node id="7923465256" lat="44.8147103" lon="20.4617250" version="1" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski">
+    <tag k="amenity" v="fountain"/>
+  </node>
+  <node id="7923465257" lat="44.8150449" lon="20.4618555" version="1" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="7923465258" lat="44.8147883" lon="20.4616807" version="1" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="7923465259" lat="44.8148188" lon="20.4616405" version="1" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="7923465260" lat="44.8148406" lon="20.4615889" version="1" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="7923465261" lat="44.8148035" lon="20.4617652" version="1" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="7923465262" lat="44.8147560" lon="20.4617062" version="1" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="7923465263" lat="44.8146900" lon="20.4616793" version="1" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski"/>
+  <node id="7924317009" lat="44.8153224" lon="20.4628468" version="2" timestamp="2020-09-23T02:45:48Z" changeset="91325634" uid="9451067" user="b-jazz-bot">
+    <tag k="addr:city" v="Београд"/>
+    <tag k="addr:housenumber" v="22"/>
+    <tag k="addr:postcode" v="11000"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="contact:facebook" v="https://www.facebook.com/Beopolis/"/>
+    <tag k="name" v="Beopolis"/>
+    <tag k="opening_hours" v="Mo-Fr 10:00-21:00; Sa 12:00-20:00"/>
+    <tag k="phone" v="+381 11 3229922"/>
+    <tag k="shop" v="books"/>
+    <tag k="website" v="https://www.beopolis.rs/"/>
+  </node>
+  <node id="8012487022" lat="44.8151931" lon="20.4624639" version="2" timestamp="2020-10-18T15:13:50Z" changeset="92660146" uid="474183" user="ratrun"/>
+  <node id="8062285632" lat="44.8163308" lon="20.4617269" version="1" timestamp="2020-10-29T10:36:35Z" changeset="93230281" uid="6225925" user="Aleksa Marinski"/>
+  <node id="8062285633" lat="44.8162688" lon="20.4618578" version="1" timestamp="2020-10-29T10:36:35Z" changeset="93230281" uid="6225925" user="Aleksa Marinski"/>
+  <node id="8222814373" lat="44.8156028" lon="20.4623148" version="2" timestamp="2021-03-23T12:52:44Z" changeset="101575695" uid="733709" user="dizajnmario">
+    <tag k="button_operated" v="yes"/>
+    <tag k="crossing" v="traffic_signals"/>
+    <tag k="crossing:island" v="no"/>
+    <tag k="crossing_ref" v="zebra"/>
+    <tag k="highway" v="crossing"/>
+    <tag k="traffic_signals:arrow" v="yes"/>
+    <tag k="traffic_signals:minimap" v="yes"/>
+    <tag k="traffic_signals:sound" v="yes"/>
+    <tag k="traffic_signals:vibration" v="yes"/>
+  </node>
+  <node id="8222814374" lat="44.8155791" lon="20.4623233" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <tag k="highway" v="traffic_signals"/>
+  </node>
+  <node id="8222814375" lat="44.8157503" lon="20.4620241" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <tag k="highway" v="traffic_signals"/>
+  </node>
+  <node id="8222814376" lat="44.8157055" lon="20.4624977" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <tag k="highway" v="traffic_signals"/>
+  </node>
+  <node id="8222814377" lat="44.8158591" lon="20.4623161" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <tag k="highway" v="traffic_signals"/>
+  </node>
+  <node id="8222814378" lat="44.8158183" lon="20.4621370" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski"/>
+  <node id="8222814379" lat="44.8158323" lon="20.4621722" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski"/>
+  <node id="8222814380" lat="44.8156432" lon="20.4621659" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski"/>
+  <node id="8361966794" lat="44.8147899" lon="20.4616066" version="1" timestamp="2021-01-25T19:55:56Z" changeset="98142123" uid="3341588" user="Heliotrope">
+    <tag k="addr:city" v="Београд"/>
+    <tag k="addr:postcode" v="11000"/>
+    <tag k="addr:street" v="Чумићева"/>
+    <tag k="contact:instagram" v="https://www.instagram.com/makart_store/"/>
+    <tag k="delivery" v="yes"/>
+    <tag k="email" v="makart@makart.rs"/>
+    <tag k="name" v="Makart"/>
+    <tag k="opening_hours" v="Mo-Fr 10:00-20:00; Sa 10:00-16:00"/>
+    <tag k="phone" v="+381 60 0501567"/>
+    <tag k="shop" v="books"/>
+    <tag k="website" v="https://www.makart.rs/"/>
+  </node>
+  <node id="8429980311" lat="44.8027356" lon="20.4657329" version="1" timestamp="2021-02-16T21:37:22Z" changeset="99406662" uid="10427003" user="Savo25656"/>
+  <node id="8483716856" lat="44.8130532" lon="20.4609829" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716857" lat="44.8128017" lon="20.4611266" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716858" lat="44.8124518" lon="20.4613141" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716859" lat="44.8027625" lon="20.4660524" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716860" lat="44.8031321" lon="20.4663239" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716861" lat="44.8031671" lon="20.4663052" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716862" lat="44.8037952" lon="20.4659864" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716863" lat="44.8038145" lon="20.4659744" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716864" lat="44.8048575" lon="20.4654493" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716865" lat="44.8057970" lon="20.4649473" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716866" lat="44.8066635" lon="20.4644668" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716867" lat="44.8067415" lon="20.4644296" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716868" lat="44.8081107" lon="20.4636950" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716869" lat="44.8084077" lon="20.4634304" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716870" lat="44.8097921" lon="20.4627815" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716871" lat="44.8104596" lon="20.4624243" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716872" lat="44.8109800" lon="20.4621518" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716873" lat="44.8117155" lon="20.4617798" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716875" lat="44.8130922" lon="20.4610033" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716876" lat="44.8136421" lon="20.4606809" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716877" lat="44.8136516" lon="20.4607090" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716878" lat="44.8140662" lon="20.4605154" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716879" lat="44.8143149" lon="20.4604247" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483716880" lat="44.8168146" lon="20.4601490" version="1" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic"/>
+  <node id="8483762987" lat="44.8126394" lon="20.4612400" version="1" timestamp="2021-03-03T19:32:00Z" changeset="100371774" uid="12771584" user="pPetrovic"/>
+  <node id="8483780822" lat="44.8122420" lon="20.4613731" version="1" timestamp="2021-03-03T19:32:00Z" changeset="100371774" uid="12771584" user="pPetrovic"/>
+  <node id="8483780823" lat="44.8126066" lon="20.4612311" version="1" timestamp="2021-03-03T19:32:00Z" changeset="100371774" uid="12771584" user="pPetrovic"/>
+  <node id="8483780828" lat="44.8124240" lon="20.4613526" version="1" timestamp="2021-03-03T19:32:00Z" changeset="100371774" uid="12771584" user="pPetrovic"/>
+  <node id="8485784701" lat="44.8123071" lon="20.4613441" version="1" timestamp="2021-03-04T11:35:58Z" changeset="100419123" uid="12771584" user="pPetrovic"/>
+  <node id="8485784703" lat="44.8122825" lon="20.4614266" version="1" timestamp="2021-03-04T11:35:58Z" changeset="100419123" uid="12771584" user="pPetrovic"/>
+  <node id="8490384564" lat="44.8121414" lon="20.4615003" version="1" timestamp="2021-03-05T22:32:09Z" changeset="100517068" uid="6225925" user="Aleksa Marinski"/>
+  <way id="23073170" version="25" timestamp="2020-10-23T07:46:43Z" changeset="92935074" uid="875800" user="Komadinovic Vanja">
+    <nd ref="249342979"/>
+    <nd ref="256769331"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="3"/>
+    <tag k="lanes:backward" v="1"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="name" v="Дечанска"/>
+    <tag k="name:en" v="Decanska"/>
+    <tag k="name:etymology:wikidata" v="Q939112;Q849517"/>
+    <tag k="name:sr" v="Дечанска"/>
+    <tag k="name:sr-Latn" v="Dečanska"/>
+    <tag k="old_name" v="Моше Пијаде"/>
+    <tag k="old_name:sr" v="Моше Пијаде"/>
+    <tag k="old_name:sr-Latn" v="Moše Pijade"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="turn:lanes:backward" v="through"/>
+    <tag k="turn:lanes:forward" v="through|through"/>
+    <tag k="wikidata" v="Q61133766"/>
+    <tag k="wikipedia" v="sr:Улица Дечанска (Београд)"/>
+  </way>
+  <way id="23073175" version="17" timestamp="2020-08-27T13:44:01Z" changeset="90030820" uid="6225925" user="Aleksa Marinski">
+    <nd ref="249024633"/>
+    <nd ref="6763999291"/>
+    <nd ref="249024494"/>
+    <nd ref="4938899494"/>
+    <nd ref="3961392921"/>
+    <nd ref="249024495"/>
+    <nd ref="3961392922"/>
+    <nd ref="249024491"/>
+    <nd ref="3961392923"/>
+    <nd ref="5303620707"/>
+    <nd ref="249024413"/>
+    <nd ref="5303620708"/>
+    <nd ref="249024418"/>
+    <nd ref="6536028486"/>
+    <nd ref="249024695"/>
+    <nd ref="6536028485"/>
+    <nd ref="249024633"/>
+    <tag k="int_name" v="Plato dr Zorana Djindjica"/>
+    <tag k="leisure" v="park"/>
+    <tag k="name" v="Плато др Зорана Ђинђића"/>
+    <tag k="name:en" v="Dr Zoran Djindjić Plateau"/>
+    <tag k="name:etymology:wikidata" v="Q157131"/>
+    <tag k="name:sr" v="Плато др Зорана Ђинђића"/>
+    <tag k="name:sr-Latn" v="Plato dr Zorana Đinđića"/>
+  </way>
+  <way id="23098073" version="25" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski">
+    <nd ref="249342979"/>
+    <nd ref="6363316632"/>
+    <nd ref="249343033"/>
+    <nd ref="1963120010"/>
+    <nd ref="249343037"/>
+    <nd ref="1744761051"/>
+    <nd ref="583586885"/>
+    <tag k="highway" v="tertiary"/>
+    <tag k="lanes" v="2"/>
+    <tag k="name" v="Нушићева"/>
+    <tag k="name:en" v="Nusiceva"/>
+    <tag k="name:etymology:wikidata" v="Q315136"/>
+    <tag k="name:sr" v="Нушићева"/>
+    <tag k="name:sr-Latn" v="Nušićeva"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="wikidata" v="Q61133754"/>
+    <tag k="wikipedia" v="sr:Улица Нушићева (Београд)"/>
+  </way>
+  <way id="23168079" version="9" timestamp="2016-02-12T09:23:44Z" changeset="37163693" uid="2886645" user="nikicam">
+    <nd ref="1806315552"/>
+    <nd ref="4002208527"/>
+    <nd ref="3966888347"/>
+    <nd ref="1806315520"/>
+    <nd ref="1806315530"/>
+    <nd ref="1806315532"/>
+    <nd ref="1806315534"/>
+    <nd ref="1806315546"/>
+    <nd ref="1806315542"/>
+    <nd ref="1806315556"/>
+    <nd ref="1806315552"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="23671224" version="39" timestamp="2020-10-23T07:48:27Z" changeset="92935074" uid="875800" user="Komadinovic Vanja">
+    <nd ref="5761790605"/>
+    <nd ref="486262465"/>
+    <nd ref="248917064"/>
+    <nd ref="506297363"/>
+    <nd ref="488443811"/>
+    <nd ref="506297358"/>
+    <nd ref="501541433"/>
+    <nd ref="506297385"/>
+    <nd ref="1119932696"/>
+    <nd ref="248917515"/>
+    <nd ref="5761790614"/>
+    <nd ref="6071746090"/>
+    <nd ref="504918667"/>
+    <tag k="alt_name" v="Кнез Михаилова"/>
+    <tag k="alt_name:sr" v="Кнез Михаилова"/>
+    <tag k="alt_name:sr-Latn" v="Knez Mihailova"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="highway" v="pedestrian"/>
+    <tag k="maxweight" v="3.5"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+    <tag k="name" v="Кнеза Михаила"/>
+    <tag k="name:en" v="Kneza Mihaila"/>
+    <tag k="name:etymology:wikidata" v="Q434252"/>
+    <tag k="name:ru" v="Улица князя Михаила"/>
+    <tag k="name:sr" v="Кнеза Михаила"/>
+    <tag k="name:sr-Latn" v="Kneza Mihaila"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="wikidata" v="Q1420986"/>
+    <tag k="wikipedia" v="sr:Кнез Михаилова (улица у Београду)"/>
+  </way>
+  <way id="23672600" version="32" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski">
+    <nd ref="256368843"/>
+    <nd ref="249342979"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="name" v="Нушићева"/>
+    <tag k="name:en" v="Nusiceva"/>
+    <tag k="name:etymology:wikidata" v="Q315136"/>
+    <tag k="name:sr" v="Нушићева"/>
+    <tag k="name:sr-Latn" v="Nušićeva"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="wikidata" v="Q61133754"/>
+    <tag k="wikipedia" v="sr:Улица Нушићева (Београд)"/>
+  </way>
+  <way id="23672605" version="25" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="256222810"/>
+    <nd ref="6363316651"/>
+    <nd ref="6363316639"/>
+    <nd ref="6363316618"/>
+    <nd ref="6363316615"/>
+    <nd ref="6363316641"/>
+    <nd ref="6363316613"/>
+    <nd ref="6363316626"/>
+    <nd ref="6363316643"/>
+    <nd ref="6363316623"/>
+    <nd ref="256368843"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="layer" v="-1"/>
+    <tag k="maxheight" v="4.2"/>
+    <tag k="maxspeed" v="50"/>
+    <tag k="name" v="Теразијски тунел"/>
+    <tag k="name:en" v="Terazije Tunnel"/>
+    <tag k="name:etymology:wikidata" v="Q948346"/>
+    <tag k="name:sr" v="Теразијски тунел"/>
+    <tag k="name:sr-Latn" v="Terazijski tunel"/>
+    <tag k="oneway" v="no"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="23672662" version="27" timestamp="2020-10-16T08:27:37Z" changeset="92568621" uid="9026132" user="PulisakZ">
+    <nd ref="256769331"/>
+    <nd ref="6363316634"/>
+    <nd ref="256769332"/>
+    <nd ref="6363316630"/>
+    <nd ref="6363316598"/>
+    <nd ref="6363316597"/>
+    <nd ref="256769333"/>
+    <nd ref="6363316637"/>
+    <nd ref="256769334"/>
+    <nd ref="256368843"/>
+    <tag k="destination:street" v="Теразијски тунел"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary_link"/>
+    <tag k="lanes" v="2"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="placement" v="left_of:1"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="turn:lanes" v="right|right"/>
+  </way>
+  <way id="23712727" version="23" timestamp="2019-03-26T19:08:42Z" changeset="68559829" uid="5569366" user="TXBG">
+    <nd ref="256368843"/>
+    <nd ref="6363316656"/>
+    <nd ref="6363316648"/>
+    <nd ref="1145306367"/>
+    <nd ref="6363316619"/>
+    <nd ref="256222808"/>
+    <nd ref="2934858754"/>
+    <nd ref="6051047716"/>
+    <nd ref="319621245"/>
+    <tag k="destination:street" v="Дечанска"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary_link"/>
+    <tag k="lanes" v="1"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="23791841" version="14" timestamp="2021-02-23T12:23:28Z" changeset="99825856" uid="733709" user="dizajnmario">
+    <nd ref="257802664"/>
+    <nd ref="3966888348"/>
+    <nd ref="504918685"/>
+    <nd ref="504918667"/>
+    <nd ref="2934913745"/>
+    <nd ref="7526375193"/>
+    <nd ref="2934913746"/>
+    <tag k="highway" v="pedestrian"/>
+    <tag k="name" v="Сремска"/>
+    <tag k="name:en" v="Sremska"/>
+    <tag k="name:etymology:wikidata" v="Q1309492"/>
+    <tag k="name:sr" v="Сремска"/>
+    <tag k="name:sr-Latn" v="Sremska"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="29058771" version="19" timestamp="2020-10-25T11:25:38Z" changeset="93013195" uid="875800" user="Komadinovic Vanja">
+    <nd ref="6051047716"/>
+    <nd ref="5177170804"/>
+    <nd ref="319621282"/>
+    <nd ref="6244650663"/>
+    <nd ref="6244650664"/>
+    <nd ref="503894446"/>
+    <tag k="highway" v="residential"/>
+    <tag k="name" v="Нушићева"/>
+    <tag k="name:en" v="Nusiceva"/>
+    <tag k="name:etymology:wikidata" v="Q315136"/>
+    <tag k="name:sr" v="Нушићева"/>
+    <tag k="name:sr-Latn" v="Nušićeva"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="wikidata" v="Q61133754"/>
+    <tag k="wikipedia" v="sr:Улица Нушићева (Београд)"/>
+  </way>
+  <way id="38539629" version="8" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn">
+    <nd ref="5156751149"/>
+    <nd ref="5156751148"/>
+    <nd ref="5156751147"/>
+    <nd ref="5156751146"/>
+    <nd ref="3966915788"/>
+    <nd ref="5156751145"/>
+    <nd ref="456123317"/>
+    <nd ref="5156751167"/>
+    <nd ref="5156751168"/>
+    <nd ref="7526375191"/>
+    <nd ref="7526375190"/>
+    <nd ref="5156751169"/>
+    <nd ref="5156751170"/>
+    <nd ref="5156751149"/>
+    <tag k="addr:housenumber" v="2"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="38539631" version="5" timestamp="2018-09-14T21:38:01Z" changeset="62596780" uid="5715884" user="ncncdk">
+    <nd ref="456123337"/>
+    <nd ref="456123338"/>
+    <nd ref="2994328344"/>
+    <nd ref="4002208526"/>
+    <nd ref="2994328348"/>
+    <nd ref="456123342"/>
+    <nd ref="2994328342"/>
+    <nd ref="456123337"/>
+    <tag k="addr:housenumber" v="10"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="office"/>
+  </way>
+  <way id="41202284" version="30" timestamp="2020-11-02T07:09:22Z" changeset="93399285" uid="9026132" user="PulisakZ">
+    <nd ref="1677964946"/>
+    <nd ref="8012487022"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="5"/>
+    <tag k="lanes:backward" v="3"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="name" v="Дечанска"/>
+    <tag k="name:en" v="Decanska"/>
+    <tag k="name:etymology:wikidata" v="Q939112;Q849517"/>
+    <tag k="name:sr" v="Дечанска"/>
+    <tag k="name:sr-Latn" v="Dečanska"/>
+    <tag k="old_name" v="Моше Пијаде"/>
+    <tag k="old_name:sr" v="Моше Пијаде"/>
+    <tag k="old_name:sr-Latn" v="Moše Pijade"/>
+    <tag k="placement:backward" v="left_of:1"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="turn:lanes:backward" v="through|right|right"/>
+    <tag k="turn:lanes:forward" v="through|through"/>
+    <tag k="wikidata" v="Q61133766"/>
+    <tag k="wikipedia" v="sr:Улица Дечанска (Београд)"/>
+  </way>
+  <way id="41234985" version="16" timestamp="2019-12-19T12:32:01Z" changeset="78637023" uid="875800" user="Komadinovic Vanja">
+    <nd ref="5024979832"/>
+    <nd ref="503888394"/>
+    <nd ref="3964043131"/>
+    <nd ref="1629299613"/>
+    <nd ref="1629299612"/>
+    <nd ref="503888396"/>
+    <nd ref="1629299611"/>
+    <nd ref="5024979831"/>
+    <nd ref="5024979832"/>
+    <tag k="addr:housenumber" v="22/IV"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="amenity" v="arts_centre"/>
+    <tag k="building" v="yes"/>
+    <tag k="building:levels" v="13"/>
+    <tag k="name" v="Дом омладине Београда"/>
+    <tag k="name:en" v="Belgrade Youth Center"/>
+    <tag k="name:sr" v="Дом омладине Београда"/>
+    <tag k="name:sr-Latn" v="Dom omladine Beograda"/>
+    <tag k="name:uk" v="Белградський Будинок Молоді"/>
+    <tag k="website" v="http://www.domomladine.org"/>
+    <tag k="wikidata" v="Q4882656"/>
+    <tag k="wikipedia" v="en:Belgrade Youth Center"/>
+  </way>
+  <way id="41235012" version="11" timestamp="2020-04-05T15:09:30Z" changeset="83102173" uid="95504" user="Branko Kokanovic">
+    <nd ref="5177170847"/>
+    <nd ref="506286707"/>
+    <nd ref="506286708"/>
+    <nd ref="503889005"/>
+    <nd ref="506287630"/>
+    <nd ref="5177170847"/>
+    <nd ref="5177170848"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="name" v="Пешачки пролаз Нушићева"/>
+    <tag k="name:etymology:wikidata" v="Q315136"/>
+    <tag k="name:sr" v="Пешачки пролаз Нушићева"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Nušićeva"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41235013" version="3" timestamp="2019-03-11T17:41:24Z" changeset="68031673" uid="9414390" user="Gr8fulDead">
+    <nd ref="5177170848"/>
+    <nd ref="503889009"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="layer" v="-1"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41235014" version="4" timestamp="2019-09-20T08:27:05Z" changeset="74708984" uid="3733993" user="Aleksandar1994">
+    <nd ref="503889012"/>
+    <nd ref="506286705"/>
+    <nd ref="503889013"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41235015" version="2" timestamp="2019-03-11T17:41:25Z" changeset="68031673" uid="9414390" user="Gr8fulDead">
+    <nd ref="503889013"/>
+    <nd ref="503889015"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="layer" v="-1"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41235016" version="3" timestamp="2019-03-11T17:41:25Z" changeset="68031673" uid="9414390" user="Gr8fulDead">
+    <nd ref="503889017"/>
+    <nd ref="503889018"/>
+    <tag k="foot" v="yes"/>
+    <tag k="handrail" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="layer" v="-1"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41235017" version="5" timestamp="2019-08-19T12:36:48Z" changeset="73495952" uid="6225925" user="Aleksa Marinski">
+    <nd ref="503889005"/>
+    <nd ref="503889025"/>
+    <tag k="conveying" v="forward"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="layer" v="-1"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41235018" version="3" timestamp="2019-03-11T17:41:25Z" changeset="68031673" uid="9414390" user="Gr8fulDead">
+    <nd ref="503889027"/>
+    <nd ref="503889012"/>
+    <tag k="foot" v="yes"/>
+    <tag k="handrail" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="layer" v="-1"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41235020" version="6" timestamp="2020-04-05T15:09:30Z" changeset="83102173" uid="95504" user="Branko Kokanovic">
+    <nd ref="506286707"/>
+    <nd ref="503889032"/>
+    <nd ref="503889017"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="name" v="Пешачки пролаз Нушићева"/>
+    <tag k="name:etymology:wikidata" v="Q315136"/>
+    <tag k="name:sr" v="Пешачки пролаз Нушићева"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Nušićeva"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41235239" version="4" timestamp="2021-03-26T16:26:29Z" changeset="101804016" uid="733709" user="dizajnmario">
+    <nd ref="6463896387"/>
+    <nd ref="503894443"/>
+    <nd ref="503894441"/>
+    <tag k="highway" v="footway"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="41235240" version="4" timestamp="2019-03-28T20:58:53Z" changeset="68643598" uid="6980194" user="mama_bear">
+    <nd ref="6336366328"/>
+    <nd ref="503894444"/>
+    <nd ref="5177170842"/>
+    <nd ref="503894445"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="service"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="41235241" version="12" timestamp="2021-01-25T19:55:56Z" changeset="98142123" uid="3341588" user="Heliotrope">
+    <nd ref="503894446"/>
+    <nd ref="503894447"/>
+    <nd ref="3963849238"/>
+    <nd ref="503894448"/>
+    <nd ref="7923465263"/>
+    <tag k="alt_name:sr" v="Чумићево сокаче"/>
+    <tag k="alt_name:sr-Latn" v="Čumićevo sokače"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="1"/>
+    <tag k="name" v="Чумићева"/>
+    <tag k="name:etymology:wikidata" v="Q12748620"/>
+    <tag k="name:sr" v="Чумићева"/>
+    <tag k="name:sr-Latn" v="Čumićeva"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="41235242" version="3" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario">
+    <nd ref="503894448"/>
+    <nd ref="7843762725"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="41241567" version="22" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="257726631"/>
+    <nd ref="2934914881"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="2"/>
+    <tag k="lanes:psv" v="1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed:type" v="RS:urban"/>
+    <tag k="name" v="Теразије"/>
+    <tag k="name:en" v="Terazije"/>
+    <tag k="name:etymology:wikidata" v="Q274153"/>
+    <tag k="name:sr" v="Теразије"/>
+    <tag k="name:sr-Latn" v="Terazije"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="41292456" version="1" timestamp="2009-09-22T07:45:56Z" changeset="2566044" uid="168004" user="Nikola Smolenski">
+    <nd ref="504918664"/>
+    <nd ref="504918665"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="steps"/>
+  </way>
+  <way id="41292457" version="7" timestamp="2021-02-27T22:55:06Z" changeset="100118843" uid="733709" user="dizajnmario">
+    <nd ref="504918666"/>
+    <nd ref="506294587"/>
+    <nd ref="506294588"/>
+    <nd ref="504918667"/>
+    <tag k="foot" v="yes"/>
+    <tag k="handrail" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="incline" v="up"/>
+    <tag k="lit" v="yes"/>
+    <tag k="ramp" v="no"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="41292458" version="9" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="504918668"/>
+    <nd ref="504918669"/>
+    <nd ref="506294586"/>
+    <nd ref="504918666"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="name" v="Пешачки пролаз Албанија"/>
+    <tag k="name:etymology:wikidata" v="Q1278189"/>
+    <tag k="name:sr" v="Пешачки пролаз Албанија"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Albanija"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41292459" version="5" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn">
+    <nd ref="456123325"/>
+    <nd ref="7526375190"/>
+    <nd ref="504918671"/>
+    <nd ref="504918672"/>
+    <nd ref="7526375191"/>
+    <nd ref="4785337761"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="steps"/>
+  </way>
+  <way id="41292460" version="4" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina">
+    <nd ref="6487824765"/>
+    <nd ref="504918675"/>
+    <nd ref="6487824766"/>
+    <tag k="highway" v="footway"/>
+    <tag k="tunnel" v="building_passage"/>
+  </way>
+  <way id="41292461" version="10" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="504918677"/>
+    <nd ref="504918678"/>
+    <nd ref="504918679"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="name" v="Пешачки пролаз Албанија"/>
+    <tag k="name:etymology:wikidata" v="Q1278189"/>
+    <tag k="name:sr" v="Пешачки пролаз Албанија"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Albanija"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41292463" version="4" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina">
+    <nd ref="504918679"/>
+    <nd ref="504918674"/>
+    <nd ref="6487824765"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+  </way>
+  <way id="41292464" version="3" timestamp="2021-03-26T16:26:29Z" changeset="101804016" uid="733709" user="dizajnmario">
+    <nd ref="504918682"/>
+    <nd ref="504918683"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="tunnel" v="building_passage"/>
+  </way>
+  <way id="41292465" version="8" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="504918665"/>
+    <nd ref="6487824761"/>
+    <nd ref="6487824762"/>
+    <nd ref="5179720383"/>
+    <nd ref="504918682"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="name" v="Пешачки пролаз Албанија"/>
+    <tag k="name:etymology:wikidata" v="Q1278189"/>
+    <tag k="name:sr" v="Пешачки пролаз Албанија"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Albanija"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41292466" version="2" timestamp="2019-09-20T08:29:06Z" changeset="74709035" uid="3733993" user="Aleksandar1994">
+    <nd ref="503894450"/>
+    <nd ref="504918664"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="41292469" version="8" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="504918669"/>
+    <nd ref="504918677"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="name" v="Пешачки пролаз Албанија"/>
+    <tag k="name:etymology:wikidata" v="Q1278189"/>
+    <tag k="name:sr" v="Пешачки пролаз Албанија"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Albanija"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41396093" version="2" timestamp="2019-03-11T17:41:25Z" changeset="68031673" uid="9414390" user="Gr8fulDead">
+    <nd ref="506286708"/>
+    <nd ref="506286705"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="layer" v="-1"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41397455" version="8" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="456123325"/>
+    <nd ref="506294581"/>
+    <nd ref="504918668"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="name" v="Пешачки пролаз Албанија"/>
+    <tag k="name:etymology:wikidata" v="Q1278189"/>
+    <tag k="name:sr" v="Пешачки пролаз Албанија"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Albanija"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41397457" version="8" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="504918677"/>
+    <nd ref="456123325"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="name" v="Пешачки пролаз Албанија"/>
+    <tag k="name:etymology:wikidata" v="Q1278189"/>
+    <tag k="name:sr" v="Пешачки пролаз Албанија"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Albanija"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41397458" version="8" timestamp="2019-04-14T13:02:13Z" changeset="69201798" uid="6225925" user="Aleksa Marinski">
+    <nd ref="2934914881"/>
+    <nd ref="6404076786"/>
+    <nd ref="6357050988"/>
+    <nd ref="6404076887"/>
+    <nd ref="506294583"/>
+    <nd ref="6404069988"/>
+    <nd ref="2934914879"/>
+    <nd ref="6404069987"/>
+    <nd ref="6404076885"/>
+    <nd ref="2934914880"/>
+    <nd ref="6404076886"/>
+    <nd ref="249027867"/>
+    <tag k="access" v="psv"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="service"/>
+    <tag k="oneway" v="yes"/>
+  </way>
+  <way id="41397519" version="8" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="504918679"/>
+    <nd ref="506295156"/>
+    <nd ref="5179720383"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="name" v="Пешачки пролаз Албанија"/>
+    <tag k="name:etymology:wikidata" v="Q1278189"/>
+    <tag k="name:sr" v="Пешачки пролаз Албанија"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Albanija"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="41397520" version="9" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5179720383"/>
+    <nd ref="504918666"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="name" v="Пешачки пролаз Албанија"/>
+    <tag k="name:etymology:wikidata" v="Q1278189"/>
+    <tag k="name:sr" v="Пешачки пролаз Албанија"/>
+    <tag k="name:sr-Latn" v="Pešački prolaz Albanija"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="60746887" version="12" timestamp="2020-10-29T10:36:35Z" changeset="93230281" uid="6225925" user="Aleksa Marinski">
+    <nd ref="3962695759"/>
+    <nd ref="3962695752"/>
+    <nd ref="760422969"/>
+    <nd ref="3962695751"/>
+    <nd ref="8062285633"/>
+    <nd ref="760422970"/>
+    <nd ref="8062285632"/>
+    <nd ref="760422971"/>
+    <nd ref="760422972"/>
+    <nd ref="1309564697"/>
+    <nd ref="3974463433"/>
+    <nd ref="760422974"/>
+    <nd ref="3974463432"/>
+    <nd ref="3961392924"/>
+    <nd ref="3962695759"/>
+    <tag k="addr:housenumber" v="5"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="retail"/>
+    <tag k="loc_name" v="ТЦ Стакленац"/>
+    <tag k="loc_name:sr" v="ТЦ Стакленац"/>
+    <tag k="loc_name:sr-Latn" v="TC Staklenac"/>
+    <tag k="name" v="ТЦ Трг републике"/>
+    <tag k="name:sr" v="ТЦ Трг републике"/>
+    <tag k="name:sr-Latn" v="TC Trg republike"/>
+    <tag k="opening_hours" v="Mo-Su 09:00-21:00"/>
+    <tag k="shop" v="mall"/>
+    <tag k="website" v="http://www.staklenac.rs/"/>
+  </way>
+  <way id="90624667" version="8" timestamp="2021-03-24T15:20:20Z" changeset="101657830" uid="733709" user="dizajnmario">
+    <nd ref="5179724969"/>
+    <nd ref="760425380"/>
+    <nd ref="5179724926"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="96940977" version="4" timestamp="2021-03-24T15:20:03Z" changeset="101657815" uid="733709" user="dizajnmario">
+    <nd ref="1123392495"/>
+    <nd ref="1123392489"/>
+    <nd ref="1123392492"/>
+    <nd ref="1123392494"/>
+    <nd ref="1123392493"/>
+    <nd ref="1123392495"/>
+    <tag k="addr:housenumber" v="3"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="building" v="office"/>
+  </way>
+  <way id="96940978" version="7" timestamp="2019-09-19T10:16:26Z" changeset="74664132" uid="6225925" user="Aleksa Marinski">
+    <nd ref="1123392471"/>
+    <nd ref="1123392505"/>
+    <nd ref="1123392485"/>
+    <nd ref="1123392488"/>
+    <nd ref="1123392493"/>
+    <nd ref="1123392495"/>
+    <nd ref="1123392504"/>
+    <nd ref="6522159892"/>
+    <nd ref="5702072555"/>
+    <nd ref="1123392487"/>
+    <nd ref="6807583986"/>
+    <nd ref="1123392472"/>
+    <nd ref="5702072554"/>
+    <nd ref="1123392483"/>
+    <nd ref="1123392481"/>
+    <nd ref="1123392471"/>
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="building" v="office"/>
+    <tag k="building:use" v="hotel"/>
+    <tag k="email" v="info@hotelcentar-no1.com"/>
+    <tag k="internet_access" v="wlan"/>
+    <tag k="name" v="Гарни хотел Центар №1"/>
+    <tag k="name:en" v="Garni Hotel Centar №1"/>
+    <tag k="name:sr" v="Гарни хотел Центар №1"/>
+    <tag k="name:sr-Latn" v="Garni hotel Centar №1"/>
+    <tag k="phone" v="+381 11 4024000"/>
+    <tag k="rooms" v="68"/>
+    <tag k="stars" v="4"/>
+    <tag k="tourism" v="hotel"/>
+    <tag k="website" v="https://hotelcentar-no1.com/"/>
+  </way>
+  <way id="96940979" version="3" timestamp="2019-09-03T17:55:08Z" changeset="74053168" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="1123392496"/>
+    <nd ref="1123392489"/>
+    <nd ref="1123392502"/>
+    <nd ref="1123392469"/>
+    <nd ref="1123392496"/>
+    <tag k="addr:housenumber" v="5"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="96940981" version="2" timestamp="2021-02-26T09:32:55Z" changeset="100037332" uid="733709" user="dizajnmario">
+    <nd ref="1123392481"/>
+    <nd ref="1123392486"/>
+    <nd ref="1123392491"/>
+    <nd ref="1123392471"/>
+    <nd ref="1123392481"/>
+    <tag k="addr:housenumber" v="4"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="office"/>
+  </way>
+  <way id="96941233" version="3" timestamp="2017-02-01T13:37:55Z" changeset="45716879" uid="4785399" user="PhaMer">
+    <nd ref="1123395388"/>
+    <nd ref="1123395384"/>
+    <nd ref="1123395383"/>
+    <nd ref="3963864358"/>
+    <nd ref="1123395374"/>
+    <nd ref="1123395375"/>
+    <nd ref="1123395388"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="96941236" version="4" timestamp="2019-05-21T11:07:19Z" changeset="70473867" uid="3207276" user="Armin Gheorghina">
+    <nd ref="1123392496"/>
+    <nd ref="6472254613"/>
+    <nd ref="6472254614"/>
+    <nd ref="1123395387"/>
+    <nd ref="1123395389"/>
+    <nd ref="6487824762"/>
+    <nd ref="6487824764"/>
+    <nd ref="1123395381"/>
+    <nd ref="1123395390"/>
+    <nd ref="6487824763"/>
+    <nd ref="6487824761"/>
+    <nd ref="1123395382"/>
+    <nd ref="1123395386"/>
+    <nd ref="504918665"/>
+    <nd ref="6472254615"/>
+    <nd ref="1123395374"/>
+    <nd ref="1123395375"/>
+    <nd ref="1123395380"/>
+    <nd ref="1123395379"/>
+    <nd ref="1123392469"/>
+    <nd ref="1123392496"/>
+    <tag k="addr:housenumber" v="7"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="98993994" version="12" timestamp="2019-03-13T22:14:30Z" changeset="68116571" uid="8759590" user="daFisch">
+    <nd ref="319621245"/>
+    <nd ref="583586884"/>
+    <tag k="destination:street" v="Дечанска"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary_link"/>
+    <tag k="lanes" v="1"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="155396485" version="26" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic">
+    <nd ref="6338428692"/>
+    <nd ref="3963849241"/>
+    <nd ref="5179720382"/>
+    <nd ref="8483716879"/>
+    <nd ref="257726629"/>
+    <nd ref="6363316629"/>
+    <nd ref="2994328367"/>
+    <nd ref="6363316633"/>
+    <nd ref="2934914885"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="2"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed:type" v="RS:urban"/>
+    <tag k="name" v="Теразије"/>
+    <tag k="name:en" v="Terazije"/>
+    <tag k="name:etymology:wikidata" v="Q274153"/>
+    <tag k="name:sr" v="Теразије"/>
+    <tag k="name:sr-Latn" v="Terazije"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="169469875" version="9" timestamp="2021-02-27T22:54:33Z" changeset="100118827" uid="733709" user="dizajnmario">
+    <nd ref="1806315538"/>
+    <nd ref="250438342"/>
+    <nd ref="250438341"/>
+    <nd ref="3966888345"/>
+    <nd ref="4359064371"/>
+    <nd ref="250438346"/>
+    <nd ref="1806315569"/>
+    <nd ref="1806315574"/>
+    <nd ref="1806315575"/>
+    <nd ref="1806315573"/>
+    <nd ref="1806315572"/>
+    <nd ref="1806315571"/>
+    <nd ref="1806315560"/>
+    <nd ref="1806315558"/>
+    <nd ref="1806315555"/>
+    <nd ref="1806315554"/>
+    <nd ref="1806315553"/>
+    <nd ref="1806315550"/>
+    <nd ref="1806315548"/>
+    <nd ref="1806315544"/>
+    <nd ref="1806315540"/>
+    <nd ref="1806315538"/>
+    <tag k="addr:housenumber" v="6"/>
+    <tag k="addr:street" v="Кнеза Михаила"/>
+    <tag k="building" v="office"/>
+    <tag k="building:levels" v="10"/>
+    <tag k="name" v="Зграда Дома штампе"/>
+    <tag k="name:sr" v="Зграда Дома штампе"/>
+    <tag k="name:sr-Latn" v="Zgrada Doma štampe"/>
+  </way>
+  <way id="169469879" version="4" timestamp="2019-09-03T21:13:46Z" changeset="74058391" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="1806315569"/>
+    <nd ref="1806315552"/>
+    <nd ref="1806315556"/>
+    <nd ref="1806315559"/>
+    <nd ref="1806315574"/>
+    <nd ref="1806315569"/>
+    <tag k="addr:housenumber" v="4"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="169469883" version="14" timestamp="2021-03-26T16:26:24Z" changeset="101802901" uid="733709" user="dizajnmario">
+    <nd ref="1806315538"/>
+    <nd ref="1806315540"/>
+    <nd ref="4461639868"/>
+    <nd ref="1806315536"/>
+    <nd ref="1806315518"/>
+    <nd ref="1806315519"/>
+    <nd ref="1806315530"/>
+    <nd ref="1806315520"/>
+    <nd ref="5156751166"/>
+    <nd ref="4461639870"/>
+    <nd ref="5156751165"/>
+    <nd ref="4461639871"/>
+    <nd ref="250438343"/>
+    <nd ref="3966888346"/>
+    <nd ref="1806315538"/>
+    <tag k="addr:housenumber" v="2"/>
+    <tag k="addr:street" v="Кнеза Михаила"/>
+    <tag k="alt_name" v="Палата Албанија"/>
+    <tag k="alt_name:sr" v="Палата Албанија"/>
+    <tag k="alt_name:sr-Latn" v="Palata Albanija"/>
+    <tag k="building" v="office"/>
+    <tag k="building:levels" v="13"/>
+    <tag k="colour" v="gray"/>
+    <tag k="height" v="53"/>
+    <tag k="name" v="Палата „Албанија“"/>
+    <tag k="name:en" v="Albania Palace"/>
+    <tag k="name:sr" v="Палата „Албанија“"/>
+    <tag k="name:sr-Latn" v="Palata „Albanija“"/>
+    <tag k="roof:colour" v="grey"/>
+    <tag k="roof:shape" v="flat"/>
+    <tag k="start_date" v="1940"/>
+    <tag k="wikidata" v="Q1278189"/>
+    <tag k="wikipedia" v="sr:Палата Албанија"/>
+  </way>
+  <way id="195576449" version="16" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <nd ref="249024039"/>
+    <nd ref="5177170838"/>
+    <nd ref="8222814377"/>
+    <nd ref="6336272374"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:psv:backward" v="1"/>
+    <tag k="name" v="Браће Југовића"/>
+    <tag k="name:en" v="Brace Jugovica"/>
+    <tag k="name:etymology:wikidata" v="Q12750730"/>
+    <tag k="name:sr" v="Браће Југовића"/>
+    <tag k="name:sr-Latn" v="Braće Jugovića"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="217865694" version="4" timestamp="2020-01-14T23:34:22Z" changeset="79585872" uid="7009309" user="Mengesh">
+    <nd ref="319621282"/>
+    <nd ref="5289996160"/>
+    <nd ref="503889025"/>
+    <tag k="highway" v="footway"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="230065295" version="8" timestamp="2020-10-29T08:51:31Z" changeset="93222631" uid="875800" user="Komadinovic Vanja">
+    <nd ref="583586884"/>
+    <nd ref="249342979"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:backward" v="1"/>
+    <tag k="lanes:forward" v="3"/>
+    <tag k="name" v="Дечанска"/>
+    <tag k="name:en" v="Decanska"/>
+    <tag k="name:etymology:wikidata" v="Q939112;Q849517"/>
+    <tag k="name:sr" v="Дечанска"/>
+    <tag k="name:sr-Latn" v="Dečanska"/>
+    <tag k="old_name" v="Моше Пијаде"/>
+    <tag k="old_name:sr" v="Моше Пијаде"/>
+    <tag k="old_name:sr-Latn" v="Moše Pijade"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="turn:lanes:forward" v="left|left|through;right"/>
+    <tag k="wikidata" v="Q61133766"/>
+    <tag k="wikipedia" v="sr:Улица Дечанска (Београд)"/>
+  </way>
+  <way id="289959026" version="10" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="2934914885"/>
+    <nd ref="6357050689"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="2"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed:type" v="RS:urban"/>
+    <tag k="name" v="Теразије"/>
+    <tag k="name:en" v="Terazije"/>
+    <tag k="name:etymology:wikidata" v="Q274153"/>
+    <tag k="name:sr" v="Теразије"/>
+    <tag k="name:sr-Latn" v="Terazije"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="289959028" version="12" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="2934914881"/>
+    <nd ref="2934914883"/>
+    <nd ref="506294580"/>
+    <nd ref="249027867"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="2"/>
+    <tag k="lanes:psv" v="1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed:type" v="RS:urban"/>
+    <tag k="name" v="Теразије"/>
+    <tag k="name:en" v="Terazije"/>
+    <tag k="name:etymology:wikidata" v="Q274153"/>
+    <tag k="name:sr" v="Теразије"/>
+    <tag k="name:sr-Latn" v="Terazije"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="289959030" version="16" timestamp="2020-08-04T21:08:10Z" changeset="88948478" uid="6225925" user="Aleksa Marinski">
+    <nd ref="257726631"/>
+    <nd ref="5179720381"/>
+    <nd ref="5465460771"/>
+    <nd ref="2934914900"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:psv:backward" v="1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed:type" v="RS:urban"/>
+    <tag k="name" v="Коларчева"/>
+    <tag k="name:en" v="Kolarceva"/>
+    <tag k="name:etymology:wikidata" v="Q3148669"/>
+    <tag k="name:sr" v="Коларчева"/>
+    <tag k="name:sr-Latn" v="Kolarčeva"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="295686319" version="2" timestamp="2016-02-12T09:23:44Z" changeset="37163693" uid="2886645" user="nikicam">
+    <nd ref="2994328344"/>
+    <nd ref="4002208526"/>
+    <nd ref="2994328346"/>
+    <nd ref="2994328345"/>
+    <nd ref="2994328343"/>
+    <nd ref="2994328344"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="295686324" version="3" timestamp="2019-09-03T21:08:46Z" changeset="74058293" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="2994328363"/>
+    <nd ref="2994328358"/>
+    <nd ref="2994328360"/>
+    <nd ref="2994328357"/>
+    <nd ref="2994328362"/>
+    <nd ref="2994328365"/>
+    <nd ref="2994328363"/>
+    <tag k="addr:housenumber" v="6"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="295686325" version="3" timestamp="2017-10-09T10:09:35Z" changeset="52754474" uid="6225925" user="Aleksa Marinski">
+    <nd ref="456123317"/>
+    <nd ref="2994328361"/>
+    <nd ref="2994328363"/>
+    <nd ref="2994328365"/>
+    <nd ref="5156751167"/>
+    <nd ref="456123317"/>
+    <tag k="addr:housenumber" v="4"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="295686327" version="6" timestamp="2020-10-29T08:56:51Z" changeset="93222631" uid="875800" user="Komadinovic Vanja">
+    <nd ref="2994328362"/>
+    <nd ref="2994328348"/>
+    <nd ref="4002208526"/>
+    <nd ref="2994328346"/>
+    <nd ref="2994328349"/>
+    <nd ref="2994328347"/>
+    <nd ref="2994328355"/>
+    <nd ref="2994328357"/>
+    <nd ref="2994328362"/>
+    <tag k="addr:housenumber" v="8"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="yes"/>
+    <tag k="heritage" v="2"/>
+    <tag k="heritage:operator" v="rzzsk"/>
+    <tag k="heritage:ref" v="SK 2229"/>
+    <tag k="name" v="Зграда Хемпро"/>
+    <tag k="name:sr" v="Зграда Хемпро"/>
+    <tag k="name:sr-Latn" v="Zgrada Hempro"/>
+    <tag k="wikidata" v="Q64049210"/>
+    <tag k="wikipedia" v="sr:Зграда Хемпро"/>
+  </way>
+  <way id="392733865" version="3" timestamp="2018-09-14T21:38:03Z" changeset="62596780" uid="5715884" user="ncncdk">
+    <nd ref="3959208061"/>
+    <nd ref="3959208062"/>
+    <nd ref="3959208063"/>
+    <nd ref="3959208064"/>
+    <nd ref="3959208065"/>
+    <nd ref="3959208066"/>
+    <nd ref="3959208061"/>
+    <tag k="addr:housenumber" v="11"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="392733867" version="7" timestamp="2019-09-28T18:28:47Z" changeset="75046301" uid="6225925" user="Aleksa Marinski">
+    <nd ref="3959208062"/>
+    <nd ref="3959208067"/>
+    <nd ref="3959208068"/>
+    <nd ref="3959208069"/>
+    <nd ref="3959208070"/>
+    <nd ref="3959208071"/>
+    <nd ref="3959208072"/>
+    <nd ref="3959208073"/>
+    <nd ref="3959208061"/>
+    <nd ref="3959208062"/>
+    <tag k="addr:housenumber" v="23"/>
+    <tag k="addr:street" v="Браће Југовића"/>
+    <tag k="building" v="apartments"/>
+    <tag k="building:levels" v="5"/>
+  </way>
+  <way id="392739051" version="4" timestamp="2019-09-28T18:28:48Z" changeset="75046301" uid="6225925" user="Aleksa Marinski">
+    <nd ref="3959208071"/>
+    <nd ref="3959247469"/>
+    <nd ref="3959247476"/>
+    <nd ref="3959247471"/>
+    <nd ref="3959247472"/>
+    <nd ref="3959247473"/>
+    <nd ref="3959208072"/>
+    <nd ref="3959208071"/>
+    <tag k="addr:housenumber" v="4"/>
+    <tag k="addr:street" v="Скадарска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="392739052" version="4" timestamp="2019-09-04T22:20:20Z" changeset="74105961" uid="95504" user="Branko Kokanovic">
+    <nd ref="3959247469"/>
+    <nd ref="3959247474"/>
+    <nd ref="3959247475"/>
+    <nd ref="3959247476"/>
+    <nd ref="3959247469"/>
+    <tag k="addr:housenumber" v="6"/>
+    <tag k="addr:street" v="Скадарска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393068153" version="3" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario">
+    <nd ref="3962695738"/>
+    <nd ref="3962695739"/>
+    <nd ref="3962695740"/>
+    <nd ref="7843762724"/>
+    <nd ref="3962695741"/>
+    <nd ref="3962695742"/>
+    <nd ref="3962695743"/>
+    <nd ref="3962695744"/>
+    <nd ref="3963848602"/>
+    <nd ref="3962695745"/>
+    <nd ref="7843762725"/>
+    <nd ref="3962695746"/>
+    <nd ref="3962695738"/>
+    <tag k="addr:housenumber" v="8"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393068157" version="5" timestamp="2018-12-27T23:20:06Z" changeset="65827386" uid="6225925" user="Aleksa Marinski">
+    <nd ref="3962695756"/>
+    <nd ref="3962695758"/>
+    <nd ref="3974463431"/>
+    <nd ref="3961392924"/>
+    <nd ref="3962695759"/>
+    <nd ref="3962695760"/>
+    <nd ref="3962695761"/>
+    <nd ref="3962695756"/>
+    <tag k="building" v="yes"/>
+    <tag k="building:levels" v="2"/>
+  </way>
+  <way id="393068160" version="3" timestamp="2019-09-01T15:37:59Z" changeset="73975935" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3959208063"/>
+    <nd ref="3962695773"/>
+    <nd ref="3962695774"/>
+    <nd ref="3959208064"/>
+    <nd ref="3959208063"/>
+    <tag k="addr:housenumber" v="15"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393068161" version="4" timestamp="2019-09-01T15:37:59Z" changeset="73975935" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3962695773"/>
+    <nd ref="3962695775"/>
+    <nd ref="3962695776"/>
+    <nd ref="3962695777"/>
+    <nd ref="3962695774"/>
+    <nd ref="3962695773"/>
+    <tag k="addr:housenumber" v="17"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393068173" version="4" timestamp="2019-09-01T13:31:40Z" changeset="73973118" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3962695818"/>
+    <nd ref="3964043142"/>
+    <nd ref="3962695822"/>
+    <nd ref="3962695823"/>
+    <nd ref="3962695824"/>
+    <nd ref="3962695825"/>
+    <nd ref="3962695826"/>
+    <nd ref="3962695818"/>
+    <tag k="addr:housenumber" v="7"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393068174" version="4" timestamp="2019-09-01T10:54:19Z" changeset="73970063" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3962695823"/>
+    <nd ref="3962695827"/>
+    <nd ref="3962695828"/>
+    <nd ref="3962695829"/>
+    <nd ref="3962695824"/>
+    <nd ref="3962695823"/>
+    <tag k="addr:housenumber" v="5"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393068175" version="4" timestamp="2016-02-07T11:02:36Z" changeset="37057215" uid="2886645" user="nikicam">
+    <nd ref="3962695827"/>
+    <nd ref="3964043143"/>
+    <nd ref="3962695830"/>
+    <nd ref="1629299611"/>
+    <nd ref="503888396"/>
+    <nd ref="3962695831"/>
+    <nd ref="3962695828"/>
+    <nd ref="3962695827"/>
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169125" version="3" timestamp="2019-05-10T08:51:50Z" changeset="70101044" uid="3207276" user="Armin Gheorghina">
+    <nd ref="1123392486"/>
+    <nd ref="3963848566"/>
+    <nd ref="3963848567"/>
+    <nd ref="3963848568"/>
+    <nd ref="3963848573"/>
+    <nd ref="3963848569"/>
+    <nd ref="6463896387"/>
+    <nd ref="3963848570"/>
+    <nd ref="1123392491"/>
+    <nd ref="1123392486"/>
+    <tag k="addr:housenumber" v="6"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169126" version="2" timestamp="2019-08-17T15:12:49Z" changeset="73445166" uid="6225925" user="Aleksa Marinski">
+    <nd ref="3963848566"/>
+    <nd ref="3963848571"/>
+    <nd ref="3963848572"/>
+    <nd ref="3963848569"/>
+    <nd ref="3963848573"/>
+    <nd ref="3963848574"/>
+    <nd ref="3963848567"/>
+    <nd ref="3963848566"/>
+    <tag k="addr:housenumber" v="12"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169127" version="1" timestamp="2016-01-24T10:23:01Z" changeset="36772879" uid="2886645" user="nikicam">
+    <nd ref="3963848571"/>
+    <nd ref="3963848575"/>
+    <nd ref="3963848576"/>
+    <nd ref="3963848577"/>
+    <nd ref="3963848578"/>
+    <nd ref="3963848579"/>
+    <nd ref="3963848580"/>
+    <nd ref="3963848572"/>
+    <nd ref="3963848571"/>
+    <tag k="addr:housenumber" v="14"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169128" version="3" timestamp="2018-09-14T21:38:06Z" changeset="62596780" uid="5715884" user="ncncdk">
+    <nd ref="3963848575"/>
+    <nd ref="3963848581"/>
+    <nd ref="3963848582"/>
+    <nd ref="3963848583"/>
+    <nd ref="3963848584"/>
+    <nd ref="3963848576"/>
+    <nd ref="3963848575"/>
+    <tag k="addr:housenumber" v="16"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="apartments"/>
+    <tag k="building:levels" v="6"/>
+  </way>
+  <way id="393169129" version="2" timestamp="2018-09-14T21:38:06Z" changeset="62596780" uid="5715884" user="ncncdk">
+    <nd ref="3963848582"/>
+    <nd ref="3963848585"/>
+    <nd ref="3963848595"/>
+    <nd ref="3963848586"/>
+    <nd ref="3963848587"/>
+    <nd ref="3963848588"/>
+    <nd ref="3963848583"/>
+    <nd ref="3963848582"/>
+    <tag k="addr:housenumber" v="2"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393169130" version="3" timestamp="2019-09-01T07:25:55Z" changeset="73964876" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3963848585"/>
+    <nd ref="3963848589"/>
+    <nd ref="3963848590"/>
+    <nd ref="6336366328"/>
+    <nd ref="3963848591"/>
+    <nd ref="3963848592"/>
+    <nd ref="6336366329"/>
+    <nd ref="3963848593"/>
+    <nd ref="3963848594"/>
+    <nd ref="3963848595"/>
+    <nd ref="3963848585"/>
+    <tag k="addr:housenumber" v="4"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393169131" version="4" timestamp="2020-09-04T05:48:30Z" changeset="90393282" uid="3341588" user="Heliotrope">
+    <nd ref="3963848591"/>
+    <nd ref="3963848596"/>
+    <nd ref="3963848597"/>
+    <nd ref="3963848598"/>
+    <nd ref="3963848599"/>
+    <nd ref="3963848592"/>
+    <nd ref="3963848591"/>
+    <tag k="addr:city" v="Београд"/>
+    <tag k="addr:housenumber" v="6"/>
+    <tag k="addr:postcode" v="11000"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="amenity" v="music_school"/>
+    <tag k="building" v="school"/>
+    <tag k="name" v="Музичка школа Мокрањац"/>
+    <tag k="name:sr" v="Музичка школа Мокрањац"/>
+    <tag k="name:sr-Latn" v="Muzička škola Mokranjac"/>
+    <tag k="website" v="https://mokranjacbg.rs/"/>
+  </way>
+  <way id="393169132" version="2" timestamp="2019-09-01T15:30:07Z" changeset="73975750" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3962695742"/>
+    <nd ref="3963848600"/>
+    <nd ref="3963848601"/>
+    <nd ref="3963848602"/>
+    <nd ref="3962695744"/>
+    <nd ref="3962695743"/>
+    <nd ref="3962695742"/>
+    <tag k="addr:housenumber" v="7"/>
+    <tag k="addr:street" v="Нушићева"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393169133" version="2" timestamp="2019-09-23T21:16:39Z" changeset="74826888" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3963848600"/>
+    <nd ref="3963848603"/>
+    <nd ref="3963848604"/>
+    <nd ref="3963848601"/>
+    <nd ref="3963848600"/>
+    <tag k="addr:housenumber" v="7a"/>
+    <tag k="addr:street" v="Нушићева"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393169134" version="2" timestamp="2018-03-24T12:30:36Z" changeset="57483900" uid="5569366" user="TXBG">
+    <nd ref="5501138348"/>
+    <nd ref="3963848608"/>
+    <nd ref="3963848605"/>
+    <nd ref="3963848611"/>
+    <nd ref="5501138348"/>
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Чумићева"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169139" version="1" timestamp="2016-01-24T10:23:02Z" changeset="36772879" uid="2886645" user="nikicam">
+    <nd ref="1123395387"/>
+    <nd ref="3963848623"/>
+    <nd ref="3963848624"/>
+    <nd ref="3963848625"/>
+    <nd ref="3963848626"/>
+    <nd ref="1123395389"/>
+    <nd ref="1123395387"/>
+    <tag k="addr:housenumber" v="9"/>
+    <tag k="addr:street" v="Коларчева"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169141" version="1" timestamp="2016-01-24T10:23:02Z" changeset="36772879" uid="2886645" user="nikicam">
+    <nd ref="3963848627"/>
+    <nd ref="3963848628"/>
+    <nd ref="3963848639"/>
+    <nd ref="3963848636"/>
+    <nd ref="3963848629"/>
+    <nd ref="3963848630"/>
+    <nd ref="3963849229"/>
+    <nd ref="3963848627"/>
+    <tag k="addr:housenumber" v="3"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169142" version="1" timestamp="2016-01-24T10:23:02Z" changeset="36772879" uid="2886645" user="nikicam">
+    <nd ref="3963848628"/>
+    <nd ref="3963848631"/>
+    <nd ref="3963848632"/>
+    <nd ref="3963848633"/>
+    <nd ref="3963848634"/>
+    <nd ref="3963848635"/>
+    <nd ref="3963848636"/>
+    <nd ref="3963848637"/>
+    <nd ref="3963848638"/>
+    <nd ref="3963848639"/>
+    <nd ref="3963848628"/>
+    <tag k="addr:housenumber" v="5"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169143" version="1" timestamp="2016-01-24T10:23:03Z" changeset="36772879" uid="2886645" user="nikicam">
+    <nd ref="3963848631"/>
+    <nd ref="3963848640"/>
+    <nd ref="3963848641"/>
+    <nd ref="3963848642"/>
+    <nd ref="3963848631"/>
+    <tag k="addr:housenumber" v="7"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169151" version="2" timestamp="2019-08-31T20:49:21Z" changeset="73957817" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3963849165"/>
+    <nd ref="3963849170"/>
+    <nd ref="3963849166"/>
+    <nd ref="3962695733"/>
+    <nd ref="3963849167"/>
+    <nd ref="3963849165"/>
+    <tag k="addr:housenumber" v="12"/>
+    <tag k="addr:street" v="Нушићева"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393169152" version="1" timestamp="2016-01-24T10:23:03Z" changeset="36772879" uid="2886645" user="nikicam">
+    <nd ref="3963849168"/>
+    <nd ref="3963849169"/>
+    <nd ref="3963849170"/>
+    <nd ref="3963849165"/>
+    <nd ref="3963849168"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169153" version="2" timestamp="2019-09-03T17:45:43Z" changeset="74052798" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3963849171"/>
+    <nd ref="3963849168"/>
+    <nd ref="3963849169"/>
+    <nd ref="3963849172"/>
+    <nd ref="3963849173"/>
+    <nd ref="3963849174"/>
+    <nd ref="3963849171"/>
+    <tag k="addr:housenumber" v="10"/>
+    <tag k="addr:street" v="Нушићева"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393169163" version="1" timestamp="2016-01-24T10:23:04Z" changeset="36772879" uid="2886645" user="nikicam">
+    <nd ref="3963849216"/>
+    <nd ref="3963849217"/>
+    <nd ref="3963849218"/>
+    <nd ref="3963849219"/>
+    <nd ref="3963849220"/>
+    <nd ref="3963849221"/>
+    <nd ref="3963849222"/>
+    <nd ref="3963849223"/>
+    <nd ref="3963849216"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169164" version="6" timestamp="2021-01-25T19:55:56Z" changeset="98142123" uid="3341588" user="Heliotrope">
+    <nd ref="7923465263"/>
+    <nd ref="7923465262"/>
+    <nd ref="7923465261"/>
+    <nd ref="503894440"/>
+    <nd ref="503894441"/>
+    <tag k="alt_name:sr" v="Чумићево сокаче"/>
+    <tag k="alt_name:sr-Latn" v="Čumićevo sokače"/>
+    <tag k="highway" v="footway"/>
+    <tag k="name" v="Чумићева"/>
+    <tag k="name:sr" v="Чумићева"/>
+    <tag k="name:sr-Latn" v="Čumićeva"/>
+  </way>
+  <way id="393169165" version="3" timestamp="2019-09-23T21:01:46Z" changeset="74826558" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3963848604"/>
+    <nd ref="3963849227"/>
+    <nd ref="3963849228"/>
+    <nd ref="3963848601"/>
+    <nd ref="3963848604"/>
+    <tag k="addr:housenumber" v="2"/>
+    <tag k="addr:street" v="Чумићева"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393169166" version="4" timestamp="2019-09-03T21:08:46Z" changeset="74058293" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="3963848623"/>
+    <nd ref="6487824767"/>
+    <nd ref="3963848627"/>
+    <nd ref="3963849229"/>
+    <nd ref="6487824766"/>
+    <nd ref="3963849230"/>
+    <nd ref="3963848624"/>
+    <nd ref="6487824765"/>
+    <nd ref="3963848623"/>
+    <tag k="addr:housenumber" v="1"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393169167" version="2" timestamp="2017-02-01T13:37:58Z" changeset="45716879" uid="4785399" user="PhaMer">
+    <nd ref="3963848640"/>
+    <nd ref="3963848643"/>
+    <nd ref="3963848644"/>
+    <nd ref="3963849231"/>
+    <nd ref="3963849232"/>
+    <nd ref="3963849233"/>
+    <nd ref="3963848641"/>
+    <nd ref="3963848640"/>
+    <tag k="addr:housenumber" v="11"/>
+    <tag k="addr:street" v="Теразије"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393169188" version="5" timestamp="2020-01-14T05:27:22Z" changeset="79544173" uid="7009309" user="Mengesh">
+    <nd ref="3963849019"/>
+    <nd ref="3963849020"/>
+    <nd ref="3963849021"/>
+    <nd ref="5115562451"/>
+    <nd ref="3963849022"/>
+    <nd ref="3963849023"/>
+    <nd ref="3963849019"/>
+    <tag k="addr:housenumber" v="11"/>
+    <tag k="addr:street" v="Нушићева"/>
+    <tag k="building" v="yes"/>
+    <tag k="email" v="info@muzejiluzija.rs"/>
+    <tag k="name" v="Музеј илузија"/>
+    <tag k="name:en" v="Museum of Illusions"/>
+    <tag k="name:sr" v="Музеј илузија"/>
+    <tag k="name:sr-Latn" v="Muzej iluzija"/>
+    <tag k="name:tr" v="Yanılsama Müzesi"/>
+    <tag k="opening_hours" v="Mo-Su 09:00-22:00"/>
+    <tag k="phone" v="+381 63 611 911"/>
+    <tag k="tourism" v="museum"/>
+    <tag k="website" v="https://www.muzejiluzija.rs/"/>
+  </way>
+  <way id="393169249" version="2" timestamp="2017-03-14T17:20:45Z" changeset="46847391" uid="5424820" user="nanosava">
+    <nd ref="3963849553"/>
+    <nd ref="3963849554"/>
+    <nd ref="3963849555"/>
+    <nd ref="3963849556"/>
+    <nd ref="3963864357"/>
+    <nd ref="3963864358"/>
+    <nd ref="3963849553"/>
+    <tag k="building" v="yes"/>
+    <tag k="building:levels" v="5"/>
+  </way>
+  <way id="393169250" version="3" timestamp="2021-03-15T08:18:49Z" changeset="101033167" uid="733709" user="dizajnmario">
+    <nd ref="3963864359"/>
+    <nd ref="3963864360"/>
+    <nd ref="3963864361"/>
+    <nd ref="7923465257"/>
+    <nd ref="3963864362"/>
+    <nd ref="3963864359"/>
+    <tag k="building" v="office"/>
+    <tag k="name" v="Belgrade Design District"/>
+    <tag k="shop" v="mall"/>
+  </way>
+  <way id="393169251" version="1" timestamp="2016-01-24T10:26:11Z" changeset="36772926" uid="2886645" user="nikicam">
+    <nd ref="3963864363"/>
+    <nd ref="3963864364"/>
+    <nd ref="3963864365"/>
+    <nd ref="3963864366"/>
+    <nd ref="3963864363"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393178968" version="4" timestamp="2018-09-14T21:38:07Z" changeset="62596780" uid="5715884" user="ncncdk">
+    <nd ref="3963967028"/>
+    <nd ref="3963967029"/>
+    <nd ref="3963996876"/>
+    <nd ref="3963967030"/>
+    <nd ref="3963967031"/>
+    <nd ref="3963967028"/>
+    <tag k="addr:housenumber" v="11"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393183169" version="3" timestamp="2019-12-11T13:39:38Z" changeset="78263384" uid="6225925" user="Aleksa Marinski">
+    <nd ref="3963967029"/>
+    <nd ref="3963996872"/>
+    <nd ref="3963996873"/>
+    <nd ref="3963996874"/>
+    <nd ref="3963996875"/>
+    <nd ref="3963996876"/>
+    <nd ref="3963967029"/>
+    <tag k="addr:housenumber" v="13"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="building" v="yes"/>
+  </way>
+  <way id="393183171" version="4" timestamp="2019-12-11T13:39:38Z" changeset="78263384" uid="6225925" user="Aleksa Marinski">
+    <nd ref="3963996872"/>
+    <nd ref="3963996881"/>
+    <nd ref="3963996882"/>
+    <nd ref="3963996879"/>
+    <nd ref="3963996873"/>
+    <nd ref="3963996872"/>
+    <tag k="addr:housenumber" v="15"/>
+    <tag k="addr:street" v="Дечанска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="393188938" version="2" timestamp="2019-09-02T21:08:31Z" changeset="74013403" uid="6797352" user="Serbian OSM Lint bot">
+    <nd ref="503888394"/>
+    <nd ref="3964043129"/>
+    <nd ref="3964043130"/>
+    <nd ref="3964043131"/>
+    <nd ref="503888394"/>
+    <tag k="addr:housenumber" v="24"/>
+    <tag k="addr:street" v="Македонска"/>
+    <tag k="building" v="apartments"/>
+  </way>
+  <way id="485765599" version="4" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn">
+    <nd ref="4785337757"/>
+    <nd ref="4785337759"/>
+    <nd ref="4785337760"/>
+    <nd ref="7526375192"/>
+    <nd ref="4785337761"/>
+    <nd ref="504918667"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+    <tag k="lit" v="yes"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="503611736" version="8" timestamp="2021-02-16T21:37:22Z" changeset="99406662" uid="10427003" user="Savo25656">
+    <nd ref="4938882589"/>
+    <nd ref="4938882599"/>
+    <nd ref="5198571366"/>
+    <nd ref="4938882600"/>
+    <nd ref="6279644395"/>
+    <nd ref="6279644388"/>
+    <nd ref="4938882601"/>
+    <nd ref="4938882602"/>
+    <nd ref="4938882603"/>
+    <nd ref="3885525300"/>
+    <nd ref="8429980311"/>
+    <nd ref="4938882604"/>
+    <nd ref="4938882605"/>
+    <nd ref="4938882606"/>
+    <nd ref="4938882607"/>
+    <nd ref="4938882608"/>
+    <nd ref="4938882609"/>
+    <nd ref="4359064376"/>
+    <nd ref="5850036513"/>
+    <nd ref="4938882610"/>
+    <tag k="layer" v="-1"/>
+    <tag k="railway" v="proposed"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="503613251" version="2" timestamp="2018-11-10T14:05:14Z" changeset="64351730" uid="6225925" user="Aleksa Marinski">
+    <nd ref="4938890548"/>
+    <nd ref="4938893389"/>
+    <nd ref="4938893390"/>
+    <nd ref="4938893391"/>
+    <nd ref="4938893392"/>
+    <nd ref="4938893393"/>
+    <nd ref="4938893394"/>
+    <nd ref="4938893395"/>
+    <nd ref="4938893396"/>
+    <nd ref="4938893397"/>
+    <nd ref="4938893398"/>
+    <nd ref="4938893399"/>
+    <nd ref="4938893400"/>
+    <nd ref="4938882610"/>
+    <tag k="layer" v="-1"/>
+    <tag k="name" v="Метро"/>
+    <tag k="proposed" v="subway"/>
+    <tag k="railway" v="proposed"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="514312123" version="11" timestamp="2020-12-01T13:44:09Z" changeset="95097857" uid="733709" user="dizajnmario">
+    <nd ref="6363316646"/>
+    <nd ref="5924238957"/>
+    <nd ref="5177170822"/>
+    <nd ref="5177170827"/>
+    <nd ref="5924238962"/>
+    <nd ref="5924238954"/>
+    <nd ref="3962695822"/>
+    <nd ref="3962695823"/>
+    <nd ref="3962695827"/>
+    <nd ref="3962695830"/>
+    <nd ref="1629299611"/>
+    <nd ref="5024979831"/>
+    <nd ref="5024979832"/>
+    <nd ref="5177170835"/>
+    <nd ref="6363316658"/>
+    <nd ref="5924238958"/>
+    <nd ref="6363316610"/>
+    <nd ref="5924238960"/>
+    <nd ref="5924238959"/>
+    <nd ref="6363316646"/>
+  </way>
+  <way id="532823567" version="3" timestamp="2018-09-23T16:07:42Z" changeset="62854886" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5170025144"/>
+    <nd ref="5924238954"/>
+    <nd ref="503889015"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="533676376" version="3" timestamp="2019-07-17T17:53:41Z" changeset="72359407" uid="7608768" user="Blyatman">
+    <nd ref="5177170804"/>
+    <nd ref="5177170805"/>
+    <nd ref="5177170806"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+    <tag k="lit" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="533676378" version="2" timestamp="2020-08-21T16:48:52Z" changeset="89756372" uid="427807" user="Tungmar">
+    <nd ref="5177170809"/>
+    <nd ref="5177170811"/>
+    <nd ref="5177170812"/>
+    <nd ref="5177170813"/>
+    <nd ref="5177170814"/>
+    <nd ref="5177170815"/>
+    <nd ref="5177170816"/>
+    <nd ref="503889027"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="533676381" version="1" timestamp="2017-10-19T21:26:46Z" changeset="53082796" uid="2065166" user="suff">
+    <nd ref="503889018"/>
+    <nd ref="5177170829"/>
+    <nd ref="5177170826"/>
+    <nd ref="5177170828"/>
+    <nd ref="5177170827"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="533676383" version="3" timestamp="2019-03-26T19:08:45Z" changeset="68559829" uid="5569366" user="TXBG">
+    <nd ref="5177170833"/>
+    <nd ref="5177170834"/>
+    <nd ref="6363316652"/>
+    <tag k="footway" v="crossing"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="533676384" version="3" timestamp="2020-01-04T17:25:08Z" changeset="79195151" uid="6225925" user="Aleksa Marinski">
+    <nd ref="503889015"/>
+    <nd ref="5177170818"/>
+    <nd ref="5177170819"/>
+    <nd ref="5177170820"/>
+    <nd ref="5177170821"/>
+    <nd ref="5177170827"/>
+    <nd ref="5177170822"/>
+    <nd ref="5177170823"/>
+    <nd ref="5177170824"/>
+    <nd ref="5177170825"/>
+    <nd ref="6363316649"/>
+    <nd ref="5177170836"/>
+    <nd ref="6363316612"/>
+    <nd ref="6363316652"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="533676385" version="2" timestamp="2019-03-11T17:20:24Z" changeset="68031136" uid="9414390" user="Gr8fulDead">
+    <nd ref="5177170837"/>
+    <nd ref="5177170838"/>
+    <nd ref="5177170839"/>
+    <tag k="footway" v="crossing"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="533676386" version="2" timestamp="2020-01-04T17:25:08Z" changeset="79195151" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5179985232"/>
+    <nd ref="5177170839"/>
+    <nd ref="5177170840"/>
+    <nd ref="5177170841"/>
+    <nd ref="5177170833"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="533983012" version="9" timestamp="2021-03-24T15:20:21Z" changeset="101657830" uid="733709" user="dizajnmario">
+    <nd ref="2994328323"/>
+    <nd ref="5179720384"/>
+    <nd ref="5179720399"/>
+    <nd ref="5179720385"/>
+    <nd ref="5179720386"/>
+    <nd ref="5179720387"/>
+    <nd ref="5179720388"/>
+    <nd ref="5179720389"/>
+    <nd ref="5179720390"/>
+    <nd ref="5179720391"/>
+    <nd ref="5179720392"/>
+    <nd ref="503894451"/>
+    <nd ref="5179720402"/>
+    <nd ref="5179720393"/>
+    <nd ref="6735412290"/>
+    <nd ref="5179720396"/>
+    <nd ref="5179724927"/>
+    <nd ref="6522163985"/>
+    <nd ref="5179724928"/>
+    <nd ref="5179724929"/>
+    <nd ref="6735412289"/>
+    <nd ref="7107738485"/>
+    <nd ref="5179724936"/>
+    <nd ref="5179724937"/>
+    <nd ref="8222814380"/>
+    <nd ref="5177170830"/>
+    <nd ref="5177170842"/>
+    <nd ref="5177170843"/>
+    <nd ref="5177170844"/>
+    <nd ref="5177170845"/>
+    <nd ref="5177170846"/>
+    <nd ref="503889009"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="533983014" version="2" timestamp="2019-05-14T10:17:20Z" changeset="70226215" uid="3207276" user="Armin Gheorghina">
+    <nd ref="504918683"/>
+    <nd ref="5179720400"/>
+    <nd ref="6472254613"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+    <tag k="tunnel" v="building_passage"/>
+  </way>
+  <way id="533983015" version="2" timestamp="2019-05-21T11:07:19Z" changeset="70473867" uid="3207276" user="Armin Gheorghina">
+    <nd ref="504918675"/>
+    <nd ref="6487824767"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+    <tag k="tunnel" v="building_passage"/>
+  </way>
+  <way id="533983027" version="7" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5177170837"/>
+    <nd ref="5179725005"/>
+    <nd ref="5179724968"/>
+    <nd ref="5179724976"/>
+    <nd ref="5179724969"/>
+    <nd ref="5179724962"/>
+    <nd ref="5179724967"/>
+    <nd ref="5179724966"/>
+    <nd ref="5179724965"/>
+    <nd ref="5179724964"/>
+    <nd ref="5179724963"/>
+    <nd ref="5179724950"/>
+    <nd ref="5179724949"/>
+    <nd ref="6735415085"/>
+    <nd ref="5179724948"/>
+    <nd ref="5179724947"/>
+    <nd ref="5179724951"/>
+    <nd ref="5179724946"/>
+    <nd ref="5179724945"/>
+    <nd ref="5179724944"/>
+    <nd ref="5179724953"/>
+    <nd ref="6735402999"/>
+    <nd ref="5179720419"/>
+    <nd ref="5179724926"/>
+    <nd ref="5179720420"/>
+    <nd ref="5179724921"/>
+    <nd ref="7107715486"/>
+    <nd ref="5179724924"/>
+    <nd ref="8222814378"/>
+    <nd ref="5179724925"/>
+    <nd ref="8222814379"/>
+    <nd ref="5177170837"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="535364037" version="3" timestamp="2018-09-25T13:20:59Z" changeset="62913618" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5220315682"/>
+    <nd ref="5024979830"/>
+    <nd ref="5133996568"/>
+    <nd ref="5220315680"/>
+    <nd ref="5220315682"/>
+    <tag k="barrier" v="wall"/>
+    <tag k="landuse" v="grass"/>
+  </way>
+  <way id="547470780" version="4" timestamp="2019-09-20T08:26:23Z" changeset="74708971" uid="3733993" user="Aleksandar1994">
+    <nd ref="503889005"/>
+    <nd ref="5289996162"/>
+    <tag k="highway" v="footway"/>
+    <tag k="lit" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="547470782" version="3" timestamp="2019-07-17T17:53:40Z" changeset="72359402" uid="7608768" user="Blyatman">
+    <nd ref="5289996159"/>
+    <nd ref="5289996161"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="layer" v="-1"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="547470783" version="4" timestamp="2019-07-17T17:53:47Z" changeset="72359407" uid="7608768" user="Blyatman">
+    <nd ref="5289996162"/>
+    <nd ref="5289996158"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="steps"/>
+    <tag k="layer" v="-1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="547470785" version="3" timestamp="2020-01-14T23:34:35Z" changeset="79585872" uid="7009309" user="Mengesh">
+    <nd ref="5289996161"/>
+    <nd ref="5289996160"/>
+    <tag k="highway" v="footway"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="547470787" version="4" timestamp="2019-09-20T08:26:02Z" changeset="74708962" uid="3733993" user="Aleksandar1994">
+    <nd ref="5289996158"/>
+    <nd ref="5289996159"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="-1"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="tunnel" v="yes"/>
+  </way>
+  <way id="567949328" version="11" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="249027867"/>
+    <nd ref="6578723588"/>
+    <nd ref="5179720380"/>
+    <nd ref="5179720379"/>
+    <nd ref="6338207812"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="2"/>
+    <tag k="lanes:psv" v="1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed:type" v="RS:urban"/>
+    <tag k="name" v="Теразије"/>
+    <tag k="name:en" v="Terazije"/>
+    <tag k="name:etymology:wikidata" v="Q274153"/>
+    <tag k="name:sr" v="Теразије"/>
+    <tag k="name:sr-Latn" v="Terazije"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="608095396" version="6" timestamp="2021-03-24T15:19:57Z" changeset="101657804" uid="733709" user="dizajnmario">
+    <nd ref="5761790614"/>
+    <nd ref="6297848186"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="highway" v="pedestrian"/>
+    <tag k="maxweight" v="3.5"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+    <tag k="name" v="Трг републике"/>
+    <tag k="name:en" v="Republic Square"/>
+    <tag k="name:etymology:wikidata" v="Q7270"/>
+    <tag k="name:sr" v="Трг републике"/>
+    <tag k="name:sr-Latn" v="Trg republike"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="618797985" version="6" timestamp="2021-03-23T13:59:06Z" changeset="101579539" uid="733709" user="dizajnmario">
+    <nd ref="5866002417"/>
+    <nd ref="6760759195"/>
+    <nd ref="6297848186"/>
+    <nd ref="6423895085"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="emergency" v="yes"/>
+    <tag k="goods:conditional" v="private @ (06:00-09:00 AND weight&lt;3.5)"/>
+    <tag k="highway" v="pedestrian"/>
+    <tag k="maxweight" v="3.5"/>
+    <tag k="motorcar:conditional" v="private @ (00:00-24:00 AND weight&lt;3.5)"/>
+    <tag k="name" v="Трг републике"/>
+    <tag k="name:en" v="Republic Square"/>
+    <tag k="name:etymology:wikidata" v="Q7270"/>
+    <tag k="name:sr" v="Трг републике"/>
+    <tag k="name:sr-Latn" v="Trg republike"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="619005684" version="14" timestamp="2020-04-05T12:23:21Z" changeset="83097647" uid="95504" user="Branko Kokanovic">
+    <nd ref="5850036516"/>
+    <nd ref="5850035181"/>
+    <nd ref="5850035182"/>
+    <nd ref="5850035183"/>
+    <nd ref="6735412288"/>
+    <nd ref="5850036492"/>
+    <nd ref="5850035179"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="3"/>
+    <tag k="lanes:backward" v="1"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed" v="30"/>
+    <tag k="name" v="Трг републике"/>
+    <tag k="name:en" v="Republic Square"/>
+    <tag k="name:etymology:wikidata" v="Q7270"/>
+    <tag k="name:sr" v="Трг републике"/>
+    <tag k="name:sr-Latn" v="Trg republike"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="619005688" version="16" timestamp="2020-04-05T15:09:30Z" changeset="83102173" uid="95504" user="Branko Kokanovic">
+    <nd ref="6735403188"/>
+    <nd ref="5850036500"/>
+    <nd ref="5850036499"/>
+    <nd ref="5850036498"/>
+    <nd ref="5850036497"/>
+    <nd ref="5850036496"/>
+    <nd ref="5850036495"/>
+    <nd ref="5850036494"/>
+    <nd ref="5850036493"/>
+    <nd ref="5850035178"/>
+    <nd ref="5850035179"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:backward" v="2"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed" v="30"/>
+    <tag k="name" v="Коларчева"/>
+    <tag k="name:en" v="Kolarčeva"/>
+    <tag k="name:etymology:wikidata" v="Q3148669"/>
+    <tag k="name:sr" v="Коларчева"/>
+    <tag k="name:sr-Latn" v="Kolarčeva"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="619005695" version="14" timestamp="2020-10-29T08:25:53Z" changeset="93222631" uid="875800" user="Komadinovic Vanja">
+    <nd ref="6735403188"/>
+    <nd ref="6735403189"/>
+    <nd ref="5850036514"/>
+    <nd ref="5850036517"/>
+    <nd ref="6735403187"/>
+    <nd ref="5850036515"/>
+    <nd ref="5850036516"/>
+    <tag k="highway" v="secondary_link"/>
+    <tag k="lanes" v="1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed" v="30"/>
+    <tag k="name" v="Македонска"/>
+    <tag k="name:en" v="Makedonska"/>
+    <tag k="name:etymology:wikidata" v="Q103251"/>
+    <tag k="name:sr" v="Македонска"/>
+    <tag k="name:sr-Latn" v="Makedonska"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="wikidata" v="Q63092521"/>
+    <tag k="wikipedia" v="sr:Македонска улица (Београд)"/>
+  </way>
+  <way id="620921370" version="5" timestamp="2021-03-10T05:23:02Z" changeset="100748771" uid="7009309" user="Mengesh">
+    <nd ref="2934913746"/>
+    <nd ref="5179720403"/>
+    <nd ref="5179720404"/>
+    <nd ref="5179720405"/>
+    <nd ref="5866002416"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+    <tag k="lit" v="yes"/>
+    <tag k="surface" v="concrete"/>
+  </way>
+  <way id="628034130" version="1" timestamp="2018-09-25T13:20:58Z" changeset="62913618" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5133996568"/>
+    <nd ref="5024979832"/>
+    <tag k="barrier" v="wall"/>
+  </way>
+  <way id="633746633" version="24" timestamp="2020-05-16T13:44:29Z" changeset="85304771" uid="6877782" user="GrumpyJohn">
+    <nd ref="5377749946"/>
+    <nd ref="6467099985"/>
+    <nd ref="5062600382"/>
+    <nd ref="5062600383"/>
+    <nd ref="5062600384"/>
+    <nd ref="5062600385"/>
+    <nd ref="5028769613"/>
+    <nd ref="5028769614"/>
+    <nd ref="5028769615"/>
+    <nd ref="5028769617"/>
+    <nd ref="5028769620"/>
+    <nd ref="471048376"/>
+    <nd ref="256411982"/>
+    <nd ref="5105387159"/>
+    <nd ref="5105387162"/>
+    <nd ref="256411914"/>
+    <nd ref="7526304276"/>
+    <nd ref="1039025161"/>
+    <nd ref="5060514015"/>
+    <nd ref="5060514020"/>
+    <nd ref="7086976207"/>
+    <nd ref="7086976209"/>
+    <nd ref="5077708883"/>
+    <nd ref="7086976191"/>
+    <nd ref="7086976214"/>
+    <nd ref="7086976216"/>
+    <nd ref="7086976219"/>
+    <nd ref="5060514013"/>
+    <nd ref="6319505585"/>
+    <nd ref="456920115"/>
+    <nd ref="5028771231"/>
+    <nd ref="5153992282"/>
+    <nd ref="5153992299"/>
+    <nd ref="5153992301"/>
+    <nd ref="454733033"/>
+    <nd ref="6319505789"/>
+    <nd ref="1801912953"/>
+    <nd ref="6485379808"/>
+    <nd ref="3964869602"/>
+    <nd ref="3964869599"/>
+    <nd ref="3964869598"/>
+    <nd ref="3964869591"/>
+    <nd ref="5028771246"/>
+    <nd ref="3964869593"/>
+    <nd ref="6815615287"/>
+    <nd ref="428987363"/>
+    <nd ref="6815615389"/>
+    <nd ref="456863745"/>
+    <nd ref="5028771249"/>
+    <nd ref="5028771250"/>
+    <nd ref="5028771253"/>
+    <nd ref="5028771252"/>
+    <nd ref="6757247986"/>
+    <nd ref="5028771251"/>
+    <nd ref="5492010675"/>
+    <nd ref="5028771248"/>
+    <nd ref="5028771247"/>
+    <nd ref="3966774686"/>
+    <nd ref="3966774685"/>
+    <nd ref="4014618798"/>
+    <nd ref="3966774684"/>
+    <nd ref="3966774683"/>
+    <nd ref="3966774694"/>
+    <nd ref="5028771254"/>
+    <nd ref="5028771258"/>
+    <nd ref="5028771260"/>
+    <nd ref="5028771262"/>
+    <nd ref="6742417487"/>
+    <nd ref="5028771261"/>
+    <nd ref="5492010676"/>
+    <nd ref="3966809469"/>
+    <nd ref="5028771259"/>
+    <nd ref="5028771257"/>
+    <nd ref="456863695"/>
+    <nd ref="456863697"/>
+    <nd ref="3966809474"/>
+    <nd ref="3966809475"/>
+    <nd ref="458976886"/>
+    <nd ref="3966809478"/>
+    <nd ref="3966809480"/>
+    <nd ref="3966809484"/>
+    <nd ref="4709053332"/>
+    <nd ref="4709053333"/>
+    <nd ref="6757247586"/>
+    <nd ref="4709053336"/>
+    <nd ref="4709053335"/>
+    <nd ref="4709053334"/>
+    <nd ref="1344306016"/>
+    <nd ref="1344306046"/>
+    <nd ref="1344306049"/>
+    <nd ref="1344306021"/>
+    <nd ref="1344306040"/>
+    <nd ref="1344306022"/>
+    <nd ref="6757258285"/>
+    <nd ref="3966888340"/>
+    <nd ref="3966888339"/>
+    <nd ref="3966888338"/>
+    <nd ref="3966888337"/>
+    <nd ref="3966888336"/>
+    <nd ref="3966888341"/>
+    <nd ref="6757247587"/>
+    <nd ref="248920241"/>
+    <nd ref="248920238"/>
+    <nd ref="248920239"/>
+    <nd ref="5832766080"/>
+    <nd ref="248920240"/>
+    <nd ref="5866002418"/>
+    <nd ref="6718724788"/>
+    <nd ref="6761575690"/>
+    <nd ref="2934914890"/>
+    <nd ref="6382912486"/>
+    <nd ref="6382932286"/>
+    <nd ref="6382928789"/>
+    <nd ref="6382932585"/>
+    <nd ref="5179720413"/>
+    <nd ref="6382928788"/>
+    <nd ref="6382912487"/>
+    <nd ref="5195043687"/>
+    <nd ref="6382932586"/>
+    <nd ref="6382904787"/>
+    <nd ref="6522159890"/>
+    <nd ref="6382912488"/>
+    <nd ref="6382912489"/>
+    <nd ref="6382928790"/>
+    <nd ref="5179720376"/>
+    <nd ref="257726488"/>
+    <nd ref="5850036522"/>
+    <nd ref="5866002417"/>
+    <nd ref="250438346"/>
+    <nd ref="4359064371"/>
+    <nd ref="3966888345"/>
+    <nd ref="250438341"/>
+    <nd ref="250438342"/>
+    <nd ref="1806315538"/>
+    <nd ref="250438343"/>
+    <nd ref="4461639871"/>
+    <nd ref="5156751165"/>
+    <nd ref="4461639870"/>
+    <nd ref="5156751166"/>
+    <nd ref="7526375193"/>
+    <nd ref="6357050989"/>
+    <nd ref="6357050690"/>
+    <nd ref="6357050789"/>
+    <nd ref="6357050790"/>
+    <nd ref="7526375192"/>
+    <nd ref="5156751167"/>
+    <nd ref="5156751168"/>
+    <nd ref="7526375191"/>
+    <nd ref="7526375190"/>
+    <nd ref="5156751169"/>
+    <nd ref="5156751170"/>
+    <nd ref="5156751149"/>
+    <nd ref="5156751148"/>
+    <nd ref="5156751147"/>
+    <nd ref="5156751146"/>
+    <nd ref="5156751145"/>
+    <nd ref="5156751142"/>
+    <nd ref="5156751140"/>
+    <nd ref="5156751135"/>
+    <nd ref="1145157627"/>
+    <nd ref="5156751134"/>
+    <nd ref="5156751131"/>
+    <nd ref="5156751130"/>
+    <nd ref="7526375187"/>
+    <nd ref="456123418"/>
+    <nd ref="456123415"/>
+    <nd ref="456123414"/>
+    <nd ref="3976968090"/>
+    <nd ref="3976968093"/>
+    <nd ref="3976968088"/>
+    <nd ref="3976968084"/>
+    <nd ref="3976968085"/>
+    <nd ref="3976968255"/>
+    <nd ref="7526304281"/>
+    <nd ref="3976968100"/>
+    <nd ref="6388121894"/>
+    <nd ref="430927123"/>
+    <nd ref="430927122"/>
+    <nd ref="430927121"/>
+    <nd ref="430927120"/>
+    <nd ref="430927119"/>
+    <nd ref="6448526090"/>
+    <nd ref="6448531885"/>
+    <nd ref="6448531491"/>
+    <nd ref="5764020731"/>
+    <nd ref="6448526091"/>
+    <nd ref="3964812028"/>
+    <nd ref="3964812025"/>
+    <nd ref="3964812029"/>
+    <nd ref="3964812032"/>
+    <nd ref="6391576486"/>
+    <nd ref="3966851740"/>
+    <nd ref="3966851741"/>
+    <nd ref="3964812039"/>
+    <nd ref="3964812040"/>
+    <nd ref="3964812043"/>
+    <nd ref="4176309405"/>
+    <nd ref="3964812051"/>
+    <nd ref="6466736285"/>
+    <nd ref="1124731543"/>
+    <nd ref="1124731540"/>
+    <nd ref="1124731547"/>
+    <nd ref="1124731556"/>
+    <nd ref="1124731542"/>
+    <nd ref="1124731549"/>
+    <nd ref="1124731545"/>
+    <nd ref="1124731541"/>
+    <nd ref="1124731553"/>
+    <nd ref="1124731538"/>
+    <nd ref="430923133"/>
+    <nd ref="430923140"/>
+    <nd ref="6466736385"/>
+    <nd ref="430923108"/>
+    <nd ref="430923111"/>
+    <nd ref="1124731544"/>
+    <nd ref="1124731558"/>
+    <nd ref="1124731539"/>
+    <nd ref="1124731554"/>
+    <nd ref="1124731551"/>
+    <nd ref="1124731557"/>
+    <nd ref="5352677732"/>
+    <nd ref="5973507034"/>
+    <nd ref="6742422585"/>
+    <nd ref="7526304279"/>
+    <nd ref="5638026338"/>
+    <nd ref="7526304278"/>
+    <nd ref="6295883086"/>
+    <nd ref="5095890379"/>
+    <nd ref="5638025303"/>
+    <nd ref="5638025290"/>
+    <nd ref="5638026329"/>
+    <nd ref="5638026331"/>
+    <nd ref="5111771470"/>
+    <nd ref="5638026321"/>
+    <nd ref="5638025320"/>
+    <nd ref="5638026325"/>
+    <nd ref="6761575692"/>
+    <nd ref="5638025315"/>
+    <nd ref="5709691985"/>
+    <nd ref="5105387147"/>
+    <nd ref="5111771478"/>
+    <nd ref="5111771480"/>
+    <nd ref="5111771482"/>
+    <nd ref="5111771486"/>
+    <nd ref="5105387142"/>
+    <nd ref="7526304277"/>
+    <nd ref="5133996592"/>
+    <nd ref="6260774785"/>
+    <nd ref="5646679895"/>
+    <nd ref="5377749945"/>
+    <nd ref="5095890353"/>
+    <nd ref="5095890354"/>
+    <nd ref="5095890355"/>
+    <nd ref="5095890356"/>
+    <nd ref="5095890357"/>
+    <nd ref="5095890358"/>
+    <nd ref="5105387156"/>
+    <nd ref="3966684325"/>
+    <nd ref="6467091488"/>
+    <nd ref="5377749946"/>
+  </way>
+  <way id="642898872" version="8" timestamp="2021-03-04T11:35:58Z" changeset="100419123" uid="12771584" user="pPetrovic">
+    <nd ref="6051259886"/>
+    <nd ref="6317125635"/>
+    <nd ref="6051259895"/>
+    <nd ref="6051259896"/>
+    <nd ref="6051259897"/>
+    <nd ref="6485350481"/>
+    <nd ref="6051259891"/>
+    <nd ref="8483716880"/>
+    <nd ref="6051259898"/>
+    <nd ref="6051259899"/>
+    <nd ref="6051259900"/>
+    <nd ref="6051259901"/>
+    <nd ref="6051259902"/>
+    <nd ref="6051259903"/>
+    <nd ref="6051259904"/>
+    <nd ref="6051259905"/>
+    <nd ref="6051259906"/>
+    <nd ref="6051259907"/>
+    <nd ref="6051259908"/>
+    <nd ref="6051259909"/>
+    <nd ref="6051259910"/>
+    <nd ref="6051259911"/>
+    <nd ref="6051259912"/>
+    <nd ref="6051259913"/>
+    <nd ref="6051259914"/>
+    <nd ref="6051259915"/>
+    <nd ref="6051259916"/>
+    <nd ref="6051259917"/>
+    <nd ref="6051259918"/>
+    <nd ref="6051259919"/>
+    <nd ref="6051259892"/>
+    <nd ref="8483716876"/>
+    <nd ref="6051259893"/>
+    <nd ref="8483716856"/>
+    <nd ref="8483716857"/>
+    <nd ref="8483780823"/>
+    <nd ref="8483716858"/>
+    <nd ref="8485784701"/>
+    <nd ref="8483780822"/>
+    <nd ref="6051259920"/>
+    <nd ref="6051259921"/>
+    <nd ref="8483716869"/>
+    <nd ref="6055687108"/>
+    <nd ref="6055687107"/>
+    <nd ref="8483716863"/>
+    <nd ref="36471163"/>
+    <nd ref="8483716862"/>
+    <nd ref="8483716861"/>
+    <nd ref="8483716860"/>
+    <nd ref="6051259669"/>
+    <nd ref="6051259668"/>
+    <nd ref="6051259666"/>
+    <nd ref="6051259667"/>
+    <nd ref="8483716859"/>
+    <tag k="description" v="Предвиђена трамвајска пруга од Калемегдана до Славије. Proposed tram tracks from Kalemegdan to Slavija."/>
+    <tag k="electrified" v="yes"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="proposed" v="tram"/>
+    <tag k="railway" v="proposed"/>
+  </way>
+  <way id="642898874" version="6" timestamp="2021-03-05T22:32:09Z" changeset="100517068" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5077391384"/>
+    <nd ref="6051259663"/>
+    <nd ref="8483716864"/>
+    <nd ref="8483716865"/>
+    <nd ref="8483716866"/>
+    <nd ref="6055687106"/>
+    <nd ref="6055687105"/>
+    <nd ref="8483716867"/>
+    <nd ref="8483716868"/>
+    <nd ref="6051259924"/>
+    <nd ref="8483716870"/>
+    <nd ref="8483716871"/>
+    <nd ref="8483716872"/>
+    <nd ref="6051259925"/>
+    <nd ref="8483716873"/>
+    <nd ref="8490384564"/>
+    <nd ref="8485784703"/>
+    <nd ref="8483780828"/>
+    <nd ref="8483762987"/>
+    <nd ref="8483716875"/>
+    <nd ref="8483716877"/>
+    <nd ref="8483716878"/>
+    <nd ref="6051259926"/>
+    <nd ref="6051259927"/>
+    <nd ref="6051259928"/>
+    <nd ref="6051259929"/>
+    <nd ref="6051259930"/>
+    <nd ref="6051259931"/>
+    <nd ref="6051259932"/>
+    <nd ref="6051259933"/>
+    <nd ref="6051259934"/>
+    <nd ref="6051259935"/>
+    <nd ref="6051259936"/>
+    <nd ref="6051259937"/>
+    <nd ref="6051259938"/>
+    <nd ref="6051259939"/>
+    <nd ref="6051259940"/>
+    <nd ref="6051259941"/>
+    <nd ref="6051259942"/>
+    <nd ref="6051259943"/>
+    <nd ref="6051259944"/>
+    <nd ref="6051259945"/>
+    <nd ref="6051259946"/>
+    <nd ref="6051259947"/>
+    <nd ref="6051259948"/>
+    <nd ref="6051259949"/>
+    <nd ref="6051259950"/>
+    <nd ref="6051259951"/>
+    <tag k="description" v="Предвиђена трамвајска пруга од Калемегдана до Славије. Proposed tram tracks from Kalemegdan to Slavija."/>
+    <tag k="electrified" v="yes"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="proposed" v="tram"/>
+    <tag k="railway" v="proposed"/>
+  </way>
+  <way id="676068916" version="4" timestamp="2020-10-29T08:37:05Z" changeset="93222631" uid="875800" user="Komadinovic Vanja">
+    <nd ref="256769331"/>
+    <nd ref="1677964946"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="5"/>
+    <tag k="lanes:backward" v="3"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="name" v="Дечанска"/>
+    <tag k="name:en" v="Decanska"/>
+    <tag k="name:etymology:wikidata" v="Q939112;Q849517"/>
+    <tag k="name:sr" v="Дечанска"/>
+    <tag k="name:sr-Latn" v="Dečanska"/>
+    <tag k="old_name" v="Моше Пијаде"/>
+    <tag k="old_name:sr" v="Моше Пијаде"/>
+    <tag k="old_name:sr-Latn" v="Moše Pijade"/>
+    <tag k="placement:backward" v="left_of:1"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="turn:lanes:backward" v="through|right|right"/>
+    <tag k="turn:lanes:forward" v="through|through"/>
+    <tag k="wikidata" v="Q61133766"/>
+    <tag k="wikipedia" v="sr:Улица Дечанска (Београд)"/>
+  </way>
+  <way id="676637001" version="5" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <nd ref="249024039"/>
+    <nd ref="5177170834"/>
+    <nd ref="8222814376"/>
+    <nd ref="6336272373"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="3"/>
+    <tag k="lanes:backward" v="2"/>
+    <tag k="lanes:forward" v="1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed:type" v="RS:urban"/>
+    <tag k="name" v="Македонска"/>
+    <tag k="name:en" v="Makedonska"/>
+    <tag k="name:etymology:wikidata" v="Q103251"/>
+    <tag k="name:sr" v="Македонска"/>
+    <tag k="name:sr-Latn" v="Makedonska"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="trolley_wire" v="yes"/>
+    <tag k="wikidata" v="Q63092521"/>
+    <tag k="wikipedia" v="sr:Македонска улица (Београд)"/>
+  </way>
+  <way id="676637002" version="3" timestamp="2020-08-04T21:08:10Z" changeset="88948478" uid="6225925" user="Aleksa Marinski">
+    <nd ref="6336272374"/>
+    <nd ref="249026854"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:psv:backward" v="1"/>
+    <tag k="name" v="Браће Југовића"/>
+    <tag k="name:en" v="Brace Jugovica"/>
+    <tag k="name:etymology:wikidata" v="Q12750730"/>
+    <tag k="name:sr" v="Браће Југовића"/>
+    <tag k="name:sr-Latn" v="Braće Jugovića"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="turn:lanes:forward" v="through|through;right"/>
+  </way>
+  <way id="676647001" version="2" timestamp="2019-03-28T20:58:53Z" changeset="68643598" uid="6980194" user="mama_bear">
+    <nd ref="6336366329"/>
+    <nd ref="6336366328"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="service"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="tunnel" v="building_passage"/>
+  </way>
+  <way id="676647002" version="2" timestamp="2019-03-28T20:58:53Z" changeset="68643598" uid="6980194" user="mama_bear">
+    <nd ref="503894441"/>
+    <nd ref="6336366329"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="service"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="680974973" version="4" timestamp="2020-08-26T14:14:58Z" changeset="89977335" uid="6225925" user="Aleksa Marinski">
+    <nd ref="6357050689"/>
+    <nd ref="257726631"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="2"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed:type" v="RS:urban"/>
+    <tag k="name" v="Теразије"/>
+    <tag k="name:en" v="Terazije"/>
+    <tag k="name:etymology:wikidata" v="Q274153"/>
+    <tag k="name:sr" v="Теразије"/>
+    <tag k="name:sr-Latn" v="Terazije"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="683693009" version="3" timestamp="2021-02-27T22:54:30Z" changeset="100118825" uid="733709" user="dizajnmario">
+    <nd ref="6357050689"/>
+    <nd ref="6357050788"/>
+    <nd ref="2934914881"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary_link"/>
+    <tag k="lane_markings" v="no"/>
+    <tag k="oneway" v="yes"/>
+    <tag k="surface" v="asphalt"/>
+  </way>
+  <way id="684356845" version="9" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <nd ref="249024039"/>
+    <nd ref="7107738385"/>
+    <nd ref="8222814375"/>
+    <nd ref="5850036516"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="3"/>
+    <tag k="lanes:backward" v="2"/>
+    <tag k="lanes:forward" v="1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="name" v="Македонска"/>
+    <tag k="name:en" v="Makedonska"/>
+    <tag k="name:etymology:wikidata" v="Q103251"/>
+    <tag k="name:sr" v="Македонска"/>
+    <tag k="name:sr-Latn" v="Makedonska"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="trolley_wire" v="yes"/>
+    <tag k="wikidata" v="Q63092521"/>
+    <tag k="wikipedia" v="sr:Македонска улица (Београд)"/>
+  </way>
+  <way id="689894012" version="1" timestamp="2019-05-14T10:17:19Z" changeset="70226215" uid="3207276" user="Armin Gheorghina">
+    <nd ref="6472254613"/>
+    <nd ref="5179720401"/>
+    <nd ref="5179720402"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="689894013" version="2" timestamp="2019-09-20T08:32:33Z" changeset="74709124" uid="3733993" user="Aleksandar1994">
+    <nd ref="6472254614"/>
+    <nd ref="503894451"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="689894014" version="2" timestamp="2019-05-21T11:07:19Z" changeset="70473867" uid="3207276" user="Armin Gheorghina">
+    <nd ref="6472254615"/>
+    <nd ref="6487824763"/>
+    <nd ref="6487824764"/>
+    <nd ref="6472254614"/>
+    <tag k="highway" v="footway"/>
+    <tag k="tunnel" v="building_passage"/>
+  </way>
+  <way id="691410899" version="2" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski">
+    <nd ref="6487824766"/>
+    <nd ref="7923465263"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="691410900" version="1" timestamp="2019-05-21T11:07:18Z" changeset="70473867" uid="3207276" user="Armin Gheorghina">
+    <nd ref="6487824767"/>
+    <nd ref="5179720391"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="694593065" version="3" timestamp="2021-02-23T12:24:02Z" changeset="99825884" uid="733709" user="dizajnmario">
+    <nd ref="6522163985"/>
+    <nd ref="6522163887"/>
+    <nd ref="6522159889"/>
+    <nd ref="6522159890"/>
+    <tag k="crossing" v="zebra"/>
+    <tag k="footway" v="crossing"/>
+    <tag k="highway" v="footway"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="717160493" version="3" timestamp="2021-02-23T12:24:06Z" changeset="99825884" uid="733709" user="dizajnmario">
+    <nd ref="6735402999"/>
+    <nd ref="6735412288"/>
+    <nd ref="6735403187"/>
+    <nd ref="6735412289"/>
+    <tag k="crossing" v="zebra"/>
+    <tag k="footway" v="crossing"/>
+    <tag k="highway" v="footway"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="720375804" version="3" timestamp="2021-02-23T12:23:36Z" changeset="99825856" uid="733709" user="dizajnmario">
+    <nd ref="6760759195"/>
+    <nd ref="6760759194"/>
+    <nd ref="6522159890"/>
+    <tag k="bicycle" v="yes"/>
+    <tag k="highway" v="pedestrian"/>
+    <tag k="noname" v="yes"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="720489083" version="2" timestamp="2021-02-23T12:24:07Z" changeset="99825884" uid="733709" user="dizajnmario">
+    <nd ref="5866002416"/>
+    <nd ref="5866002417"/>
+    <tag k="footway" v="sidewalk"/>
+    <tag k="highway" v="footway"/>
+    <tag k="motor_vehicle" v="permissive"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="720489084" version="2" timestamp="2019-09-18T11:20:48Z" changeset="74620665" uid="6225925" user="Aleksa Marinski">
+    <nd ref="6761575689"/>
+    <nd ref="5866002416"/>
+    <tag k="highway" v="service"/>
+    <tag k="lit" v="yes"/>
+    <tag k="motor_vehicle" v="permissive"/>
+    <tag k="surface" v="paving_stones"/>
+  </way>
+  <way id="722621619" version="5" timestamp="2020-08-04T21:08:10Z" changeset="88948478" uid="6225925" user="Aleksa Marinski">
+    <nd ref="2934914900"/>
+    <nd ref="6761575689"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:backward" v="2"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="lanes:psv:backward" v="1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed" v="30"/>
+    <tag k="name" v="Коларчева"/>
+    <tag k="name:en" v="Kolarčeva"/>
+    <tag k="name:etymology:wikidata" v="Q3148669"/>
+    <tag k="name:sr" v="Коларчева"/>
+    <tag k="name:sr-Latn" v="Kolarčeva"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="752824506" version="2" timestamp="2020-04-05T15:09:30Z" changeset="83102173" uid="95504" user="Branko Kokanovic">
+    <nd ref="6522159889"/>
+    <nd ref="6735403188"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:backward" v="2"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed" v="30"/>
+    <tag k="name" v="Коларчева"/>
+    <tag k="name:en" v="Kolarčeva"/>
+    <tag k="name:etymology:wikidata" v="Q3148669"/>
+    <tag k="name:sr" v="Коларчева"/>
+    <tag k="name:sr-Latn" v="Kolarčeva"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="752824507" version="3" timestamp="2020-08-04T21:08:10Z" changeset="88948478" uid="6225925" user="Aleksa Marinski">
+    <nd ref="6761575689"/>
+    <nd ref="5850036521"/>
+    <nd ref="5850036520"/>
+    <nd ref="5850036519"/>
+    <nd ref="5850036518"/>
+    <nd ref="6522159889"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:backward" v="2"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="lanes:psv:backward" v="1"/>
+    <tag k="lit" v="yes"/>
+    <tag k="maxspeed" v="30"/>
+    <tag k="name" v="Коларчева"/>
+    <tag k="name:en" v="Kolarčeva"/>
+    <tag k="name:etymology:wikidata" v="Q3148669"/>
+    <tag k="name:sr" v="Коларчева"/>
+    <tag k="name:sr-Latn" v="Kolarčeva"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="trolley_wire" v="yes"/>
+  </way>
+  <way id="760800618" version="1" timestamp="2020-01-04T17:25:08Z" changeset="79195151" uid="6225925" user="Aleksa Marinski">
+    <nd ref="7107715486"/>
+    <nd ref="7107738385"/>
+    <nd ref="7107738485"/>
+    <tag k="footway" v="crossing"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="768573346" version="6" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <nd ref="503894445"/>
+    <nd ref="5177170807"/>
+    <nd ref="8222814374"/>
+    <nd ref="8222814373"/>
+    <nd ref="5177170831"/>
+    <nd ref="7609370651"/>
+    <nd ref="7609370652"/>
+    <nd ref="249024039"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:backward" v="2"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="name" v="Дечанска"/>
+    <tag k="name:en" v="Decanska"/>
+    <tag k="name:etymology:wikidata" v="Q939112;Q849517"/>
+    <tag k="name:sr" v="Дечанска"/>
+    <tag k="name:sr-Latn" v="Dečanska"/>
+    <tag k="old_name" v="Моше Пијаде"/>
+    <tag k="old_name:sr" v="Моше Пијаде"/>
+    <tag k="old_name:sr-Latn" v="Moše Pijade"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="turn:lanes:forward" v="through|through"/>
+    <tag k="wikidata" v="Q61133766"/>
+    <tag k="wikipedia" v="sr:Улица Дечанска (Београд)"/>
+  </way>
+  <way id="840586922" version="1" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario">
+    <nd ref="7843762725"/>
+    <nd ref="7843762724"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="0"/>
+    <tag k="tunnel" v="building_passage"/>
+  </way>
+  <way id="840586923" version="1" timestamp="2020-08-25T15:26:37Z" changeset="89923205" uid="733709" user="dizajnmario">
+    <nd ref="7843762724"/>
+    <nd ref="503889009"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="849268326" version="1" timestamp="2020-09-19T15:11:55Z" changeset="91153078" uid="6225925" user="Aleksa Marinski">
+    <nd ref="7923465262"/>
+    <nd ref="7923465258"/>
+    <nd ref="7923465259"/>
+    <nd ref="7923465260"/>
+    <nd ref="503894449"/>
+    <nd ref="503894450"/>
+    <nd ref="6472254615"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="859599232" version="2" timestamp="2020-11-03T08:16:38Z" changeset="93465292" uid="875800" user="Komadinovic Vanja">
+    <nd ref="8012487022"/>
+    <nd ref="503894445"/>
+    <tag k="foot" v="no"/>
+    <tag k="highway" v="secondary"/>
+    <tag k="lanes" v="4"/>
+    <tag k="lanes:backward" v="2"/>
+    <tag k="lanes:forward" v="2"/>
+    <tag k="name" v="Дечанска"/>
+    <tag k="name:en" v="Decanska"/>
+    <tag k="name:etymology:wikidata" v="Q939112;Q849517"/>
+    <tag k="name:sr" v="Дечанска"/>
+    <tag k="name:sr-Latn" v="Dečanska"/>
+    <tag k="old_name" v="Моше Пијаде"/>
+    <tag k="old_name:sr" v="Моше Пијаде"/>
+    <tag k="old_name:sr-Latn" v="Moše Pijade"/>
+    <tag k="surface" v="asphalt"/>
+    <tag k="wikidata" v="Q61133766"/>
+    <tag k="wikipedia" v="sr:Улица Дечанска (Београд)"/>
+  </way>
+  <way id="884185268" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5177170836"/>
+    <nd ref="249024039"/>
+    <nd ref="8222814379"/>
+    <tag k="footway" v="crossing"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="884185269" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5177170841"/>
+    <nd ref="249024039"/>
+    <nd ref="8222814380"/>
+    <tag k="footway" v="crossing"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="884185270" version="1" timestamp="2020-12-12T19:20:15Z" changeset="95733902" uid="6225925" user="Aleksa Marinski">
+    <nd ref="5177170825"/>
+    <nd ref="8222814373"/>
+    <nd ref="5177170830"/>
+    <tag k="footway" v="crossing"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <relation id="2938" version="245" timestamp="2021-01-03T16:46:54Z" changeset="96855440" uid="10980979" user="Mineo">
+    <member type="relation" ref="2764576" role=""/>
+    <member type="relation" ref="2764634" role=""/>
+    <member type="relation" ref="102227" role=""/>
+    <member type="relation" ref="2764556" role=""/>
+    <member type="relation" ref="2764721" role=""/>
+    <member type="relation" ref="215778" role=""/>
+    <member type="relation" ref="2766912" role=""/>
+    <member type="relation" ref="2764744" role=""/>
+    <member type="relation" ref="2764756" role=""/>
+    <member type="relation" ref="2764816" role=""/>
+    <tag k="colour" v="#003399"/>
+    <tag k="cycle_network" v="EuroVelo"/>
+    <tag k="icn_ref" v="6"/>
+    <tag k="name" v="EuroVelo 6 - Atlantic - Black Sea"/>
+    <tag k="name:cs" v="EuroVelo 6 - Atlantik-Černé moře"/>
+    <tag k="name:de" v="EuroVelo 6 - Atlantik-Schwarzes Meer"/>
+    <tag k="name:en" v="EuroVelo 6 - Atlantic - Black Sea"/>
+    <tag k="name:fr" v="EuroVelo 6 - Atlantique-Mer Noire"/>
+    <tag k="name:hr" v="EuroVelo 6 - Atlantik-Crno More"/>
+    <tag k="name:hu" v="EuroVelo 6 - Atlanti-óceán–Fekete-tenger"/>
+    <tag k="name:it" v="EuroVelo 6 - Atlantico-Mar Nero"/>
+    <tag k="name:pl" v="EuroVelo 6 - Atlantyk - Morze Czarne"/>
+    <tag k="name:ro" v="EuroVelo 6 - Atlantic-Marea Neagră"/>
+    <tag k="name:sk" v="EuroVelo 6 - Atlantik-Čierne more"/>
+    <tag k="name:sl" v="EuroVelo 6 - Atlántik-Črno morje"/>
+    <tag k="name:sr" v="ЕуроВело 6 - Атлантик - Црно море"/>
+    <tag k="name:sr-Latn" v="EuroVelo 6 - Atlantik - Crno more"/>
+    <tag k="network" v="icn"/>
+    <tag k="operator" v="European Cyclists' Federation"/>
+    <tag k="ref" v="EV6"/>
+    <tag k="route" v="bicycle"/>
+    <tag k="type" v="superroute"/>
+    <tag k="website" v="https://en.eurovelo.com/ev6"/>
+    <tag k="wikidata" v="Q3060537"/>
+    <tag k="wikipedia" v="en:EV6 The Rivers Route"/>
+  </relation>
+  <relation id="269734" version="152" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="5153659048" role="platform_entry_only"/>
+    <member type="node" ref="830397704" role="platform"/>
+    <member type="node" ref="2051798488" role="platform"/>
+    <member type="node" ref="2066297402" role="platform"/>
+    <member type="node" ref="2059956587" role="platform"/>
+    <member type="node" ref="1331577978" role="platform"/>
+    <member type="node" ref="1808382560" role="platform"/>
+    <member type="node" ref="2059956597" role="platform"/>
+    <member type="node" ref="2053079432" role="platform"/>
+    <member type="node" ref="1685509555" role="platform"/>
+    <member type="node" ref="1618643087" role="platform"/>
+    <member type="node" ref="1618643091" role="platform"/>
+    <member type="node" ref="1618713347" role="platform"/>
+    <member type="node" ref="2055938848" role="platform"/>
+    <member type="node" ref="1796210280" role="platform"/>
+    <member type="node" ref="1796210252" role="platform"/>
+    <member type="node" ref="1796210304" role="platform"/>
+    <member type="node" ref="1796210299" role="platform"/>
+    <member type="node" ref="1796210276" role="platform"/>
+    <member type="node" ref="1796210305" role="platform"/>
+    <member type="node" ref="1796210323" role="platform"/>
+    <member type="node" ref="2055938853" role="platform"/>
+    <member type="node" ref="1796210279" role="platform_exit_only"/>
+    <member type="way" ref="474490835" role=""/>
+    <member type="way" ref="624717793" role=""/>
+    <member type="way" ref="195109746" role=""/>
+    <member type="way" ref="679600751" role=""/>
+    <member type="way" ref="679600752" role=""/>
+    <member type="way" ref="679845348" role=""/>
+    <member type="way" ref="679845347" role=""/>
+    <member type="way" ref="203424510" role=""/>
+    <member type="way" ref="208996982" role=""/>
+    <member type="way" ref="476171272" role=""/>
+    <member type="way" ref="660602095" role=""/>
+    <member type="way" ref="473641213" role=""/>
+    <member type="way" ref="675260095" role=""/>
+    <member type="way" ref="195109737" role=""/>
+    <member type="way" ref="675260094" role=""/>
+    <member type="way" ref="24844511" role=""/>
+    <member type="way" ref="835639937" role=""/>
+    <member type="way" ref="675275513" role=""/>
+    <member type="way" ref="675275514" role=""/>
+    <member type="way" ref="675275515" role=""/>
+    <member type="way" ref="417006296" role=""/>
+    <member type="way" ref="196297234" role=""/>
+    <member type="way" ref="675320912" role=""/>
+    <member type="way" ref="740027655" role=""/>
+    <member type="way" ref="675320911" role=""/>
+    <member type="way" ref="679788255" role=""/>
+    <member type="way" ref="679788256" role=""/>
+    <member type="way" ref="622354859" role=""/>
+    <member type="way" ref="622354840" role=""/>
+    <member type="way" ref="740027654" role=""/>
+    <member type="way" ref="622354855" role=""/>
+    <member type="way" ref="676065810" role=""/>
+    <member type="way" ref="740027653" role=""/>
+    <member type="way" ref="740027652" role=""/>
+    <member type="way" ref="196297237" role=""/>
+    <member type="way" ref="675302536" role=""/>
+    <member type="way" ref="116482670" role=""/>
+    <member type="way" ref="116482674" role=""/>
+    <member type="way" ref="473795254" role=""/>
+    <member type="way" ref="680727271" role=""/>
+    <member type="way" ref="23720049" role=""/>
+    <member type="way" ref="471317420" role=""/>
+    <member type="way" ref="705363889" role=""/>
+    <member type="way" ref="23650408" role=""/>
+    <member type="way" ref="705363890" role=""/>
+    <member type="way" ref="822320892" role=""/>
+    <member type="way" ref="114682422" role=""/>
+    <member type="way" ref="41235874" role=""/>
+    <member type="way" ref="822320897" role=""/>
+    <member type="way" ref="41235877" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23672600" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="195576438" role=""/>
+    <member type="way" ref="680489364" role=""/>
+    <member type="way" ref="679908018" role=""/>
+    <member type="way" ref="200423289" role=""/>
+    <member type="way" ref="459873725" role=""/>
+    <member type="way" ref="465772552" role=""/>
+    <member type="way" ref="381522648" role=""/>
+    <member type="way" ref="23152597" role=""/>
+    <member type="way" ref="679915798" role=""/>
+    <member type="way" ref="381494686" role=""/>
+    <member type="way" ref="647344748" role=""/>
+    <member type="way" ref="461754338" role=""/>
+    <member type="way" ref="676142030" role=""/>
+    <member type="way" ref="287873252" role=""/>
+    <member type="way" ref="26000987" role=""/>
+    <member type="way" ref="26001449" role=""/>
+    <member type="way" ref="41965484" role=""/>
+    <member type="way" ref="408466343" role=""/>
+    <member type="way" ref="408466346" role=""/>
+    <member type="way" ref="39596307" role=""/>
+    <member type="way" ref="121005675" role=""/>
+    <member type="way" ref="39596308" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="45:00"/>
+    <tag k="from" v="Нови Београд /Павиљони/"/>
+    <tag k="from:sr-Latn" v="Novi Beograd /Paviljoni/"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00016"/>
+    <tag k="gtfs:shape_id" v="00016_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="669000"/>
+    <tag k="interval" v="04:00"/>
+    <tag k="name" v="16: Нови Београд /Павиљони/ =&gt; Карабурма 2"/>
+    <tag k="name:sr-Latn" v="16: Novi Beograd /Paviljoni/ =&gt; Karaburma 2"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="16"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Карабурма 2"/>
+    <tag k="to:sr-Latn" v="Karaburma 2"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="269738" version="75" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2655313" role=""/>
+    <member type="relation" ref="2655312" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00095"/>
+    <tag k="name" v="95"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="95"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="270135" version="21" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2627541" role=""/>
+    <member type="relation" ref="2627540" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00028"/>
+    <tag k="name" v="28"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="28"/>
+    <tag k="route_master" v="trolleybus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="270136" version="25" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2627542" role=""/>
+    <member type="relation" ref="2627543" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00029"/>
+    <tag k="name" v="29"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="29"/>
+    <tag k="route_master" v="trolleybus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="270138" version="109" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="957069821" role="platform_entry_only"/>
+    <member type="node" ref="4359066192" role="platform"/>
+    <member type="node" ref="4658245523" role="platform"/>
+    <member type="node" ref="2077480521" role="platform"/>
+    <member type="node" ref="2165543108" role="platform"/>
+    <member type="node" ref="2165460916" role="platform"/>
+    <member type="node" ref="2148659245" role="platform"/>
+    <member type="node" ref="1693518822" role="platform"/>
+    <member type="node" ref="4659538445" role="platform"/>
+    <member type="node" ref="4659551092" role="platform"/>
+    <member type="node" ref="114147859" role="platform"/>
+    <member type="node" ref="1493377975" role="platform"/>
+    <member type="node" ref="1493404090" role="platform"/>
+    <member type="node" ref="2059956599" role="platform"/>
+    <member type="node" ref="1769947072" role="platform"/>
+    <member type="node" ref="5116144222" role="platform_exit_only"/>
+    <member type="way" ref="135929796" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="122976428" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="391815708" role=""/>
+    <member type="way" ref="474200724" role=""/>
+    <member type="way" ref="541623556" role=""/>
+    <member type="way" ref="627370440" role=""/>
+    <member type="way" ref="355758668" role=""/>
+    <member type="way" ref="355758669" role=""/>
+    <member type="way" ref="675314279" role=""/>
+    <member type="way" ref="355758670" role=""/>
+    <member type="way" ref="355758671" role=""/>
+    <member type="way" ref="675314278" role=""/>
+    <member type="way" ref="355758673" role=""/>
+    <member type="way" ref="355758674" role=""/>
+    <member type="way" ref="675487836" role=""/>
+    <member type="way" ref="195576462" role=""/>
+    <member type="way" ref="675516942" role=""/>
+    <member type="way" ref="23079498" role=""/>
+    <member type="way" ref="675518888" role=""/>
+    <member type="way" ref="675516941" role=""/>
+    <member type="way" ref="652132158" role=""/>
+    <member type="way" ref="693301033" role=""/>
+    <member type="way" ref="702625988" role=""/>
+    <member type="way" ref="399303365" role=""/>
+    <member type="way" ref="526358632" role=""/>
+    <member type="way" ref="478708664" role=""/>
+    <member type="way" ref="199914574" role=""/>
+    <member type="way" ref="701304276" role=""/>
+    <member type="way" ref="23090543" role=""/>
+    <member type="way" ref="12528313" role=""/>
+    <member type="way" ref="677140149" role=""/>
+    <member type="way" ref="677131714" role=""/>
+    <member type="way" ref="677111515" role=""/>
+    <member type="way" ref="677137999" role=""/>
+    <member type="way" ref="677111540" role=""/>
+    <member type="way" ref="677111544" role=""/>
+    <member type="way" ref="677111542" role=""/>
+    <member type="way" ref="723343155" role=""/>
+    <member type="way" ref="677111543" role=""/>
+    <member type="way" ref="36948217" role=""/>
+    <member type="way" ref="702634273" role=""/>
+    <member type="way" ref="680371974" role=""/>
+    <member type="way" ref="676328291" role=""/>
+    <member type="way" ref="676362380" role=""/>
+    <member type="way" ref="136098116" role=""/>
+    <member type="way" ref="676362376" role=""/>
+    <member type="way" ref="136092183" role=""/>
+    <member type="way" ref="195144127" role=""/>
+    <member type="way" ref="676362375" role=""/>
+    <member type="way" ref="198644158" role=""/>
+    <member type="way" ref="676377463" role=""/>
+    <member type="way" ref="676377471" role=""/>
+    <member type="way" ref="195144122" role=""/>
+    <member type="way" ref="43929055" role=""/>
+    <member type="way" ref="195144192" role=""/>
+    <member type="way" ref="677167266" role=""/>
+    <member type="way" ref="196715611" role=""/>
+    <member type="way" ref="478290593" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="disused:route" v="trolleybus"/>
+    <tag k="from" v="Студентски Трг"/>
+    <tag k="from:sr-Latn" v="Studentski Trg"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="name" v="19: Студентски Трг =&gt; Коњарник"/>
+    <tag k="name:sr-Latn" v="19: Studentski Trg =&gt; Konjarnik"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="19"/>
+    <tag k="to" v="Коњарник"/>
+    <tag k="to:sr-Latn" v="Konjarnik"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="660161" version="32" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2655310" role=""/>
+    <member type="relation" ref="2655311" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00043"/>
+    <tag k="name" v="43"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="43"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2402665" version="322" timestamp="2021-01-13T11:20:42Z" changeset="97436809" uid="95504" user="Branko Kokanovic">
+    <member type="way" ref="710631153" role=""/>
+    <member type="way" ref="81615588" role=""/>
+    <member type="way" ref="81615549" role=""/>
+    <member type="way" ref="81615593" role=""/>
+    <member type="way" ref="817525277" role=""/>
+    <member type="way" ref="81615419" role=""/>
+    <member type="way" ref="817525278" role=""/>
+    <member type="way" ref="251492819" role=""/>
+    <member type="way" ref="509473571" role=""/>
+    <member type="way" ref="509473570" role=""/>
+    <member type="way" ref="508813705" role=""/>
+    <member type="way" ref="508813704" role=""/>
+    <member type="way" ref="713772241" role=""/>
+    <member type="way" ref="508813694" role=""/>
+    <member type="way" ref="508813695" role=""/>
+    <member type="way" ref="875457897" role=""/>
+    <member type="way" ref="82538501" role=""/>
+    <member type="way" ref="875457896" role=""/>
+    <member type="way" ref="713772239" role=""/>
+    <member type="way" ref="723793411" role=""/>
+    <member type="way" ref="722531465" role=""/>
+    <member type="way" ref="26732456" role=""/>
+    <member type="way" ref="26732455" role=""/>
+    <member type="way" ref="75682032" role="forward"/>
+    <member type="way" ref="701945820" role="forward"/>
+    <member type="way" ref="701945819" role="forward"/>
+    <member type="way" ref="710634217" role=""/>
+    <member type="way" ref="875457901" role=""/>
+    <member type="way" ref="871141487" role=""/>
+    <member type="way" ref="871141486" role=""/>
+    <member type="way" ref="871141491" role=""/>
+    <member type="way" ref="893327876" role=""/>
+    <member type="way" ref="893327875" role=""/>
+    <member type="way" ref="80765168" role="backward"/>
+    <member type="way" ref="80765144" role="backward"/>
+    <member type="way" ref="75682330" role="backward"/>
+    <member type="way" ref="867772798" role="backward"/>
+    <member type="way" ref="80765167" role="forward"/>
+    <member type="way" ref="75682294" role="forward"/>
+    <member type="way" ref="75682399" role="forward"/>
+    <member type="way" ref="867772797" role="forward"/>
+    <member type="way" ref="867772799" role="forward"/>
+    <member type="way" ref="735281267" role=""/>
+    <member type="way" ref="893406313" role=""/>
+    <member type="way" ref="259480287" role=""/>
+    <member type="way" ref="835846448" role=""/>
+    <member type="way" ref="833126873" role=""/>
+    <member type="way" ref="835846452" role=""/>
+    <member type="way" ref="835846451" role=""/>
+    <member type="way" ref="833126872" role=""/>
+    <member type="way" ref="835846446" role=""/>
+    <member type="way" ref="833126870" role=""/>
+    <member type="way" ref="835846447" role=""/>
+    <member type="way" ref="867772800" role="backward"/>
+    <member type="way" ref="835846449" role=""/>
+    <member type="way" ref="835846453" role=""/>
+    <member type="way" ref="833126871" role=""/>
+    <member type="way" ref="833126869" role=""/>
+    <member type="way" ref="808444439" role=""/>
+    <member type="way" ref="808444440" role=""/>
+    <member type="way" ref="833126867" role=""/>
+    <member type="way" ref="835846454" role=""/>
+    <member type="way" ref="713772231" role=""/>
+    <member type="way" ref="713772230" role=""/>
+    <member type="way" ref="735286336" role=""/>
+    <member type="way" ref="835553912" role=""/>
+    <member type="way" ref="835553905" role=""/>
+    <member type="way" ref="75682426" role=""/>
+    <member type="way" ref="737044762" role=""/>
+    <member type="way" ref="835562465" role=""/>
+    <member type="way" ref="835563780" role=""/>
+    <member type="way" ref="142882660" role=""/>
+    <member type="way" ref="142882658" role=""/>
+    <member type="way" ref="835563776" role=""/>
+    <member type="way" ref="835563775" role=""/>
+    <member type="way" ref="835563773" role=""/>
+    <member type="way" ref="142882659" role=""/>
+    <member type="way" ref="835565616" role=""/>
+    <member type="way" ref="835565619" role=""/>
+    <member type="way" ref="835565617" role=""/>
+    <member type="way" ref="75683018" role=""/>
+    <member type="way" ref="26700956" role=""/>
+    <member type="way" ref="260763929" role=""/>
+    <member type="way" ref="26730510" role=""/>
+    <member type="way" ref="875413258" role=""/>
+    <member type="way" ref="875413256" role=""/>
+    <member type="way" ref="875413251" role=""/>
+    <member type="way" ref="875468298" role=""/>
+    <member type="way" ref="875413250" role=""/>
+    <member type="way" ref="875468297" role=""/>
+    <member type="way" ref="587805528" role=""/>
+    <member type="way" ref="587805529" role=""/>
+    <member type="way" ref="645437401" role=""/>
+    <member type="way" ref="645437400" role=""/>
+    <member type="way" ref="781620933" role=""/>
+    <member type="way" ref="781620934" role=""/>
+    <member type="way" ref="256898414" role=""/>
+    <member type="way" ref="691536006" role=""/>
+    <member type="way" ref="691536001" role=""/>
+    <member type="way" ref="256898415" role=""/>
+    <member type="way" ref="691536003" role=""/>
+    <member type="way" ref="691538683" role=""/>
+    <member type="way" ref="375926723" role=""/>
+    <member type="way" ref="691536007" role=""/>
+    <member type="way" ref="236864507" role=""/>
+    <member type="way" ref="26957058" role=""/>
+    <member type="way" ref="637014281" role=""/>
+    <member type="way" ref="375926711" role=""/>
+    <member type="way" ref="375926710" role=""/>
+    <member type="way" ref="637014282" role=""/>
+    <member type="way" ref="236864511" role=""/>
+    <member type="way" ref="588002930" role=""/>
+    <member type="way" ref="588002929" role=""/>
+    <member type="way" ref="340953328" role=""/>
+    <member type="way" ref="236864513" role=""/>
+    <member type="way" ref="236864516" role=""/>
+    <member type="way" ref="672298933" role=""/>
+    <member type="way" ref="672298942" role=""/>
+    <member type="way" ref="672298936" role=""/>
+    <member type="way" ref="257243870" role=""/>
+    <member type="way" ref="257245248" role=""/>
+    <member type="way" ref="392152791" role=""/>
+    <member type="way" ref="588257392" role=""/>
+    <member type="way" ref="92644316" role=""/>
+    <member type="way" ref="224036061" role=""/>
+    <member type="way" ref="224036060" role=""/>
+    <member type="way" ref="725333899" role=""/>
+    <member type="way" ref="725333897" role=""/>
+    <member type="way" ref="726092367" role=""/>
+    <member type="way" ref="736443670" role=""/>
+    <member type="way" ref="725333895" role=""/>
+    <member type="way" ref="726097409" role=""/>
+    <member type="way" ref="726092368" role=""/>
+    <member type="way" ref="736443671" role=""/>
+    <member type="way" ref="736421897" role=""/>
+    <member type="way" ref="736443672" role=""/>
+    <member type="way" ref="92644315" role=""/>
+    <member type="way" ref="736443678" role=""/>
+    <member type="way" ref="392152789" role=""/>
+    <member type="way" ref="19913000" role=""/>
+    <member type="way" ref="398919817" role=""/>
+    <member type="way" ref="398919815" role=""/>
+    <member type="way" ref="229189277" role=""/>
+    <member type="way" ref="725344260" role=""/>
+    <member type="way" ref="726088357" role=""/>
+    <member type="way" ref="726077788" role=""/>
+    <member type="way" ref="725344259" role=""/>
+    <member type="way" ref="725344261" role=""/>
+    <member type="way" ref="219514648" role=""/>
+    <member type="way" ref="219514646" role=""/>
+    <member type="way" ref="229189282" role=""/>
+    <member type="way" ref="144936622" role=""/>
+    <member type="way" ref="266860199" role=""/>
+    <member type="way" ref="516653143" role=""/>
+    <member type="way" ref="758486397" role=""/>
+    <member type="way" ref="758486396" role=""/>
+    <member type="way" ref="239880331" role=""/>
+    <member type="way" ref="239880332" role=""/>
+    <member type="way" ref="144887512" role=""/>
+    <member type="way" ref="356298777" role=""/>
+    <member type="way" ref="356298779" role=""/>
+    <member type="way" ref="356298786" role=""/>
+    <member type="way" ref="358356088" role=""/>
+    <member type="way" ref="8085861" role=""/>
+    <member type="way" ref="23147062" role=""/>
+    <member type="way" ref="23147063" role=""/>
+    <member type="way" ref="370623916" role=""/>
+    <member type="way" ref="881526995" role=""/>
+    <member type="way" ref="289535968" role="forward"/>
+    <member type="way" ref="702060756" role="forward"/>
+    <member type="way" ref="269852798" role="forward"/>
+    <member type="way" ref="269852800" role="forward"/>
+    <member type="way" ref="269852799" role="backward"/>
+    <member type="way" ref="370620006" role="backward"/>
+    <member type="way" ref="289535967" role="backward"/>
+    <member type="way" ref="289535966" role=""/>
+    <member type="way" ref="25197270" role=""/>
+    <member type="way" ref="8080782" role="forward"/>
+    <member type="way" ref="245159912" role="forward"/>
+    <member type="way" ref="725805933" role="forward"/>
+    <member type="way" ref="725805932" role="forward"/>
+    <member type="way" ref="263432401" role="forward"/>
+    <member type="way" ref="8067765" role="forward"/>
+    <member type="way" ref="263388516" role="forward"/>
+    <member type="way" ref="725787061" role="backward"/>
+    <member type="way" ref="106941765" role="backward"/>
+    <member type="way" ref="263388515" role="backward"/>
+    <member type="way" ref="725787060" role="backward"/>
+    <member type="way" ref="122919993" role=""/>
+    <member type="way" ref="622324680" role=""/>
+    <member type="way" ref="449054273" role=""/>
+    <member type="way" ref="289044919" role=""/>
+    <member type="way" ref="724335064" role=""/>
+    <member type="way" ref="724335069" role=""/>
+    <member type="way" ref="289075598" role=""/>
+    <member type="way" ref="808909883" role=""/>
+    <member type="way" ref="808909882" role=""/>
+    <member type="way" ref="808909881" role=""/>
+    <member type="way" ref="808855092" role=""/>
+    <member type="way" ref="289075597" role="forward"/>
+    <member type="way" ref="289075591" role="forward"/>
+    <member type="way" ref="808832912" role="forward"/>
+    <member type="way" ref="147776369" role="backward"/>
+    <member type="way" ref="147776371" role="backward"/>
+    <member type="way" ref="422458253" role="forward"/>
+    <member type="way" ref="422458251" role="forward"/>
+    <member type="way" ref="289075593" role="backward"/>
+    <member type="way" ref="422458240" role="backward"/>
+    <member type="way" ref="422458244" role="backward"/>
+    <member type="way" ref="73687418" role="forward"/>
+    <member type="way" ref="725389386" role="forward"/>
+    <member type="way" ref="148056141" role="backward"/>
+    <member type="way" ref="725389382" role="backward"/>
+    <member type="way" ref="37185517" role="backward"/>
+    <member type="way" ref="726162992" role="backward"/>
+    <member type="way" ref="373653520" role="backward"/>
+    <member type="way" ref="725405488" role="backward"/>
+    <member type="way" ref="725405486" role="backward"/>
+    <member type="way" ref="355741776" role="backward"/>
+    <member type="way" ref="808832914" role="backward"/>
+    <member type="way" ref="725791067" role="backward"/>
+    <member type="way" ref="808832913" role="forward"/>
+    <member type="way" ref="725791065" role="forward"/>
+    <member type="way" ref="637286506" role="forward"/>
+    <member type="way" ref="725405485" role="forward"/>
+    <member type="way" ref="725405487" role="forward"/>
+    <member type="way" ref="373653515" role="forward"/>
+    <member type="way" ref="726162991" role="forward"/>
+    <member type="way" ref="725389379" role="forward"/>
+    <member type="way" ref="174342798" role="forward"/>
+    <member type="way" ref="725389381" role="forward"/>
+    <member type="way" ref="725389380" role="forward"/>
+    <member type="way" ref="92166009" role=""/>
+    <member type="way" ref="92166012" role="forward"/>
+    <member type="way" ref="93207396" role="forward"/>
+    <member type="way" ref="93207373" role="forward"/>
+    <member type="way" ref="286973305" role="backward"/>
+    <member type="way" ref="93207395" role="backward"/>
+    <member type="way" ref="93207382" role="backward"/>
+    <member type="way" ref="107381589" role="forward"/>
+    <member type="way" ref="107381589" role=""/>
+    <member type="way" ref="107381596" role="forward"/>
+    <member type="way" ref="808855085" role="forward"/>
+    <member type="way" ref="725269684" role="forward"/>
+    <member type="way" ref="725269683" role="forward"/>
+    <member type="way" ref="263827317" role="forward"/>
+    <member type="way" ref="867760153" role=""/>
+    <member type="way" ref="867760152" role=""/>
+    <member type="way" ref="867763884" role=""/>
+    <member type="way" ref="75223339" role=""/>
+    <member type="way" ref="867763882" role=""/>
+    <member type="way" ref="808855084" role=""/>
+    <member type="way" ref="157066815" role="forward"/>
+    <member type="way" ref="107381585" role="forward"/>
+    <member type="way" ref="725269675" role="backward"/>
+    <member type="way" ref="263827318" role="backward"/>
+    <member type="way" ref="107381595" role="backward"/>
+    <member type="way" ref="871142842" role=""/>
+    <member type="way" ref="107381597" role=""/>
+    <member type="way" ref="252399089" role=""/>
+    <member type="way" ref="286986911" role=""/>
+    <member type="way" ref="637286511" role=""/>
+    <member type="way" ref="286986486" role=""/>
+    <member type="way" ref="116653527" role=""/>
+    <member type="way" ref="882323091" role=""/>
+    <member type="way" ref="116653516" role=""/>
+    <member type="way" ref="882323093" role=""/>
+    <member type="way" ref="355259841" role=""/>
+    <member type="way" ref="871150183" role=""/>
+    <member type="way" ref="871150184" role=""/>
+    <member type="way" ref="875114216" role=""/>
+    <member type="way" ref="875110724" role=""/>
+    <member type="way" ref="875110723" role=""/>
+    <member type="way" ref="175227186" role=""/>
+    <member type="way" ref="175227187" role=""/>
+    <member type="way" ref="771292091" role=""/>
+    <member type="way" ref="771292090" role=""/>
+    <member type="way" ref="741020038" role=""/>
+    <member type="way" ref="75223388" role=""/>
+    <member type="way" ref="741020041" role=""/>
+    <member type="way" ref="741020037" role=""/>
+    <member type="way" ref="741005232" role=""/>
+    <member type="way" ref="741020042" role=""/>
+    <member type="way" ref="741005227" role=""/>
+    <member type="way" ref="741005230" role=""/>
+    <member type="way" ref="741005229" role=""/>
+    <member type="way" ref="741005226" role=""/>
+    <member type="way" ref="741005231" role=""/>
+    <member type="way" ref="23146874" role=""/>
+    <member type="way" ref="738557813" role=""/>
+    <member type="way" ref="738557818" role=""/>
+    <member type="way" ref="738557817" role=""/>
+    <member type="way" ref="738557816" role=""/>
+    <member type="way" ref="738557819" role=""/>
+    <member type="way" ref="738548865" role=""/>
+    <member type="way" ref="738545887" role=""/>
+    <member type="way" ref="721736633" role=""/>
+    <member type="way" ref="633752934" role=""/>
+    <member type="way" ref="517567391" role=""/>
+    <member type="way" ref="695796181" role=""/>
+    <member type="way" ref="695796180" role=""/>
+    <member type="way" ref="261889393" role=""/>
+    <member type="way" ref="725314873" role=""/>
+    <member type="way" ref="37089006" role=""/>
+    <member type="way" ref="858016982" role=""/>
+    <member type="way" ref="261889390" role=""/>
+    <member type="way" ref="858016983" role=""/>
+    <member type="way" ref="858016985" role=""/>
+    <member type="way" ref="367771152" role=""/>
+    <member type="way" ref="858016986" role=""/>
+    <member type="way" ref="367771151" role=""/>
+    <member type="way" ref="354340312" role=""/>
+    <member type="way" ref="858016987" role=""/>
+    <member type="way" ref="858016989" role=""/>
+    <member type="way" ref="867687807" role=""/>
+    <member type="way" ref="858016988" role=""/>
+    <member type="way" ref="825783138" role=""/>
+    <member type="way" ref="308534789" role=""/>
+    <member type="way" ref="858016991" role=""/>
+    <member type="way" ref="308534788" role=""/>
+    <member type="way" ref="858016992" role=""/>
+    <member type="way" ref="858016993" role=""/>
+    <member type="way" ref="554744707" role=""/>
+    <member type="way" ref="47002086" role=""/>
+    <member type="way" ref="555077555" role=""/>
+    <member type="way" ref="555077556" role=""/>
+    <member type="way" ref="554744706" role=""/>
+    <member type="way" ref="688932458" role=""/>
+    <member type="way" ref="688932447" role=""/>
+    <member type="way" ref="714614418" role=""/>
+    <member type="way" ref="47002085" role=""/>
+    <member type="way" ref="48805030" role=""/>
+    <member type="way" ref="48805032" role=""/>
+    <member type="way" ref="697883041" role=""/>
+    <member type="way" ref="554744703" role=""/>
+    <member type="way" ref="554744705" role=""/>
+    <member type="way" ref="554744704" role=""/>
+    <member type="way" ref="689103190" role=""/>
+    <member type="way" ref="689103200" role=""/>
+    <member type="way" ref="689103185" role=""/>
+    <member type="way" ref="739670120" role=""/>
+    <member type="way" ref="739670094" role=""/>
+    <member type="way" ref="739670093" role=""/>
+    <member type="way" ref="739670092" role=""/>
+    <member type="way" ref="47002084" role=""/>
+    <member type="way" ref="48805042" role=""/>
+    <member type="way" ref="742612712" role=""/>
+    <member type="way" ref="742612711" role=""/>
+    <member type="way" ref="742612710" role=""/>
+    <member type="way" ref="742612709" role=""/>
+    <member type="way" ref="47002087" role=""/>
+    <member type="way" ref="758909254" role=""/>
+    <member type="way" ref="525232672" role=""/>
+    <member type="way" ref="545495978" role=""/>
+    <member type="way" ref="693838392" role=""/>
+    <member type="way" ref="802720798" role=""/>
+    <member type="way" ref="693838391" role=""/>
+    <member type="way" ref="47895796" role=""/>
+    <member type="way" ref="47895797" role=""/>
+    <member type="way" ref="48834584" role=""/>
+    <member type="way" ref="354339451" role=""/>
+    <member type="way" ref="8843851" role=""/>
+    <member type="way" ref="8826248" role=""/>
+    <member type="way" ref="526501617" role=""/>
+    <member type="way" ref="526501596" role=""/>
+    <member type="way" ref="209086494" role=""/>
+    <member type="way" ref="526501587" role=""/>
+    <member type="way" ref="526501592" role=""/>
+    <member type="way" ref="526501619" role=""/>
+    <member type="way" ref="526501618" role=""/>
+    <member type="way" ref="475301088" role=""/>
+    <member type="way" ref="179934184" role=""/>
+    <member type="way" ref="179934183" role=""/>
+    <member type="way" ref="179934182" role=""/>
+    <member type="way" ref="130344378" role=""/>
+    <member type="way" ref="37859010" role=""/>
+    <member type="way" ref="681282572" role=""/>
+    <member type="way" ref="681405085" role=""/>
+    <member type="way" ref="677099877" role=""/>
+    <member type="way" ref="144714967" role=""/>
+    <member type="way" ref="676662076" role=""/>
+    <member type="way" ref="679901109" role=""/>
+    <member type="way" ref="475269102" role=""/>
+    <member type="way" ref="676848681" role=""/>
+    <member type="way" ref="676848682" role=""/>
+    <member type="way" ref="676848680" role=""/>
+    <member type="way" ref="875103743" role=""/>
+    <member type="way" ref="875103742" role=""/>
+    <member type="way" ref="475307931" role=""/>
+    <member type="way" ref="677099880" role=""/>
+    <member type="way" ref="677099881" role=""/>
+    <member type="way" ref="676869561" role=""/>
+    <member type="way" ref="681281119" role=""/>
+    <member type="way" ref="676869562" role=""/>
+    <member type="way" ref="195144204" role=""/>
+    <member type="way" ref="676869560" role=""/>
+    <member type="way" ref="479019391" role=""/>
+    <member type="way" ref="209086486" role=""/>
+    <member type="way" ref="894908303" role=""/>
+    <member type="way" ref="479019390" role=""/>
+    <member type="way" ref="785527419" role=""/>
+    <member type="way" ref="478097541" role=""/>
+    <member type="way" ref="681403881" role=""/>
+    <member type="way" ref="475307928" role=""/>
+    <member type="way" ref="676869556" role=""/>
+    <member type="way" ref="676869559" role=""/>
+    <member type="way" ref="681403880" role=""/>
+    <member type="way" ref="681405083" role=""/>
+    <member type="way" ref="677099878" role=""/>
+    <member type="way" ref="884467496" role=""/>
+    <member type="way" ref="412929436" role=""/>
+    <member type="way" ref="37859009" role=""/>
+    <member type="way" ref="500523371" role=""/>
+    <member type="way" ref="209086498" role=""/>
+    <member type="way" ref="676612177" role=""/>
+    <member type="way" ref="676612169" role=""/>
+    <member type="way" ref="500406653" role=""/>
+    <member type="way" ref="676612173" role=""/>
+    <member type="way" ref="354344705" role=""/>
+    <member type="way" ref="679901095" role=""/>
+    <member type="way" ref="473641208" role=""/>
+    <member type="way" ref="473641211" role=""/>
+    <member type="way" ref="474805530" role=""/>
+    <member type="way" ref="679901093" role=""/>
+    <member type="way" ref="679901092" role=""/>
+    <member type="way" ref="472091322" role=""/>
+    <member type="way" ref="679873932" role=""/>
+    <member type="way" ref="679873935" role=""/>
+    <member type="way" ref="679873933" role=""/>
+    <member type="way" ref="679872603" role=""/>
+    <member type="way" ref="688876243" role=""/>
+    <member type="way" ref="679871496" role=""/>
+    <member type="way" ref="365392549" role=""/>
+    <member type="way" ref="679871497" role=""/>
+    <member type="way" ref="679871498" role=""/>
+    <member type="way" ref="679871499" role=""/>
+    <member type="way" ref="679869843" role=""/>
+    <member type="way" ref="679869844" role=""/>
+    <member type="way" ref="679869845" role=""/>
+    <member type="way" ref="679868961" role=""/>
+    <member type="way" ref="679868965" role=""/>
+    <member type="way" ref="679865913" role=""/>
+    <member type="way" ref="679865914" role=""/>
+    <member type="way" ref="679864977" role=""/>
+    <member type="way" ref="679864978" role=""/>
+    <member type="way" ref="679864979" role=""/>
+    <member type="way" ref="679864981" role=""/>
+    <member type="way" ref="676594758" role=""/>
+    <member type="way" ref="196297299" role=""/>
+    <member type="way" ref="196297300" role=""/>
+    <member type="way" ref="408884499" role=""/>
+    <member type="way" ref="96346705" role=""/>
+    <member type="way" ref="328778602" role=""/>
+    <member type="way" ref="676386548" role=""/>
+    <member type="way" ref="680124858" role=""/>
+    <member type="way" ref="680124856" role=""/>
+    <member type="way" ref="676386547" role=""/>
+    <member type="way" ref="329633347" role=""/>
+    <member type="way" ref="680115555" role=""/>
+    <member type="way" ref="676417159" role=""/>
+    <member type="way" ref="676386546" role=""/>
+    <member type="way" ref="676417156" role=""/>
+    <member type="way" ref="680143384" role=""/>
+    <member type="way" ref="43664586" role=""/>
+    <member type="way" ref="680143381" role=""/>
+    <member type="way" ref="680143382" role=""/>
+    <member type="way" ref="680143385" role=""/>
+    <member type="way" ref="24779422" role=""/>
+    <member type="way" ref="653890212" role=""/>
+    <member type="way" ref="25092843" role=""/>
+    <member type="way" ref="25311889" role="forward"/>
+    <member type="way" ref="680143386" role="forward"/>
+    <member type="way" ref="23578253" role="forward"/>
+    <member type="way" ref="625018648" role="forward"/>
+    <member type="way" ref="676027207" role="forward"/>
+    <member type="way" ref="676027982" role="forward"/>
+    <member type="way" ref="676027981" role="forward"/>
+    <member type="way" ref="412169579" role="forward"/>
+    <member type="way" ref="625018645" role="forward"/>
+    <member type="way" ref="625018638" role="forward"/>
+    <member type="way" ref="676028777" role="forward"/>
+    <member type="way" ref="676028775" role="forward"/>
+    <member type="way" ref="676028776" role="forward"/>
+    <member type="way" ref="488427211" role="forward"/>
+    <member type="way" ref="531118874" role="forward"/>
+    <member type="way" ref="676032164" role="forward"/>
+    <member type="way" ref="676032163" role="forward"/>
+    <member type="way" ref="676032160" role="forward"/>
+    <member type="way" ref="643891368" role="forward"/>
+    <member type="way" ref="643892530" role="forward"/>
+    <member type="way" ref="875104366" role="forward"/>
+    <member type="way" ref="643892835" role="forward"/>
+    <member type="way" ref="676035677" role="forward"/>
+    <member type="way" ref="648042148" role="forward"/>
+    <member type="way" ref="676035675" role="forward"/>
+    <member type="way" ref="676035676" role="forward"/>
+    <member type="way" ref="208469481" role="forward"/>
+    <member type="way" ref="23720049" role="forward"/>
+    <member type="way" ref="471317420" role="forward"/>
+    <member type="way" ref="23650408" role="forward"/>
+    <member type="way" ref="531118876" role="forward"/>
+    <member type="way" ref="203424539" role="forward"/>
+    <member type="way" ref="676032165" role="forward"/>
+    <member type="way" ref="676030471" role="forward"/>
+    <member type="way" ref="676030472" role="forward"/>
+    <member type="way" ref="625018643" role="forward"/>
+    <member type="way" ref="676030476" role="forward"/>
+    <member type="way" ref="676030477" role="forward"/>
+    <member type="way" ref="114682422" role="forward"/>
+    <member type="way" ref="41235874" role="forward"/>
+    <member type="way" ref="822320897" role="forward"/>
+    <member type="way" ref="41235877" role="forward"/>
+    <member type="way" ref="290014336" role="forward"/>
+    <member type="way" ref="532823603" role="forward"/>
+    <member type="way" ref="23712777" role="forward"/>
+    <member type="way" ref="154244381" role="forward"/>
+    <member type="way" ref="448103774" role="forward"/>
+    <member type="way" ref="448103775" role="forward"/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23672600" role="forward"/>
+    <member type="way" ref="23073170" role="forward"/>
+    <member type="way" ref="23672662" role="backward"/>
+    <member type="way" ref="474488021" role="backward"/>
+    <member type="way" ref="679609972" role="backward"/>
+    <member type="way" ref="412169588" role="backward"/>
+    <member type="way" ref="625018647" role="backward"/>
+    <member type="way" ref="625018646" role="backward"/>
+    <member type="way" ref="625018640" role="backward"/>
+    <member type="way" ref="679609962" role="backward"/>
+    <member type="way" ref="625018641" role="backward"/>
+    <member type="way" ref="203424538" role="backward"/>
+    <member type="way" ref="675288309" role="backward"/>
+    <member type="way" ref="675288306" role="backward"/>
+    <member type="way" ref="676030473" role="backward"/>
+    <member type="way" ref="675288313" role="backward"/>
+    <member type="way" ref="675463803" role="backward"/>
+    <member type="way" ref="531118878" role="backward"/>
+    <member type="way" ref="478280102" role="backward"/>
+    <member type="way" ref="675312232" role="backward"/>
+    <member type="way" ref="473759843" role="backward"/>
+    <member type="way" ref="25311886" role="backward"/>
+    <member type="way" ref="26826000" role="backward"/>
+    <member type="way" ref="676108741" role="backward"/>
+    <member type="way" ref="822320893" role="backward"/>
+    <member type="way" ref="205987189" role="backward"/>
+    <member type="way" ref="41235875" role="backward"/>
+    <member type="way" ref="41235876" role="backward"/>
+    <member type="way" ref="675220727" role="backward"/>
+    <member type="way" ref="675220726" role="backward"/>
+    <member type="way" ref="290012968" role="backward"/>
+    <member type="way" ref="290012969" role="backward"/>
+    <member type="way" ref="643892832" role="backward"/>
+    <member type="way" ref="875104365" role="backward"/>
+    <member type="way" ref="643892532" role="backward"/>
+    <member type="way" ref="676032158" role="backward"/>
+    <member type="way" ref="676044238" role="backward"/>
+    <member type="way" ref="675312229" role="backward"/>
+    <member type="way" ref="675312228" role="backward"/>
+    <member type="way" ref="675312227" role="backward"/>
+    <member type="way" ref="675312226" role="backward"/>
+    <member type="way" ref="643892533" role="backward"/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="286981822" role="forward"/>
+    <member type="way" ref="358356089" role=""/>
+    <member type="way" ref="738545890" role=""/>
+    <member type="way" ref="738545892" role=""/>
+    <member type="way" ref="354340310" role=""/>
+    <member type="way" ref="738545891" role=""/>
+    <member type="way" ref="257334943" role=""/>
+    <member type="way" ref="37088993" role=""/>
+    <member type="way" ref="813907018" role=""/>
+    <member type="way" ref="813907019" role=""/>
+    <member type="way" ref="721736639" role=""/>
+    <member type="way" ref="721736638" role=""/>
+    <member type="way" ref="721736632" role=""/>
+    <member type="way" ref="633752933" role=""/>
+    <member type="way" ref="695720981" role=""/>
+    <member type="way" ref="517795401" role=""/>
+    <member type="way" ref="517795400" role=""/>
+    <tag k="distance" v="197.7"/>
+    <tag k="name" v="M22.1"/>
+    <tag k="network" v="RS:national"/>
+    <tag k="old_ref" v="M22.1"/>
+    <tag k="route" v="road"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2625734" version="130" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="1796210279" role="platform_entry_only"/>
+    <member type="node" ref="5116045651" role="platform"/>
+    <member type="node" ref="1796210328" role="platform"/>
+    <member type="node" ref="1796210307" role="platform"/>
+    <member type="node" ref="4723298158" role="platform"/>
+    <member type="node" ref="1796210303" role="platform"/>
+    <member type="node" ref="1796210257" role="platform"/>
+    <member type="node" ref="1796210294" role="platform"/>
+    <member type="node" ref="2055938849" role="platform"/>
+    <member type="node" ref="2055938851" role="platform"/>
+    <member type="node" ref="1618717623" role="platform"/>
+    <member type="node" ref="1618643103" role="platform"/>
+    <member type="node" ref="1618643110" role="platform"/>
+    <member type="node" ref="1685509556" role="platform"/>
+    <member type="node" ref="2053079440" role="platform"/>
+    <member type="node" ref="1808382562" role="platform"/>
+    <member type="node" ref="1808382559" role="platform"/>
+    <member type="node" ref="1331577993" role="platform"/>
+    <member type="node" ref="2059956590" role="platform"/>
+    <member type="node" ref="2051798487" role="platform"/>
+    <member type="node" ref="830397914" role="platform"/>
+    <member type="node" ref="5153659049" role="platform_exit_only"/>
+    <member type="way" ref="577591507" role=""/>
+    <member type="way" ref="577591509" role=""/>
+    <member type="way" ref="41201424" role=""/>
+    <member type="way" ref="474842438" role=""/>
+    <member type="way" ref="121005675" role=""/>
+    <member type="way" ref="39596307" role=""/>
+    <member type="way" ref="408466344" role=""/>
+    <member type="way" ref="474838751" role=""/>
+    <member type="way" ref="474838748" role=""/>
+    <member type="way" ref="408466345" role=""/>
+    <member type="way" ref="26001449" role=""/>
+    <member type="way" ref="26000987" role=""/>
+    <member type="way" ref="676139576" role=""/>
+    <member type="way" ref="676139575" role=""/>
+    <member type="way" ref="287873251" role=""/>
+    <member type="way" ref="676139573" role=""/>
+    <member type="way" ref="41201421" role=""/>
+    <member type="way" ref="676631539" role=""/>
+    <member type="way" ref="647344755" role=""/>
+    <member type="way" ref="676663863" role=""/>
+    <member type="way" ref="685870724" role=""/>
+    <member type="way" ref="200423286" role=""/>
+    <member type="way" ref="465772552" role=""/>
+    <member type="way" ref="459873725" role=""/>
+    <member type="way" ref="200423289" role=""/>
+    <member type="way" ref="291559250" role=""/>
+    <member type="way" ref="200724860" role=""/>
+    <member type="way" ref="478468906" role=""/>
+    <member type="way" ref="200724862" role=""/>
+    <member type="way" ref="675555278" role=""/>
+    <member type="way" ref="574867478" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23672662" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="290012969" role=""/>
+    <member type="way" ref="290012968" role=""/>
+    <member type="way" ref="675220726" role=""/>
+    <member type="way" ref="675220727" role=""/>
+    <member type="way" ref="41235876" role=""/>
+    <member type="way" ref="41235875" role=""/>
+    <member type="way" ref="205987189" role=""/>
+    <member type="way" ref="822320893" role=""/>
+    <member type="way" ref="676108741" role=""/>
+    <member type="way" ref="26826000" role=""/>
+    <member type="way" ref="131952994" role=""/>
+    <member type="way" ref="680727272" role=""/>
+    <member type="way" ref="92469728" role=""/>
+    <member type="way" ref="675478314" role=""/>
+    <member type="way" ref="116482680" role=""/>
+    <member type="way" ref="116482672" role=""/>
+    <member type="way" ref="675312233" role=""/>
+    <member type="way" ref="196297236" role=""/>
+    <member type="way" ref="675484789" role=""/>
+    <member type="way" ref="675484790" role=""/>
+    <member type="way" ref="622354847" role=""/>
+    <member type="way" ref="675485549" role=""/>
+    <member type="way" ref="675485546" role=""/>
+    <member type="way" ref="622354851" role=""/>
+    <member type="way" ref="675320913" role=""/>
+    <member type="way" ref="675320914" role=""/>
+    <member type="way" ref="417006301" role=""/>
+    <member type="way" ref="675486047" role=""/>
+    <member type="way" ref="675486046" role=""/>
+    <member type="way" ref="196297235" role=""/>
+    <member type="way" ref="473641212" role=""/>
+    <member type="way" ref="23578196" role=""/>
+    <member type="way" ref="676275082" role=""/>
+    <member type="way" ref="676275081" role=""/>
+    <member type="way" ref="676280080" role=""/>
+    <member type="way" ref="676280079" role=""/>
+    <member type="way" ref="208996975" role=""/>
+    <member type="way" ref="195109740" role=""/>
+    <member type="way" ref="195109744" role=""/>
+    <member type="way" ref="195109745" role=""/>
+    <member type="way" ref="679600753" role=""/>
+    <member type="way" ref="208996986" role=""/>
+    <member type="way" ref="679600754" role=""/>
+    <member type="way" ref="199914563" role=""/>
+    <member type="way" ref="199914572" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="45:00"/>
+    <tag k="from" v="Карабурма 2"/>
+    <tag k="from:sr-Latn" v="Karaburma 2"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00016"/>
+    <tag k="gtfs:shape_id" v="00016_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="669003"/>
+    <tag k="interval" v="04:00"/>
+    <tag k="name" v="16: Карабурма 2 =&gt; Нови Београд /Павиљони/"/>
+    <tag k="name:sr-Latn" v="16: Karaburma 2 =&gt; Novi Beograd /Paviljoni/"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="16"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Нови Београд /Павиљони/"/>
+    <tag k="to:sr-Latn" v="Novi Beograd /Paviljoni/"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2625736" version="10" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2625734" role=""/>
+    <member type="relation" ref="269734" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00016"/>
+    <tag k="name" v="16"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="16"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2626210" version="81" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="965840651" role="platform_entry_only"/>
+    <member type="node" ref="1769947073" role="platform"/>
+    <member type="node" ref="1493404092" role="platform"/>
+    <member type="node" ref="1493404089" role="platform"/>
+    <member type="node" ref="249251890" role="platform"/>
+    <member type="node" ref="475029120" role="platform"/>
+    <member type="node" ref="4659551091" role="platform"/>
+    <member type="node" ref="1693535022" role="platform"/>
+    <member type="node" ref="1693518819" role="platform"/>
+    <member type="node" ref="4682002342" role="platform"/>
+    <member type="node" ref="2165462758" role="platform"/>
+    <member type="node" ref="2165543291" role="platform"/>
+    <member type="node" ref="4658236196" role="platform"/>
+    <member type="node" ref="4658245524" role="platform"/>
+    <member type="node" ref="1124739236" role="platform"/>
+    <member type="node" ref="957069819" role="platform_exit_only"/>
+    <member type="way" ref="881419949" role=""/>
+    <member type="way" ref="478290594" role=""/>
+    <member type="way" ref="677167310" role=""/>
+    <member type="way" ref="677167328" role=""/>
+    <member type="way" ref="677167297" role=""/>
+    <member type="way" ref="677167305" role=""/>
+    <member type="way" ref="677167285" role=""/>
+    <member type="way" ref="526007428" role=""/>
+    <member type="way" ref="677167271" role=""/>
+    <member type="way" ref="676385447" role=""/>
+    <member type="way" ref="195144130" role=""/>
+    <member type="way" ref="676385446" role=""/>
+    <member type="way" ref="195144125" role=""/>
+    <member type="way" ref="676412517" role=""/>
+    <member type="way" ref="676412516" role=""/>
+    <member type="way" ref="676412518" role=""/>
+    <member type="way" ref="136092184" role=""/>
+    <member type="way" ref="676388364" role=""/>
+    <member type="way" ref="136098115" role=""/>
+    <member type="way" ref="702634271" role=""/>
+    <member type="way" ref="702634272" role=""/>
+    <member type="way" ref="677111545" role=""/>
+    <member type="way" ref="677111543" role=""/>
+    <member type="way" ref="723343155" role=""/>
+    <member type="way" ref="677111542" role=""/>
+    <member type="way" ref="677111544" role=""/>
+    <member type="way" ref="677111540" role=""/>
+    <member type="way" ref="677137999" role=""/>
+    <member type="way" ref="677111515" role=""/>
+    <member type="way" ref="677131714" role=""/>
+    <member type="way" ref="677140149" role=""/>
+    <member type="way" ref="12528313" role=""/>
+    <member type="way" ref="23090543" role=""/>
+    <member type="way" ref="701304276" role=""/>
+    <member type="way" ref="199914574" role=""/>
+    <member type="way" ref="478708664" role=""/>
+    <member type="way" ref="526358632" role=""/>
+    <member type="way" ref="399303365" role=""/>
+    <member type="way" ref="702625988" role=""/>
+    <member type="way" ref="693301033" role=""/>
+    <member type="way" ref="652132158" role=""/>
+    <member type="way" ref="675516941" role=""/>
+    <member type="way" ref="675518888" role=""/>
+    <member type="way" ref="23079498" role=""/>
+    <member type="way" ref="675516943" role=""/>
+    <member type="way" ref="195576462" role=""/>
+    <member type="way" ref="675487836" role=""/>
+    <member type="way" ref="355758674" role=""/>
+    <member type="way" ref="355758673" role=""/>
+    <member type="way" ref="675314278" role=""/>
+    <member type="way" ref="355758671" role=""/>
+    <member type="way" ref="355758670" role=""/>
+    <member type="way" ref="675314279" role=""/>
+    <member type="way" ref="355758669" role=""/>
+    <member type="way" ref="355758668" role=""/>
+    <member type="way" ref="676861483" role=""/>
+    <member type="way" ref="6121432" role=""/>
+    <member type="way" ref="391815719" role=""/>
+    <member type="way" ref="474200724" role=""/>
+    <member type="way" ref="391815707" role=""/>
+    <member type="way" ref="541623551" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="23786175" role=""/>
+    <member type="way" ref="676885138" role=""/>
+    <member type="way" ref="721794451" role=""/>
+    <member type="way" ref="155396485" role=""/>
+    <member type="way" ref="289959026" role=""/>
+    <member type="way" ref="680974973" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="135929794" role=""/>
+    <member type="way" ref="82203841" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="disused:route" v="trolleybus"/>
+    <tag k="from" v="Коњарник"/>
+    <tag k="from:sr-Latn" v="Konjarnik"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="name" v="19: Коњарник =&gt; Студентски Трг"/>
+    <tag k="name:sr-Latn" v="19: Konjarnik =&gt; Studentski Trg"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="19"/>
+    <tag k="to" v="Студентски Трг"/>
+    <tag k="to:sr-Latn" v="Studentski Trg"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2627540" version="64" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="4359066201" role="platform_entry_only"/>
+    <member type="node" ref="5866599809" role="platform"/>
+    <member type="node" ref="1541542019" role="platform"/>
+    <member type="node" ref="1541542041" role="platform"/>
+    <member type="node" ref="1541510107" role="platform"/>
+    <member type="node" ref="4016399425" role="platform"/>
+    <member type="node" ref="1541510121" role="platform"/>
+    <member type="node" ref="1541510109" role="platform"/>
+    <member type="node" ref="1541510132" role="platform"/>
+    <member type="node" ref="6551419003" role="platform"/>
+    <member type="node" ref="1541510115" role="platform"/>
+    <member type="node" ref="5152183601" role="platform_exit_only"/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005684" role=""/>
+    <member type="way" ref="684356845" role=""/>
+    <member type="way" ref="676637001" role=""/>
+    <member type="way" ref="195576461" role=""/>
+    <member type="way" ref="751959845" role=""/>
+    <member type="way" ref="751959844" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="63204501" role=""/>
+    <member type="way" ref="676379850" role=""/>
+    <member type="way" ref="676379846" role=""/>
+    <member type="way" ref="556944649" role=""/>
+    <member type="way" ref="676379853" role=""/>
+    <member type="way" ref="676382067" role=""/>
+    <member type="way" ref="676382066" role=""/>
+    <member type="way" ref="556944702" role=""/>
+    <member type="way" ref="751976828" role=""/>
+    <member type="way" ref="63204850" role=""/>
+    <member type="way" ref="23098126" role=""/>
+    <member type="way" ref="63204557" role=""/>
+    <member type="way" ref="675319417" role=""/>
+    <member type="way" ref="197158298" role=""/>
+    <member type="way" ref="473657978" role=""/>
+    <member type="way" ref="675316529" role=""/>
+    <member type="way" ref="205598210" role=""/>
+    <member type="way" ref="23102985" role=""/>
+    <member type="way" ref="680389472" role=""/>
+    <member type="way" ref="677695986" role=""/>
+    <member type="way" ref="677695985" role=""/>
+    <member type="way" ref="677695982" role=""/>
+    <member type="way" ref="677695980" role=""/>
+    <member type="way" ref="677695978" role=""/>
+    <member type="way" ref="677695977" role=""/>
+    <member type="way" ref="677695970" role=""/>
+    <member type="way" ref="677695966" role=""/>
+    <member type="way" ref="677695962" role=""/>
+    <member type="way" ref="677695960" role=""/>
+    <member type="way" ref="205598203" role=""/>
+    <member type="way" ref="871154993" role=""/>
+    <member type="way" ref="705360568" role=""/>
+    <member type="way" ref="705360569" role=""/>
+    <member type="way" ref="705360567" role=""/>
+    <member type="way" ref="705360566" role=""/>
+    <member type="way" ref="680391877" role=""/>
+    <member type="way" ref="680391878" role=""/>
+    <member type="way" ref="871156114" role=""/>
+    <member type="way" ref="677697515" role=""/>
+    <member type="way" ref="135929799" role=""/>
+    <member type="way" ref="23103010" role=""/>
+    <member type="way" ref="400293418" role=""/>
+    <member type="way" ref="850225631" role=""/>
+    <member type="way" ref="478158039" role=""/>
+    <member type="way" ref="478158040" role=""/>
+    <member type="way" ref="135929800" role=""/>
+    <member type="way" ref="627370436" role=""/>
+    <member type="way" ref="265703017" role=""/>
+    <member type="way" ref="63204498" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="duration" v="31:30"/>
+    <tag k="from" v="Студентски Трг"/>
+    <tag k="from:sr-Latn" v="Studentski Trg"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00028"/>
+    <tag k="gtfs:shape_id" v="00028_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="684616"/>
+    <tag k="interval" v="09:00"/>
+    <tag k="name" v="28: Студентски Трг =&gt; Звездара"/>
+    <tag k="name:sr-Latn" v="28: Studentski Trg =&gt; Zvezdara"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="28"/>
+    <tag k="route" v="trolleybus"/>
+    <tag k="to" v="Звездара"/>
+    <tag k="to:sr-Latn" v="Zvezdara"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2627541" version="57" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="2713215326" role="platform_entry_only"/>
+    <member type="node" ref="4714130115" role="platform"/>
+    <member type="node" ref="475064480" role="platform"/>
+    <member type="node" ref="1541510130" role="platform"/>
+    <member type="node" ref="1541510133" role="platform"/>
+    <member type="node" ref="1541510112" role="platform"/>
+    <member type="node" ref="1541510118" role="platform"/>
+    <member type="node" ref="4016399426" role="platform"/>
+    <member type="node" ref="1541510108" role="platform"/>
+    <member type="node" ref="1541542037" role="platform"/>
+    <member type="node" ref="1541542031" role="platform"/>
+    <member type="node" ref="1124739236" role="platform"/>
+    <member type="node" ref="957069819" role="platform_exit_only"/>
+    <member type="way" ref="135929800" role=""/>
+    <member type="way" ref="627370436" role=""/>
+    <member type="way" ref="265703017" role=""/>
+    <member type="way" ref="63204498" role=""/>
+    <member type="way" ref="478158040" role=""/>
+    <member type="way" ref="478158039" role=""/>
+    <member type="way" ref="850225631" role=""/>
+    <member type="way" ref="400293418" role=""/>
+    <member type="way" ref="23103010" role=""/>
+    <member type="way" ref="23103030" role=""/>
+    <member type="way" ref="676849764" role=""/>
+    <member type="way" ref="680391879" role=""/>
+    <member type="way" ref="680391880" role=""/>
+    <member type="way" ref="676849763" role=""/>
+    <member type="way" ref="676855352" role=""/>
+    <member type="way" ref="676855351" role=""/>
+    <member type="way" ref="676855342" role=""/>
+    <member type="way" ref="680389471" role=""/>
+    <member type="way" ref="680389470" role=""/>
+    <member type="way" ref="36947117" role=""/>
+    <member type="way" ref="205598204" role=""/>
+    <member type="way" ref="23098118" role=""/>
+    <member type="way" ref="205598215" role=""/>
+    <member type="way" ref="675318442" role=""/>
+    <member type="way" ref="675318441" role=""/>
+    <member type="way" ref="197158296" role=""/>
+    <member type="way" ref="676073614" role=""/>
+    <member type="way" ref="135929792" role=""/>
+    <member type="way" ref="23098126" role=""/>
+    <member type="way" ref="63204850" role=""/>
+    <member type="way" ref="751976828" role=""/>
+    <member type="way" ref="556944702" role=""/>
+    <member type="way" ref="676382066" role=""/>
+    <member type="way" ref="676382067" role=""/>
+    <member type="way" ref="676379853" role=""/>
+    <member type="way" ref="556944649" role=""/>
+    <member type="way" ref="676379846" role=""/>
+    <member type="way" ref="676379850" role=""/>
+    <member type="way" ref="63204501" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="751959844" role=""/>
+    <member type="way" ref="751959845" role=""/>
+    <member type="way" ref="195576461" role=""/>
+    <member type="way" ref="676637001" role=""/>
+    <member type="way" ref="684356845" role=""/>
+    <member type="way" ref="619005684" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="135929794" role=""/>
+    <member type="way" ref="82203841" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="duration" v="33:00"/>
+    <tag k="from" v="Звездара"/>
+    <tag k="from:sr-Latn" v="Zvezdara"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00028"/>
+    <tag k="gtfs:shape_id" v="00028_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="684617"/>
+    <tag k="interval" v="09:00"/>
+    <tag k="name" v="28: Звездара =&gt; Студентски Трг"/>
+    <tag k="name:sr-Latn" v="28: Zvezdara =&gt; Studentski Trg"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="28"/>
+    <tag k="route" v="trolleybus"/>
+    <tag k="to" v="Студентски Трг"/>
+    <tag k="to:sr-Latn" v="Studentski Trg"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2627542" version="96" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="957069821" role="platform_entry_only"/>
+    <member type="node" ref="4359066192" role="platform"/>
+    <member type="node" ref="4658245523" role="platform"/>
+    <member type="node" ref="2077480521" role="platform"/>
+    <member type="node" ref="2165543108" role="platform"/>
+    <member type="node" ref="2165460916" role="platform"/>
+    <member type="node" ref="2148659245" role="platform"/>
+    <member type="node" ref="1693518822" role="platform"/>
+    <member type="node" ref="4659538445" role="platform"/>
+    <member type="node" ref="4659551092" role="platform"/>
+    <member type="node" ref="114147859" role="platform"/>
+    <member type="node" ref="1493377975" role="platform"/>
+    <member type="node" ref="1493404090" role="platform"/>
+    <member type="node" ref="3811515040" role="platform"/>
+    <member type="node" ref="1493343395" role="platform"/>
+    <member type="node" ref="1493343387" role="platform"/>
+    <member type="node" ref="8198905650" role="platform"/>
+    <member type="node" ref="2676100853" role="platform_exit_only"/>
+    <member type="way" ref="135929796" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="122976428" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="391815708" role=""/>
+    <member type="way" ref="474200724" role=""/>
+    <member type="way" ref="541623556" role=""/>
+    <member type="way" ref="627370440" role=""/>
+    <member type="way" ref="355758668" role=""/>
+    <member type="way" ref="355758669" role=""/>
+    <member type="way" ref="675314279" role=""/>
+    <member type="way" ref="355758670" role=""/>
+    <member type="way" ref="355758671" role=""/>
+    <member type="way" ref="675314278" role=""/>
+    <member type="way" ref="355758673" role=""/>
+    <member type="way" ref="355758674" role=""/>
+    <member type="way" ref="675487836" role=""/>
+    <member type="way" ref="195576462" role=""/>
+    <member type="way" ref="675516942" role=""/>
+    <member type="way" ref="23079498" role=""/>
+    <member type="way" ref="675518888" role=""/>
+    <member type="way" ref="675516941" role=""/>
+    <member type="way" ref="652132158" role=""/>
+    <member type="way" ref="693301033" role=""/>
+    <member type="way" ref="702625988" role=""/>
+    <member type="way" ref="399303365" role=""/>
+    <member type="way" ref="526358632" role=""/>
+    <member type="way" ref="478708664" role=""/>
+    <member type="way" ref="199914574" role=""/>
+    <member type="way" ref="701304276" role=""/>
+    <member type="way" ref="23090543" role=""/>
+    <member type="way" ref="12528313" role=""/>
+    <member type="way" ref="677140149" role=""/>
+    <member type="way" ref="677131714" role=""/>
+    <member type="way" ref="677111515" role=""/>
+    <member type="way" ref="677137999" role=""/>
+    <member type="way" ref="677111540" role=""/>
+    <member type="way" ref="677111544" role=""/>
+    <member type="way" ref="677111542" role=""/>
+    <member type="way" ref="723343155" role=""/>
+    <member type="way" ref="677111543" role=""/>
+    <member type="way" ref="36948217" role=""/>
+    <member type="way" ref="702634273" role=""/>
+    <member type="way" ref="680371974" role=""/>
+    <member type="way" ref="676328291" role=""/>
+    <member type="way" ref="676362380" role=""/>
+    <member type="way" ref="136098116" role=""/>
+    <member type="way" ref="676362376" role=""/>
+    <member type="way" ref="136092183" role=""/>
+    <member type="way" ref="195144127" role=""/>
+    <member type="way" ref="676362375" role=""/>
+    <member type="way" ref="198644158" role=""/>
+    <member type="way" ref="676377463" role=""/>
+    <member type="way" ref="676377471" role=""/>
+    <member type="way" ref="195144122" role=""/>
+    <member type="way" ref="676865683" role=""/>
+    <member type="way" ref="704484570" role=""/>
+    <member type="way" ref="704484569" role=""/>
+    <member type="way" ref="195144132" role=""/>
+    <member type="way" ref="676865677" role=""/>
+    <member type="way" ref="674927676" role=""/>
+    <member type="way" ref="135270351" role=""/>
+    <member type="way" ref="135270348" role=""/>
+    <member type="way" ref="676880429" role=""/>
+    <member type="way" ref="676880432" role=""/>
+    <member type="way" ref="676880426" role=""/>
+    <member type="way" ref="676880417" role=""/>
+    <member type="way" ref="676880416" role=""/>
+    <member type="way" ref="198644157" role=""/>
+    <member type="way" ref="676880414" role=""/>
+    <member type="way" ref="32662526" role=""/>
+    <member type="way" ref="677089987" role=""/>
+    <member type="way" ref="136088102" role=""/>
+    <member type="way" ref="725326205" role=""/>
+    <member type="way" ref="875415879" role=""/>
+    <member type="way" ref="136088107" role=""/>
+    <member type="way" ref="473668060" role=""/>
+    <member type="way" ref="478070000" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="duration" v="44:00"/>
+    <tag k="from" v="Студентски Трг"/>
+    <tag k="from:sr-Latn" v="Studentski Trg"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00029"/>
+    <tag k="gtfs:shape_id" v="00029_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="686211"/>
+    <tag k="interval" v="04:00"/>
+    <tag k="name" v="29: Студентски Трг =&gt; Медаковић 3"/>
+    <tag k="name:sr-Latn" v="29: Studentski Trg =&gt; Medaković 3"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="29"/>
+    <tag k="route" v="trolleybus"/>
+    <tag k="to" v="Медаковић 3"/>
+    <tag k="to:sr-Latn" v="Medaković 3"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2627543" version="85" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="2676100846" role="platform_entry_only"/>
+    <member type="node" ref="5116144224" role="platform"/>
+    <member type="node" ref="249251872" role="platform"/>
+    <member type="node" ref="4659850128" role="platform"/>
+    <member type="node" ref="1493404092" role="platform"/>
+    <member type="node" ref="1493404089" role="platform"/>
+    <member type="node" ref="249251890" role="platform"/>
+    <member type="node" ref="475029120" role="platform"/>
+    <member type="node" ref="4659551091" role="platform"/>
+    <member type="node" ref="1693535022" role="platform"/>
+    <member type="node" ref="1693518819" role="platform"/>
+    <member type="node" ref="4682002342" role="platform"/>
+    <member type="node" ref="2165462758" role="platform"/>
+    <member type="node" ref="2165543291" role="platform"/>
+    <member type="node" ref="4658236196" role="platform"/>
+    <member type="node" ref="4658245524" role="platform"/>
+    <member type="node" ref="1124739236" role="platform"/>
+    <member type="node" ref="957069819" role="platform_exit_only"/>
+    <member type="way" ref="526005393" role=""/>
+    <member type="way" ref="136088106" role=""/>
+    <member type="way" ref="677089985" role=""/>
+    <member type="way" ref="676287825" role=""/>
+    <member type="way" ref="32662525" role=""/>
+    <member type="way" ref="23090913" role=""/>
+    <member type="way" ref="676880415" role=""/>
+    <member type="way" ref="676880420" role=""/>
+    <member type="way" ref="676880424" role=""/>
+    <member type="way" ref="676880422" role=""/>
+    <member type="way" ref="676880423" role=""/>
+    <member type="way" ref="135270350" role=""/>
+    <member type="way" ref="681634324" role=""/>
+    <member type="way" ref="681634326" role=""/>
+    <member type="way" ref="136094808" role=""/>
+    <member type="way" ref="676865678" role=""/>
+    <member type="way" ref="198644159" role=""/>
+    <member type="way" ref="676865682" role=""/>
+    <member type="way" ref="196715545" role=""/>
+    <member type="way" ref="195144123" role=""/>
+    <member type="way" ref="676385447" role=""/>
+    <member type="way" ref="195144130" role=""/>
+    <member type="way" ref="676385446" role=""/>
+    <member type="way" ref="195144125" role=""/>
+    <member type="way" ref="676412517" role=""/>
+    <member type="way" ref="676412516" role=""/>
+    <member type="way" ref="676412518" role=""/>
+    <member type="way" ref="136092184" role=""/>
+    <member type="way" ref="676388364" role=""/>
+    <member type="way" ref="136098115" role=""/>
+    <member type="way" ref="702634271" role=""/>
+    <member type="way" ref="702634272" role=""/>
+    <member type="way" ref="677111545" role=""/>
+    <member type="way" ref="677111543" role=""/>
+    <member type="way" ref="723343155" role=""/>
+    <member type="way" ref="677111542" role=""/>
+    <member type="way" ref="677111544" role=""/>
+    <member type="way" ref="677111540" role=""/>
+    <member type="way" ref="677137999" role=""/>
+    <member type="way" ref="677111515" role=""/>
+    <member type="way" ref="677131714" role=""/>
+    <member type="way" ref="677140149" role=""/>
+    <member type="way" ref="12528313" role=""/>
+    <member type="way" ref="23090543" role=""/>
+    <member type="way" ref="701304276" role=""/>
+    <member type="way" ref="199914574" role=""/>
+    <member type="way" ref="478708664" role=""/>
+    <member type="way" ref="526358632" role=""/>
+    <member type="way" ref="399303365" role=""/>
+    <member type="way" ref="702625988" role=""/>
+    <member type="way" ref="693301033" role=""/>
+    <member type="way" ref="652132158" role=""/>
+    <member type="way" ref="675516941" role=""/>
+    <member type="way" ref="675518888" role=""/>
+    <member type="way" ref="23079498" role=""/>
+    <member type="way" ref="675516943" role=""/>
+    <member type="way" ref="195576462" role=""/>
+    <member type="way" ref="675487836" role=""/>
+    <member type="way" ref="355758674" role=""/>
+    <member type="way" ref="355758673" role=""/>
+    <member type="way" ref="675314278" role=""/>
+    <member type="way" ref="355758671" role=""/>
+    <member type="way" ref="355758670" role=""/>
+    <member type="way" ref="675314279" role=""/>
+    <member type="way" ref="355758669" role=""/>
+    <member type="way" ref="355758668" role=""/>
+    <member type="way" ref="676861483" role=""/>
+    <member type="way" ref="6121432" role=""/>
+    <member type="way" ref="391815719" role=""/>
+    <member type="way" ref="474200724" role=""/>
+    <member type="way" ref="391815707" role=""/>
+    <member type="way" ref="541623551" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="23786175" role=""/>
+    <member type="way" ref="676885138" role=""/>
+    <member type="way" ref="721794451" role=""/>
+    <member type="way" ref="155396485" role=""/>
+    <member type="way" ref="289959026" role=""/>
+    <member type="way" ref="680974973" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="135929794" role=""/>
+    <member type="way" ref="82203841" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="duration" v="45:00"/>
+    <tag k="from" v="Медаковић 3"/>
+    <tag k="from:sr-Latn" v="Medaković 3"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00029"/>
+    <tag k="gtfs:shape_id" v="00029_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="687695"/>
+    <tag k="interval" v="04:00"/>
+    <tag k="name" v="29: Медаковић 3 =&gt; Студентски Трг"/>
+    <tag k="name:sr-Latn" v="29: Medaković 3 =&gt; Studentski Trg"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="29"/>
+    <tag k="route" v="trolleybus"/>
+    <tag k="to" v="Студентски Трг"/>
+    <tag k="to:sr-Latn" v="Studentski Trg"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2627546" version="112" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="4359066201" role="platform_entry_only"/>
+    <member type="node" ref="5866599809" role="platform"/>
+    <member type="node" ref="1541542019" role="platform"/>
+    <member type="node" ref="2059750345" role="platform"/>
+    <member type="node" ref="2059750330" role="platform"/>
+    <member type="node" ref="5116045641" role="platform"/>
+    <member type="node" ref="4711935307" role="platform"/>
+    <member type="node" ref="1599229496" role="platform"/>
+    <member type="node" ref="4711907793" role="platform"/>
+    <member type="node" ref="4711949167" role="platform"/>
+    <member type="node" ref="4711949168" role="platform"/>
+    <member type="node" ref="4711967885" role="platform"/>
+    <member type="node" ref="4711972727" role="platform"/>
+    <member type="node" ref="4685597874" role="platform"/>
+    <member type="node" ref="4685597875" role="platform"/>
+    <member type="node" ref="4708454804" role="platform"/>
+    <member type="node" ref="3934995521" role="platform"/>
+    <member type="node" ref="3934995528" role="platform"/>
+    <member type="node" ref="8149086117" role="platform_exit_only"/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005684" role=""/>
+    <member type="way" ref="684356845" role=""/>
+    <member type="way" ref="676637001" role=""/>
+    <member type="way" ref="195576461" role=""/>
+    <member type="way" ref="751959845" role=""/>
+    <member type="way" ref="751959844" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="676379851" role=""/>
+    <member type="way" ref="841262422" role=""/>
+    <member type="way" ref="382485121" role=""/>
+    <member type="way" ref="543843688" role=""/>
+    <member type="way" ref="23098076" role=""/>
+    <member type="way" ref="543843689" role=""/>
+    <member type="way" ref="543842714" role=""/>
+    <member type="way" ref="543842713" role=""/>
+    <member type="way" ref="150899566" role=""/>
+    <member type="way" ref="365056147" role=""/>
+    <member type="way" ref="197158264" role=""/>
+    <member type="way" ref="196715565" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="24282347" role=""/>
+    <member type="way" ref="65399757" role=""/>
+    <member type="way" ref="200366254" role=""/>
+    <member type="way" ref="200366253" role=""/>
+    <member type="way" ref="36930474" role=""/>
+    <member type="way" ref="478250195" role=""/>
+    <member type="way" ref="684411205" role=""/>
+    <member type="way" ref="679504537" role=""/>
+    <member type="way" ref="63204846" role=""/>
+    <member type="way" ref="751312468" role=""/>
+    <member type="way" ref="63204847" role=""/>
+    <member type="way" ref="605749115" role=""/>
+    <member type="way" ref="658402353" role=""/>
+    <member type="way" ref="685068782" role=""/>
+    <member type="way" ref="685068781" role=""/>
+    <member type="way" ref="286363251" role=""/>
+    <member type="way" ref="677924692" role=""/>
+    <member type="way" ref="677924691" role=""/>
+    <member type="way" ref="286363255" role=""/>
+    <member type="way" ref="477903368" role=""/>
+    <member type="way" ref="286363257" role=""/>
+    <member type="way" ref="677713925" role=""/>
+    <member type="way" ref="195576441" role=""/>
+    <member type="way" ref="678459699" role=""/>
+    <member type="way" ref="677161486" role=""/>
+    <member type="way" ref="477903107" role=""/>
+    <member type="way" ref="172420783" role=""/>
+    <member type="way" ref="677161484" role=""/>
+    <member type="way" ref="34866876" role=""/>
+    <member type="way" ref="525993049" role=""/>
+    <member type="way" ref="525993051" role=""/>
+    <member type="way" ref="739097519" role=""/>
+    <member type="way" ref="658409000" role=""/>
+    <member type="way" ref="725402757" role=""/>
+    <member type="way" ref="659295384" role=""/>
+    <member type="way" ref="198723972" role=""/>
+    <member type="way" ref="54531243" role=""/>
+    <member type="way" ref="24282734" role=""/>
+    <member type="way" ref="677763017" role=""/>
+    <member type="way" ref="677992044" role=""/>
+    <member type="way" ref="677763015" role=""/>
+    <member type="way" ref="677763016" role=""/>
+    <member type="way" ref="677992045" role=""/>
+    <member type="way" ref="677992047" role=""/>
+    <member type="way" ref="677992046" role=""/>
+    <member type="way" ref="24282695" role=""/>
+    <member type="way" ref="121899290" role=""/>
+    <member type="way" ref="402207165" role=""/>
+    <member type="way" ref="63205320" role=""/>
+    <member type="way" ref="198644171" role=""/>
+    <member type="way" ref="676922434" role=""/>
+    <member type="way" ref="676922435" role=""/>
+    <member type="way" ref="676922436" role=""/>
+    <member type="way" ref="196715614" role=""/>
+    <member type="way" ref="677764788" role=""/>
+    <member type="way" ref="286260830" role=""/>
+    <member type="way" ref="678009217" role=""/>
+    <member type="way" ref="477505108" role=""/>
+    <member type="way" ref="29051311" role=""/>
+    <member type="way" ref="813956781" role=""/>
+    <member type="way" ref="477505107" role=""/>
+    <member type="way" ref="208317942" role=""/>
+    <member type="way" ref="63205316" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="duration" v="44:00"/>
+    <tag k="from" v="Студентски Трг"/>
+    <tag k="from:sr-Latn" v="Studentski Trg"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00041"/>
+    <tag k="gtfs:shape_id" v="00041_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="685544"/>
+    <tag k="interval" v="05:00"/>
+    <tag k="name" v="41: Студентски Трг =&gt; Бањица 2"/>
+    <tag k="name:sr-Latn" v="41: Studentski Trg =&gt; Banjica 2"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="41"/>
+    <tag k="route" v="trolleybus"/>
+    <tag k="to" v="Бањица 2"/>
+    <tag k="to:sr-Latn" v="Banjica 2"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2627547" version="103" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="3934995530" role="platform_entry_only"/>
+    <member type="node" ref="3934995529" role="platform"/>
+    <member type="node" ref="3934995522" role="platform"/>
+    <member type="node" ref="4708454803" role="platform"/>
+    <member type="node" ref="4685597876" role="platform"/>
+    <member type="node" ref="4685597873" role="platform"/>
+    <member type="node" ref="4711972726" role="platform"/>
+    <member type="node" ref="4711967886" role="platform"/>
+    <member type="node" ref="4711949169" role="platform"/>
+    <member type="node" ref="4711949166" role="platform"/>
+    <member type="node" ref="4711907794" role="platform"/>
+    <member type="node" ref="1599229647" role="platform"/>
+    <member type="node" ref="4663473499" role="platform"/>
+    <member type="node" ref="5116045644" role="platform"/>
+    <member type="node" ref="2059750331" role="platform"/>
+    <member type="node" ref="2059750410" role="platform"/>
+    <member type="node" ref="1637649117" role="platform"/>
+    <member type="node" ref="1541542031" role="platform"/>
+    <member type="node" ref="1124739236" role="platform"/>
+    <member type="node" ref="957069819" role="platform_exit_only"/>
+    <member type="way" ref="475888654" role=""/>
+    <member type="way" ref="135929793" role=""/>
+    <member type="way" ref="208317942" role=""/>
+    <member type="way" ref="477505107" role=""/>
+    <member type="way" ref="813956781" role=""/>
+    <member type="way" ref="29051311" role=""/>
+    <member type="way" ref="477505108" role=""/>
+    <member type="way" ref="678009217" role=""/>
+    <member type="way" ref="286260830" role=""/>
+    <member type="way" ref="677764788" role=""/>
+    <member type="way" ref="196715614" role=""/>
+    <member type="way" ref="676922436" role=""/>
+    <member type="way" ref="676922435" role=""/>
+    <member type="way" ref="676922434" role=""/>
+    <member type="way" ref="198644171" role=""/>
+    <member type="way" ref="63205320" role=""/>
+    <member type="way" ref="24282697" role=""/>
+    <member type="way" ref="402207163" role=""/>
+    <member type="way" ref="24282695" role=""/>
+    <member type="way" ref="677992046" role=""/>
+    <member type="way" ref="677992047" role=""/>
+    <member type="way" ref="677992045" role=""/>
+    <member type="way" ref="677763016" role=""/>
+    <member type="way" ref="677763015" role=""/>
+    <member type="way" ref="677992044" role=""/>
+    <member type="way" ref="677763017" role=""/>
+    <member type="way" ref="136079943" role=""/>
+    <member type="way" ref="54531243" role=""/>
+    <member type="way" ref="677992043" role=""/>
+    <member type="way" ref="24282718" role=""/>
+    <member type="way" ref="198723975" role=""/>
+    <member type="way" ref="658409000" role=""/>
+    <member type="way" ref="739097519" role=""/>
+    <member type="way" ref="525993051" role=""/>
+    <member type="way" ref="525993049" role=""/>
+    <member type="way" ref="34866876" role=""/>
+    <member type="way" ref="24282390" role=""/>
+    <member type="way" ref="606131081" role=""/>
+    <member type="way" ref="163975610" role=""/>
+    <member type="way" ref="678459691" role=""/>
+    <member type="way" ref="195576440" role=""/>
+    <member type="way" ref="677713927" role=""/>
+    <member type="way" ref="406441764" role=""/>
+    <member type="way" ref="685068780" role=""/>
+    <member type="way" ref="685068779" role=""/>
+    <member type="way" ref="677966367" role=""/>
+    <member type="way" ref="606131088" role=""/>
+    <member type="way" ref="63204848" role=""/>
+    <member type="way" ref="684411202" role=""/>
+    <member type="way" ref="24282340" role=""/>
+    <member type="way" ref="65399798" role=""/>
+    <member type="way" ref="200366255" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="472134922" role=""/>
+    <member type="way" ref="289953743" role=""/>
+    <member type="way" ref="289953740" role=""/>
+    <member type="way" ref="543843035" role=""/>
+    <member type="way" ref="543843689" role=""/>
+    <member type="way" ref="23098076" role=""/>
+    <member type="way" ref="543843688" role=""/>
+    <member type="way" ref="382485121" role=""/>
+    <member type="way" ref="841262422" role=""/>
+    <member type="way" ref="676379851" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="751959844" role=""/>
+    <member type="way" ref="751959845" role=""/>
+    <member type="way" ref="195576461" role=""/>
+    <member type="way" ref="676637001" role=""/>
+    <member type="way" ref="684356845" role=""/>
+    <member type="way" ref="619005684" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="135929794" role=""/>
+    <member type="way" ref="82203841" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="duration" v="46:00"/>
+    <tag k="from" v="Бањица 2"/>
+    <tag k="from:sr-Latn" v="Banjica 2"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00041"/>
+    <tag k="gtfs:shape_id" v="00041_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="685543"/>
+    <tag k="interval" v="05:00"/>
+    <tag k="name" v="41: Бањица 2 =&gt; Студентски Трг"/>
+    <tag k="name:sr-Latn" v="41: Banjica 2 =&gt; Studentski Trg"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="41"/>
+    <tag k="route" v="trolleybus"/>
+    <tag k="to" v="Студентски Трг"/>
+    <tag k="to:sr-Latn" v="Studentski Trg"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631223" version="68" timestamp="2021-03-07T22:33:43Z" changeset="100594602" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="2041567126" role="platform_entry_only"/>
+    <member type="node" ref="4682111488" role="platform"/>
+    <member type="node" ref="8495150052" role="platform"/>
+    <member type="node" ref="4682134316" role="platform"/>
+    <member type="node" ref="1618592187" role="platform"/>
+    <member type="node" ref="1119942190" role="platform"/>
+    <member type="node" ref="2148659246" role="platform"/>
+    <member type="node" ref="4676720722" role="platform"/>
+    <member type="node" ref="2148659247" role="platform"/>
+    <member type="node" ref="2148659248" role="platform"/>
+    <member type="node" ref="4682089949" role="platform"/>
+    <member type="node" ref="4682089946" role="platform"/>
+    <member type="node" ref="2148659245" role="platform"/>
+    <member type="node" ref="5196560933" role="platform"/>
+    <member type="node" ref="2148659244" role="platform_exit_only"/>
+    <member type="way" ref="474206817" role=""/>
+    <member type="way" ref="195576478" role=""/>
+    <member type="way" ref="26833144" role=""/>
+    <member type="way" ref="26833142" role=""/>
+    <member type="way" ref="148788166" role=""/>
+    <member type="way" ref="23066742" role=""/>
+    <member type="way" ref="677899115" role=""/>
+    <member type="way" ref="675324015" role=""/>
+    <member type="way" ref="675324016" role=""/>
+    <member type="way" ref="395684568" role=""/>
+    <member type="way" ref="675324014" role=""/>
+    <member type="way" ref="148788173" role=""/>
+    <member type="way" ref="865790869" role=""/>
+    <member type="way" ref="478112831" role=""/>
+    <member type="way" ref="675324013" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="23115219" role=""/>
+    <member type="way" ref="694060036" role=""/>
+    <member type="way" ref="619005693" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="23078542" role=""/>
+    <member type="way" ref="768501209" role=""/>
+    <member type="way" ref="122976429" role=""/>
+    <member type="way" ref="150899570" role=""/>
+    <member type="way" ref="195576480" role=""/>
+    <member type="way" ref="676671124" role=""/>
+    <member type="way" ref="676671123" role=""/>
+    <member type="way" ref="196715609" role=""/>
+    <member type="way" ref="23078641" role=""/>
+    <member type="way" ref="289953738" role=""/>
+    <member type="way" ref="289953744" role=""/>
+    <member type="way" ref="676612785" role=""/>
+    <member type="way" ref="197158258" role=""/>
+    <member type="way" ref="476316512" role=""/>
+    <member type="way" ref="676866522" role=""/>
+    <member type="way" ref="195576473" role=""/>
+    <member type="way" ref="195576435" role=""/>
+    <member type="way" ref="195576434" role=""/>
+    <member type="way" ref="660055166" role=""/>
+    <member type="way" ref="660055164" role=""/>
+    <member type="way" ref="30424275" role=""/>
+    <member type="way" ref="195576462" role=""/>
+    <member type="way" ref="675516942" role=""/>
+    <member type="way" ref="23298053" role=""/>
+    <member type="way" ref="195576468" role=""/>
+    <member type="way" ref="195576453" role=""/>
+    <tag k="colour" v="#008000"/>
+    <tag k="duration" v="44:00"/>
+    <tag k="from" v="Дорћол /СРЦ Милан Гале Мушкатировић/"/>
+    <tag k="from:sr-Latn" v="Dorćol /SRC Milan Gale Muškatirović/"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00024"/>
+    <tag k="gtfs:shape_id" v="00024_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="710616"/>
+    <tag k="interval" v="17:00"/>
+    <tag k="name" v="24: Дорћол /СРЦ Милан Гале Мушкатировић/ =&gt; Неимар"/>
+    <tag k="name:sr-Latn" v="24: Dorćol /SRC Milan Gale Muškatirović/ =&gt; Neimar"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="24"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Неимар"/>
+    <tag k="to:sr-Latn" v="Neimar"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631224" version="72" timestamp="2021-03-07T22:33:43Z" changeset="100594602" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="2148659244" role="platform_entry_only"/>
+    <member type="node" ref="4682002342" role="platform"/>
+    <member type="node" ref="4682089947" role="platform"/>
+    <member type="node" ref="4682089948" role="platform"/>
+    <member type="node" ref="4682089950" role="platform"/>
+    <member type="node" ref="4682089951" role="platform"/>
+    <member type="node" ref="4676720721" role="platform"/>
+    <member type="node" ref="4663473498" role="platform"/>
+    <member type="node" ref="4359064380" role="platform"/>
+    <member type="node" ref="4658230790" role="platform"/>
+    <member type="node" ref="4678513201" role="platform"/>
+    <member type="node" ref="4678513204" role="platform"/>
+    <member type="node" ref="4682111487" role="platform"/>
+    <member type="node" ref="5782135213" role="platform"/>
+    <member type="node" ref="8151261234" role="platform_exit_only"/>
+    <member type="way" ref="195576469" role=""/>
+    <member type="way" ref="195576468" role=""/>
+    <member type="way" ref="23298053" role=""/>
+    <member type="way" ref="675516943" role=""/>
+    <member type="way" ref="195576462" role=""/>
+    <member type="way" ref="30424275" role=""/>
+    <member type="way" ref="660055164" role=""/>
+    <member type="way" ref="660055166" role=""/>
+    <member type="way" ref="195576434" role=""/>
+    <member type="way" ref="195576456" role=""/>
+    <member type="way" ref="23078715" role=""/>
+    <member type="way" ref="676603333" role=""/>
+    <member type="way" ref="676603330" role=""/>
+    <member type="way" ref="195576445" role=""/>
+    <member type="way" ref="676671125" role=""/>
+    <member type="way" ref="700929590" role=""/>
+    <member type="way" ref="205990049" role=""/>
+    <member type="way" ref="676370571" role=""/>
+    <member type="way" ref="676370570" role=""/>
+    <member type="way" ref="150899574" role=""/>
+    <member type="way" ref="289953739" role=""/>
+    <member type="way" ref="289953742" role=""/>
+    <member type="way" ref="472134926" role=""/>
+    <member type="way" ref="169037914" role=""/>
+    <member type="way" ref="768510156" role=""/>
+    <member type="way" ref="23078558" role=""/>
+    <member type="way" ref="676663793" role=""/>
+    <member type="way" ref="23098071" role=""/>
+    <member type="way" ref="230065295" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="684356845" role=""/>
+    <member type="way" ref="619005684" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="686663563" role=""/>
+    <member type="way" ref="476367774" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="675324013" role=""/>
+    <member type="way" ref="478112831" role=""/>
+    <member type="way" ref="865790869" role=""/>
+    <member type="way" ref="148788173" role=""/>
+    <member type="way" ref="675324014" role=""/>
+    <member type="way" ref="395684568" role=""/>
+    <member type="way" ref="675324016" role=""/>
+    <member type="way" ref="675324015" role=""/>
+    <member type="way" ref="677899115" role=""/>
+    <member type="way" ref="23066742" role=""/>
+    <member type="way" ref="148788166" role=""/>
+    <member type="way" ref="26833142" role=""/>
+    <member type="way" ref="26833144" role=""/>
+    <member type="way" ref="195576478" role=""/>
+    <member type="way" ref="195576477" role=""/>
+    <member type="way" ref="474206816" role=""/>
+    <tag k="colour" v="#008000"/>
+    <tag k="duration" v="44:00"/>
+    <tag k="from" v="Неимар"/>
+    <tag k="from:sr-Latn" v="Neimar"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00024"/>
+    <tag k="gtfs:shape_id" v="00024_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="733463"/>
+    <tag k="interval" v="17:00"/>
+    <tag k="name" v="24: Неимар =&gt; Дорћол /СРЦ Милан Гале Мушкатировић/"/>
+    <tag k="name:sr-Latn" v="24: Neimar =&gt; Dorćol /SRC Milan Gale Muškatirović/"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="24"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Дорћол /СРЦ Милан Гале Мушкатировић/"/>
+    <tag k="to:sr-Latn" v="Dorćol /SRC Milan Gale Muškatirović/"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631227" version="110" timestamp="2021-03-07T22:33:43Z" changeset="100594602" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="1103264970" role="platform"/>
+    <member type="node" ref="4726205266" role="platform"/>
+    <member type="node" ref="8495150052" role="platform"/>
+    <member type="node" ref="4682134316" role="platform"/>
+    <member type="node" ref="1618592187" role="platform"/>
+    <member type="node" ref="1119942190" role="platform"/>
+    <member type="node" ref="2148659246" role="platform"/>
+    <member type="node" ref="4676720722" role="platform"/>
+    <member type="node" ref="4676720723" role="platform"/>
+    <member type="node" ref="4676720724" role="platform"/>
+    <member type="node" ref="1677964941" role="platform"/>
+    <member type="node" ref="4190734875" role="platform"/>
+    <member type="node" ref="4659428891" role="platform"/>
+    <member type="node" ref="3930430431" role="platform"/>
+    <member type="node" ref="4659512848" role="platform"/>
+    <member type="node" ref="2773646125" role="platform"/>
+    <member type="node" ref="2773646135" role="platform"/>
+    <member type="node" ref="2788344680" role="platform"/>
+    <member type="node" ref="2773619644" role="platform"/>
+    <member type="node" ref="4181531547" role="platform"/>
+    <member type="node" ref="2773595685" role="platform"/>
+    <member type="node" ref="2781907604" role="platform"/>
+    <member type="node" ref="4663339667" role="platform"/>
+    <member type="way" ref="473808039" role=""/>
+    <member type="way" ref="23070598" role=""/>
+    <member type="way" ref="23714543" role=""/>
+    <member type="way" ref="574867483" role=""/>
+    <member type="way" ref="148788173" role=""/>
+    <member type="way" ref="865790869" role=""/>
+    <member type="way" ref="478112831" role=""/>
+    <member type="way" ref="675324013" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="23115219" role=""/>
+    <member type="way" ref="694060036" role=""/>
+    <member type="way" ref="619005693" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="23078542" role=""/>
+    <member type="way" ref="768501209" role=""/>
+    <member type="way" ref="122976429" role=""/>
+    <member type="way" ref="150899570" role=""/>
+    <member type="way" ref="195576480" role=""/>
+    <member type="way" ref="676671124" role=""/>
+    <member type="way" ref="676671123" role=""/>
+    <member type="way" ref="196715609" role=""/>
+    <member type="way" ref="23078641" role=""/>
+    <member type="way" ref="289953738" role=""/>
+    <member type="way" ref="289953744" role=""/>
+    <member type="way" ref="676612785" role=""/>
+    <member type="way" ref="197158258" role=""/>
+    <member type="way" ref="476316512" role=""/>
+    <member type="way" ref="676866522" role=""/>
+    <member type="way" ref="195576443" role=""/>
+    <member type="way" ref="676612784" role=""/>
+    <member type="way" ref="676885851" role=""/>
+    <member type="way" ref="806539409" role=""/>
+    <member type="way" ref="289911373" role=""/>
+    <member type="way" ref="841047450" role=""/>
+    <member type="way" ref="676885849" role=""/>
+    <member type="way" ref="56693670" role=""/>
+    <member type="way" ref="121005672" role=""/>
+    <member type="way" ref="897589548" role=""/>
+    <member type="way" ref="56693672" role=""/>
+    <member type="way" ref="23073332" role=""/>
+    <member type="way" ref="121005679" role=""/>
+    <member type="way" ref="675319188" role=""/>
+    <member type="way" ref="675319189" role=""/>
+    <member type="way" ref="675525767" role=""/>
+    <member type="way" ref="652132159" role=""/>
+    <member type="way" ref="675518887" role=""/>
+    <member type="way" ref="675518886" role=""/>
+    <member type="way" ref="675497915" role=""/>
+    <member type="way" ref="680381440" role=""/>
+    <member type="way" ref="675497916" role=""/>
+    <member type="way" ref="521432746" role=""/>
+    <member type="way" ref="753830170" role=""/>
+    <member type="way" ref="28958545" role=""/>
+    <member type="way" ref="683558577" role=""/>
+    <member type="way" ref="526356195" role=""/>
+    <member type="way" ref="871136581" role=""/>
+    <member type="way" ref="56694157" role=""/>
+    <member type="way" ref="28926635" role=""/>
+    <member type="way" ref="669577276" role=""/>
+    <member type="way" ref="669577278" role=""/>
+    <member type="way" ref="396243951" role=""/>
+    <member type="way" ref="10505344" role=""/>
+    <member type="way" ref="10505345" role=""/>
+    <member type="way" ref="56694374" role=""/>
+    <member type="way" ref="396243952" role=""/>
+    <member type="way" ref="273335902" role=""/>
+    <member type="way" ref="273335897" role=""/>
+    <member type="way" ref="273335903" role=""/>
+    <member type="way" ref="195576423" role=""/>
+    <member type="way" ref="12528497" role=""/>
+    <member type="way" ref="676596481" role=""/>
+    <member type="way" ref="881757258" role=""/>
+    <member type="way" ref="12528753" role=""/>
+    <member type="way" ref="284852017" role=""/>
+    <member type="way" ref="23091006" role=""/>
+    <member type="way" ref="195576450" role=""/>
+    <member type="way" ref="661612616" role=""/>
+    <member type="way" ref="182499070" role=""/>
+    <member type="way" ref="195576437" role=""/>
+    <member type="way" ref="195144069" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="60:00"/>
+    <tag k="from" v="Дорћол /Дунавска/"/>
+    <tag k="from:sr-Latn" v="Dorćol /Dunavska/"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00026"/>
+    <tag k="gtfs:shape_id" v="00026_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="738120"/>
+    <tag k="interval" v="05:00"/>
+    <tag k="name" v="26: Дорћол /Дунавска/ =&gt; Насеље Браће Јерковић"/>
+    <tag k="name:sr-Latn" v="26: Dorćol /Dunavska/ =&gt; Naselje Braće Jerković"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="26"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Насеље Браће Јерковић"/>
+    <tag k="to:sr-Latn" v="Naselje Braće Jerković"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631228" version="184" timestamp="2021-03-07T22:33:43Z" changeset="100594602" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="4677385027" role="platform"/>
+    <member type="node" ref="3811210729" role="platform"/>
+    <member type="node" ref="2773595684" role="platform"/>
+    <member type="node" ref="4181531546" role="platform"/>
+    <member type="node" ref="2773619643" role="platform"/>
+    <member type="node" ref="3183583107" role="platform"/>
+    <member type="node" ref="2773646130" role="platform"/>
+    <member type="node" ref="2773646120" role="platform"/>
+    <member type="node" ref="4659512849" role="platform"/>
+    <member type="node" ref="3930430430" role="platform"/>
+    <member type="node" ref="4659428892" role="platform"/>
+    <member type="node" ref="3923385875" role="platform"/>
+    <member type="node" ref="702297257" role="platform"/>
+    <member type="node" ref="4676720720" role="platform"/>
+    <member type="node" ref="4676720721" role="platform"/>
+    <member type="node" ref="4658245524" role="platform"/>
+    <member type="node" ref="5866599807" role="platform"/>
+    <member type="node" ref="4658230790" role="platform"/>
+    <member type="node" ref="4678513201" role="platform"/>
+    <member type="node" ref="4678513204" role="platform"/>
+    <member type="node" ref="4682111487" role="platform"/>
+    <member type="node" ref="5782135213" role="platform"/>
+    <member type="node" ref="1103264970" role="platform"/>
+    <member type="way" ref="478274462" role=""/>
+    <member type="way" ref="195576437" role=""/>
+    <member type="way" ref="667984388" role=""/>
+    <member type="way" ref="195144066" role=""/>
+    <member type="way" ref="377745260" role=""/>
+    <member type="way" ref="195576450" role=""/>
+    <member type="way" ref="681494107" role=""/>
+    <member type="way" ref="12528983" role=""/>
+    <member type="way" ref="12528753" role=""/>
+    <member type="way" ref="881757258" role=""/>
+    <member type="way" ref="676596481" role=""/>
+    <member type="way" ref="12528497" role=""/>
+    <member type="way" ref="195576423" role=""/>
+    <member type="way" ref="273335903" role=""/>
+    <member type="way" ref="273335897" role=""/>
+    <member type="way" ref="273335902" role=""/>
+    <member type="way" ref="396243952" role=""/>
+    <member type="way" ref="56694374" role=""/>
+    <member type="way" ref="10505345" role=""/>
+    <member type="way" ref="10505344" role=""/>
+    <member type="way" ref="396243951" role=""/>
+    <member type="way" ref="674962900" role=""/>
+    <member type="way" ref="674962898" role=""/>
+    <member type="way" ref="675246752" role=""/>
+    <member type="way" ref="28926635" role=""/>
+    <member type="way" ref="56694157" role=""/>
+    <member type="way" ref="871136581" role=""/>
+    <member type="way" ref="56694155" role=""/>
+    <member type="way" ref="195576463" role=""/>
+    <member type="way" ref="753830170" role=""/>
+    <member type="way" ref="521432746" role=""/>
+    <member type="way" ref="675497916" role=""/>
+    <member type="way" ref="680381440" role=""/>
+    <member type="way" ref="675497915" role=""/>
+    <member type="way" ref="675518886" role=""/>
+    <member type="way" ref="675518887" role=""/>
+    <member type="way" ref="652132159" role=""/>
+    <member type="way" ref="675525767" role=""/>
+    <member type="way" ref="675319189" role=""/>
+    <member type="way" ref="675319188" role=""/>
+    <member type="way" ref="121005679" role=""/>
+    <member type="way" ref="24415030" role=""/>
+    <member type="way" ref="23079117" role=""/>
+    <member type="way" ref="676602677" role=""/>
+    <member type="way" ref="28469965" role=""/>
+    <member type="way" ref="155396480" role=""/>
+    <member type="way" ref="195576444" role=""/>
+    <member type="way" ref="676603730" role=""/>
+    <member type="way" ref="104879985" role=""/>
+    <member type="way" ref="841047451" role=""/>
+    <member type="way" ref="521052119" role=""/>
+    <member type="way" ref="841045563" role=""/>
+    <member type="way" ref="480092339" role=""/>
+    <member type="way" ref="205990048" role=""/>
+    <member type="way" ref="806539410" role=""/>
+    <member type="way" ref="676603333" role=""/>
+    <member type="way" ref="676603330" role=""/>
+    <member type="way" ref="195576445" role=""/>
+    <member type="way" ref="676671125" role=""/>
+    <member type="way" ref="700929590" role=""/>
+    <member type="way" ref="205990049" role=""/>
+    <member type="way" ref="676370571" role=""/>
+    <member type="way" ref="676370570" role=""/>
+    <member type="way" ref="150899574" role=""/>
+    <member type="way" ref="289953739" role=""/>
+    <member type="way" ref="289953742" role=""/>
+    <member type="way" ref="472134926" role=""/>
+    <member type="way" ref="150899580" role=""/>
+    <member type="way" ref="291575508" role=""/>
+    <member type="way" ref="122976429" role=""/>
+    <member type="way" ref="768501209" role=""/>
+    <member type="way" ref="676885138" role=""/>
+    <member type="way" ref="721794451" role=""/>
+    <member type="way" ref="155396485" role=""/>
+    <member type="way" ref="289959026" role=""/>
+    <member type="way" ref="680974973" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="686663563" role=""/>
+    <member type="way" ref="476367774" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="675324013" role=""/>
+    <member type="way" ref="478112831" role=""/>
+    <member type="way" ref="865790869" role=""/>
+    <member type="way" ref="148788173" role=""/>
+    <member type="way" ref="675324014" role=""/>
+    <member type="way" ref="395684568" role=""/>
+    <member type="way" ref="675324016" role=""/>
+    <member type="way" ref="675324015" role=""/>
+    <member type="way" ref="677899115" role=""/>
+    <member type="way" ref="23066742" role=""/>
+    <member type="way" ref="148788166" role=""/>
+    <member type="way" ref="33063309" role=""/>
+    <member type="way" ref="148788170" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="60:00"/>
+    <tag k="from" v="Насеље Браће Јерковић"/>
+    <tag k="from:sr-Latn" v="Naselje Braće Jerković"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00026"/>
+    <tag k="gtfs:shape_id" v="00026_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="738119"/>
+    <tag k="interval" v="06:00"/>
+    <tag k="name" v="26: Насеље Браће Јерковић =&gt; Дорћол /Дунавска/"/>
+    <tag k="name:sr-Latn" v="26: Naselje Braće Jerković =&gt; Dorćol /Dunavska/"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="26"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Дорћол /Дунавска/"/>
+    <tag k="to:sr-Latn" v="Dorćol /Dunavska/"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631230" version="78" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="4682191122" role="platform_entry_only"/>
+    <member type="node" ref="4682191125" role="platform"/>
+    <member type="node" ref="4687702176" role="platform"/>
+    <member type="node" ref="4687702179" role="platform"/>
+    <member type="node" ref="4327534894" role="platform"/>
+    <member type="node" ref="4327547191" role="platform"/>
+    <member type="node" ref="4362537891" role="platform"/>
+    <member type="node" ref="4687704658" role="platform"/>
+    <member type="node" ref="4687731786" role="platform"/>
+    <member type="node" ref="4687731789" role="platform"/>
+    <member type="node" ref="4687731790" role="platform"/>
+    <member type="node" ref="4687731792" role="platform"/>
+    <member type="node" ref="4687731794" role="platform"/>
+    <member type="node" ref="4687731796" role="platform"/>
+    <member type="node" ref="4687731798" role="platform"/>
+    <member type="node" ref="4687731800" role="platform"/>
+    <member type="node" ref="3849440160" role="platform"/>
+    <member type="node" ref="3889684920" role="platform"/>
+    <member type="node" ref="1541440685" role="platform"/>
+    <member type="node" ref="1541440636" role="platform"/>
+    <member type="node" ref="1541440631" role="platform"/>
+    <member type="node" ref="702297257" role="platform"/>
+    <member type="node" ref="4676720720" role="platform"/>
+    <member type="node" ref="4676720721" role="platform"/>
+    <member type="node" ref="4658245524" role="platform"/>
+    <member type="node" ref="8149703051" role="platform_exit_only"/>
+    <member type="way" ref="195144134" role=""/>
+    <member type="way" ref="195144133" role=""/>
+    <member type="way" ref="38959450" role=""/>
+    <member type="way" ref="195576467" role=""/>
+    <member type="way" ref="45702111" role=""/>
+    <member type="way" ref="195576465" role=""/>
+    <member type="way" ref="727389723" role=""/>
+    <member type="way" ref="675548491" role=""/>
+    <member type="way" ref="39625718" role=""/>
+    <member type="way" ref="23152737" role=""/>
+    <member type="way" ref="809972497" role=""/>
+    <member type="way" ref="195576451" role=""/>
+    <member type="way" ref="526359485" role=""/>
+    <member type="way" ref="287873243" role=""/>
+    <member type="way" ref="526359484" role=""/>
+    <member type="way" ref="526535455" role=""/>
+    <member type="way" ref="526359483" role=""/>
+    <member type="way" ref="381447582" role=""/>
+    <member type="way" ref="289905492" role=""/>
+    <member type="way" ref="556934054" role=""/>
+    <member type="way" ref="556932729" role=""/>
+    <member type="way" ref="556932610" role=""/>
+    <member type="way" ref="675225777" role=""/>
+    <member type="way" ref="23151907" role=""/>
+    <member type="way" ref="675225780" role=""/>
+    <member type="way" ref="675225785" role=""/>
+    <member type="way" ref="675225790" role=""/>
+    <member type="way" ref="675225791" role=""/>
+    <member type="way" ref="675218448" role=""/>
+    <member type="way" ref="197158281" role=""/>
+    <member type="way" ref="675281923" role=""/>
+    <member type="way" ref="675281926" role=""/>
+    <member type="way" ref="675281916" role=""/>
+    <member type="way" ref="675281919" role=""/>
+    <member type="way" ref="675315244" role=""/>
+    <member type="way" ref="675315243" role=""/>
+    <member type="way" ref="205598208" role=""/>
+    <member type="way" ref="289905491" role=""/>
+    <member type="way" ref="676923528" role=""/>
+    <member type="way" ref="676923530" role=""/>
+    <member type="way" ref="676923529" role=""/>
+    <member type="way" ref="289778700" role=""/>
+    <member type="way" ref="676606147" role=""/>
+    <member type="way" ref="289663742" role=""/>
+    <member type="way" ref="676088136" role=""/>
+    <member type="way" ref="291575506" role=""/>
+    <member type="way" ref="121005674" role=""/>
+    <member type="way" ref="751933284" role=""/>
+    <member type="way" ref="676585428" role=""/>
+    <member type="way" ref="178541649" role=""/>
+    <member type="way" ref="104879985" role=""/>
+    <member type="way" ref="841047451" role=""/>
+    <member type="way" ref="521052119" role=""/>
+    <member type="way" ref="841045563" role=""/>
+    <member type="way" ref="480092339" role=""/>
+    <member type="way" ref="205990048" role=""/>
+    <member type="way" ref="806539410" role=""/>
+    <member type="way" ref="676603333" role=""/>
+    <member type="way" ref="676603330" role=""/>
+    <member type="way" ref="195576445" role=""/>
+    <member type="way" ref="676671125" role=""/>
+    <member type="way" ref="700929590" role=""/>
+    <member type="way" ref="205990049" role=""/>
+    <member type="way" ref="676370571" role=""/>
+    <member type="way" ref="676370570" role=""/>
+    <member type="way" ref="150899574" role=""/>
+    <member type="way" ref="289953739" role=""/>
+    <member type="way" ref="289953742" role=""/>
+    <member type="way" ref="472134926" role=""/>
+    <member type="way" ref="150899580" role=""/>
+    <member type="way" ref="291575508" role=""/>
+    <member type="way" ref="122976429" role=""/>
+    <member type="way" ref="768501209" role=""/>
+    <member type="way" ref="676885138" role=""/>
+    <member type="way" ref="721794451" role=""/>
+    <member type="way" ref="155396485" role=""/>
+    <member type="way" ref="289959026" role=""/>
+    <member type="way" ref="680974973" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="686663563" role=""/>
+    <member type="way" ref="23073203" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="48:00"/>
+    <tag k="from" v="Миријево 3"/>
+    <tag k="from:sr-Latn" v="Mirijevo 3"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00027"/>
+    <tag k="gtfs:shape_id" v="00027_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="665918"/>
+    <tag k="interval" v="07:00"/>
+    <tag k="name" v="27: Миријево 3 =&gt; Трг Републике"/>
+    <tag k="name:sr-Latn" v="27: Mirijevo 3 =&gt; Trg Republike"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="27"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Трг Републике"/>
+    <tag k="to:sr-Latn" v="Trg Republike"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631231" version="72" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="8149703051" role="platform_entry_only"/>
+    <member type="node" ref="2148659246" role="platform"/>
+    <member type="node" ref="4676720722" role="platform"/>
+    <member type="node" ref="4676720723" role="platform"/>
+    <member type="node" ref="4676720724" role="platform"/>
+    <member type="node" ref="1493551533" role="platform"/>
+    <member type="node" ref="1541440613" role="platform"/>
+    <member type="node" ref="1541440639" role="platform"/>
+    <member type="node" ref="1541440688" role="platform"/>
+    <member type="node" ref="4743850040" role="platform"/>
+    <member type="node" ref="3849440161" role="platform"/>
+    <member type="node" ref="4687731801" role="platform"/>
+    <member type="node" ref="4687731799" role="platform"/>
+    <member type="node" ref="4687731797" role="platform"/>
+    <member type="node" ref="4687731795" role="platform"/>
+    <member type="node" ref="4687731793" role="platform"/>
+    <member type="node" ref="4687731791" role="platform"/>
+    <member type="node" ref="4687731788" role="platform"/>
+    <member type="node" ref="4687731787" role="platform"/>
+    <member type="node" ref="4687704657" role="platform"/>
+    <member type="node" ref="4327547990" role="platform"/>
+    <member type="node" ref="4327534892" role="platform"/>
+    <member type="node" ref="4327534893" role="platform"/>
+    <member type="node" ref="4687702178" role="platform"/>
+    <member type="node" ref="4687702177" role="platform"/>
+    <member type="node" ref="4682191124" role="platform"/>
+    <member type="node" ref="4682191123" role="platform_exit_only"/>
+    <member type="way" ref="478280095" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="230065295" role=""/>
+    <member type="way" ref="23098071" role=""/>
+    <member type="way" ref="676663793" role=""/>
+    <member type="way" ref="23078558" role=""/>
+    <member type="way" ref="768510156" role=""/>
+    <member type="way" ref="150899568" role=""/>
+    <member type="way" ref="291575507" role=""/>
+    <member type="way" ref="676862084" role=""/>
+    <member type="way" ref="195576480" role=""/>
+    <member type="way" ref="676671124" role=""/>
+    <member type="way" ref="676671123" role=""/>
+    <member type="way" ref="196715609" role=""/>
+    <member type="way" ref="23078641" role=""/>
+    <member type="way" ref="289953738" role=""/>
+    <member type="way" ref="289953744" role=""/>
+    <member type="way" ref="676612785" role=""/>
+    <member type="way" ref="197158258" role=""/>
+    <member type="way" ref="476316512" role=""/>
+    <member type="way" ref="676866522" role=""/>
+    <member type="way" ref="195576443" role=""/>
+    <member type="way" ref="676612784" role=""/>
+    <member type="way" ref="676885851" role=""/>
+    <member type="way" ref="806539409" role=""/>
+    <member type="way" ref="289911373" role=""/>
+    <member type="way" ref="841047450" role=""/>
+    <member type="way" ref="676885849" role=""/>
+    <member type="way" ref="23098187" role=""/>
+    <member type="way" ref="178541649" role=""/>
+    <member type="way" ref="676585428" role=""/>
+    <member type="way" ref="751933284" role=""/>
+    <member type="way" ref="121005674" role=""/>
+    <member type="way" ref="291575506" role=""/>
+    <member type="way" ref="676088136" role=""/>
+    <member type="way" ref="289663742" role=""/>
+    <member type="way" ref="676606147" role=""/>
+    <member type="way" ref="289778700" role=""/>
+    <member type="way" ref="676923529" role=""/>
+    <member type="way" ref="676923530" role=""/>
+    <member type="way" ref="676923528" role=""/>
+    <member type="way" ref="289905491" role=""/>
+    <member type="way" ref="205598208" role=""/>
+    <member type="way" ref="675315243" role=""/>
+    <member type="way" ref="675315244" role=""/>
+    <member type="way" ref="675281919" role=""/>
+    <member type="way" ref="675281916" role=""/>
+    <member type="way" ref="675281926" role=""/>
+    <member type="way" ref="675281923" role=""/>
+    <member type="way" ref="197158281" role=""/>
+    <member type="way" ref="675218448" role=""/>
+    <member type="way" ref="675225791" role=""/>
+    <member type="way" ref="675225790" role=""/>
+    <member type="way" ref="675225785" role=""/>
+    <member type="way" ref="675225780" role=""/>
+    <member type="way" ref="23151907" role=""/>
+    <member type="way" ref="675225777" role=""/>
+    <member type="way" ref="556932610" role=""/>
+    <member type="way" ref="556932729" role=""/>
+    <member type="way" ref="556934054" role=""/>
+    <member type="way" ref="289905492" role=""/>
+    <member type="way" ref="381447583" role=""/>
+    <member type="way" ref="526359481" role=""/>
+    <member type="way" ref="526359480" role=""/>
+    <member type="way" ref="32035247" role=""/>
+    <member type="way" ref="809972497" role=""/>
+    <member type="way" ref="23152737" role=""/>
+    <member type="way" ref="39625718" role=""/>
+    <member type="way" ref="675548491" role=""/>
+    <member type="way" ref="727389723" role=""/>
+    <member type="way" ref="195576465" role=""/>
+    <member type="way" ref="45702111" role=""/>
+    <member type="way" ref="195576467" role=""/>
+    <member type="way" ref="38959450" role=""/>
+    <member type="way" ref="195144133" role=""/>
+    <member type="way" ref="45408946" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="45:00"/>
+    <tag k="from" v="Трг Републике"/>
+    <tag k="from:sr-Latn" v="Trg Republike"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00027"/>
+    <tag k="gtfs:shape_id" v="00027_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="665921"/>
+    <tag k="interval" v="06:00"/>
+    <tag k="name" v="27: Трг Републике =&gt; Миријево 3"/>
+    <tag k="name:sr-Latn" v="27: Trg Republike =&gt; Mirijevo 3"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="27"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Миријево 3"/>
+    <tag k="to:sr-Latn" v="Mirijevo 3"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631232" version="68" timestamp="2021-01-29T22:50:19Z" changeset="98393097" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="4715143479" role="platform_entry_only"/>
+    <member type="node" ref="2066417343" role="platform"/>
+    <member type="node" ref="2053079432" role="platform"/>
+    <member type="node" ref="1685509555" role="platform"/>
+    <member type="node" ref="1618643087" role="platform"/>
+    <member type="node" ref="1618643091" role="platform"/>
+    <member type="node" ref="1618713347" role="platform"/>
+    <member type="node" ref="2055938848" role="platform"/>
+    <member type="node" ref="3849440161" role="platform"/>
+    <member type="node" ref="4687731801" role="platform"/>
+    <member type="node" ref="4687731799" role="platform"/>
+    <member type="node" ref="4687731797" role="platform"/>
+    <member type="node" ref="4687731795" role="platform"/>
+    <member type="node" ref="4687731793" role="platform"/>
+    <member type="node" ref="4687731791" role="platform"/>
+    <member type="node" ref="4687731788" role="platform"/>
+    <member type="node" ref="4687731787" role="platform"/>
+    <member type="node" ref="4687704657" role="platform"/>
+    <member type="node" ref="4327547990" role="platform"/>
+    <member type="node" ref="4327534892" role="platform"/>
+    <member type="node" ref="4327534893" role="platform"/>
+    <member type="node" ref="4685649933" role="platform"/>
+    <member type="node" ref="1803344633" role="platform"/>
+    <member type="node" ref="1803344641" role="platform"/>
+    <member type="node" ref="1803344634" role="platform"/>
+    <member type="node" ref="1802191549" role="platform_exit_only"/>
+    <member type="way" ref="675277672" role=""/>
+    <member type="way" ref="901800003" role=""/>
+    <member type="way" ref="901800005" role=""/>
+    <member type="way" ref="478280153" role=""/>
+    <member type="way" ref="675239060" role=""/>
+    <member type="way" ref="478280139" role=""/>
+    <member type="way" ref="675302535" role=""/>
+    <member type="way" ref="478280129" role=""/>
+    <member type="way" ref="116482674" role=""/>
+    <member type="way" ref="473795254" role=""/>
+    <member type="way" ref="680727271" role=""/>
+    <member type="way" ref="23720049" role=""/>
+    <member type="way" ref="471317420" role=""/>
+    <member type="way" ref="705363889" role=""/>
+    <member type="way" ref="23650408" role=""/>
+    <member type="way" ref="705363890" role=""/>
+    <member type="way" ref="822320892" role=""/>
+    <member type="way" ref="114682422" role=""/>
+    <member type="way" ref="41235874" role=""/>
+    <member type="way" ref="822320897" role=""/>
+    <member type="way" ref="41235877" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23672600" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="23115379" role=""/>
+    <member type="way" ref="680496364" role=""/>
+    <member type="way" ref="23152150" role=""/>
+    <member type="way" ref="675265859" role=""/>
+    <member type="way" ref="398904906" role=""/>
+    <member type="way" ref="675246023" role=""/>
+    <member type="way" ref="574867476" role=""/>
+    <member type="way" ref="32039299" role=""/>
+    <member type="way" ref="474918017" role=""/>
+    <member type="way" ref="206318276" role=""/>
+    <member type="way" ref="474918016" role=""/>
+    <member type="way" ref="178541647" role=""/>
+    <member type="way" ref="122183518" role=""/>
+    <member type="way" ref="32035225" role=""/>
+    <member type="way" ref="526359483" role=""/>
+    <member type="way" ref="526359482" role=""/>
+    <member type="way" ref="526359481" role=""/>
+    <member type="way" ref="526359480" role=""/>
+    <member type="way" ref="32035247" role=""/>
+    <member type="way" ref="809972497" role=""/>
+    <member type="way" ref="23152737" role=""/>
+    <member type="way" ref="39625718" role=""/>
+    <member type="way" ref="675548491" role=""/>
+    <member type="way" ref="727389723" role=""/>
+    <member type="way" ref="195576465" role=""/>
+    <member type="way" ref="169044351" role=""/>
+    <member type="way" ref="195144180" role=""/>
+    <member type="way" ref="489312202" role=""/>
+    <member type="way" ref="489312203" role=""/>
+    <member type="way" ref="169044341" role=""/>
+    <member type="way" ref="169044353" role=""/>
+    <member type="way" ref="45408947" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="48:00"/>
+    <tag k="from" v="Нови Београд (Блок 20)"/>
+    <tag k="from:sr-Latn" v="Novi Beograd (Blok 20)"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="10027"/>
+    <tag k="gtfs:shape_id" v="10027_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="666096"/>
+    <tag k="interval" v="07:00"/>
+    <tag k="name" v="27E: Нови Београд (Блок 20) =&gt; Миријево 4"/>
+    <tag k="name:sr-Latn" v="27E: Novi Beograd (Blok 20) =&gt; Mirijevo 4"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="27E"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Миријево 4"/>
+    <tag k="to:sr-Latn" v="Mirijevo 4"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631233" version="77" timestamp="2021-01-29T22:50:19Z" changeset="98393097" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="1803254399" role="platform_entry_only"/>
+    <member type="node" ref="1803344637" role="platform"/>
+    <member type="node" ref="1803344642" role="platform"/>
+    <member type="node" ref="4715415980" role="platform"/>
+    <member type="node" ref="4685649934" role="platform"/>
+    <member type="node" ref="4327534894" role="platform"/>
+    <member type="node" ref="4327547191" role="platform"/>
+    <member type="node" ref="4362537891" role="platform"/>
+    <member type="node" ref="4687704658" role="platform"/>
+    <member type="node" ref="4687731786" role="platform"/>
+    <member type="node" ref="4687731789" role="platform"/>
+    <member type="node" ref="4687731790" role="platform"/>
+    <member type="node" ref="4687731792" role="platform"/>
+    <member type="node" ref="4687731794" role="platform"/>
+    <member type="node" ref="4687731796" role="platform"/>
+    <member type="node" ref="4687731798" role="platform"/>
+    <member type="node" ref="4687731800" role="platform"/>
+    <member type="node" ref="3849440160" role="platform"/>
+    <member type="node" ref="4241976012" role="platform"/>
+    <member type="node" ref="2055938849" role="platform"/>
+    <member type="node" ref="2055938851" role="platform"/>
+    <member type="node" ref="1618717623" role="platform"/>
+    <member type="node" ref="1618643103" role="platform"/>
+    <member type="node" ref="1618643110" role="platform"/>
+    <member type="node" ref="1685509556" role="platform"/>
+    <member type="node" ref="2053079440" role="platform"/>
+    <member type="node" ref="4715143477" role="platform"/>
+    <member type="node" ref="4715143479" role="platform_exit_only"/>
+    <member type="way" ref="474215508" role=""/>
+    <member type="way" ref="169044352" role=""/>
+    <member type="way" ref="169044353" role=""/>
+    <member type="way" ref="169044341" role=""/>
+    <member type="way" ref="489312203" role=""/>
+    <member type="way" ref="489312202" role=""/>
+    <member type="way" ref="195144180" role=""/>
+    <member type="way" ref="169044351" role=""/>
+    <member type="way" ref="195576465" role=""/>
+    <member type="way" ref="727389723" role=""/>
+    <member type="way" ref="675548491" role=""/>
+    <member type="way" ref="39625718" role=""/>
+    <member type="way" ref="23152737" role=""/>
+    <member type="way" ref="809972497" role=""/>
+    <member type="way" ref="195576451" role=""/>
+    <member type="way" ref="526359485" role=""/>
+    <member type="way" ref="287873243" role=""/>
+    <member type="way" ref="526359484" role=""/>
+    <member type="way" ref="32035147" role=""/>
+    <member type="way" ref="122183518" role=""/>
+    <member type="way" ref="178541647" role=""/>
+    <member type="way" ref="474918016" role=""/>
+    <member type="way" ref="206318276" role=""/>
+    <member type="way" ref="474918017" role=""/>
+    <member type="way" ref="32039299" role=""/>
+    <member type="way" ref="574867476" role=""/>
+    <member type="way" ref="675246023" role=""/>
+    <member type="way" ref="398904906" role=""/>
+    <member type="way" ref="675265859" role=""/>
+    <member type="way" ref="23152150" role=""/>
+    <member type="way" ref="680496364" role=""/>
+    <member type="way" ref="23115379" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23672662" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="290012969" role=""/>
+    <member type="way" ref="290012968" role=""/>
+    <member type="way" ref="675220726" role=""/>
+    <member type="way" ref="675220727" role=""/>
+    <member type="way" ref="41235876" role=""/>
+    <member type="way" ref="41235875" role=""/>
+    <member type="way" ref="205987189" role=""/>
+    <member type="way" ref="822320893" role=""/>
+    <member type="way" ref="676108741" role=""/>
+    <member type="way" ref="26826000" role=""/>
+    <member type="way" ref="25311886" role=""/>
+    <member type="way" ref="473759843" role=""/>
+    <member type="way" ref="675302539" role=""/>
+    <member type="way" ref="26825996" role=""/>
+    <member type="way" ref="648042149" role=""/>
+    <member type="way" ref="816973147" role=""/>
+    <member type="way" ref="675302541" role=""/>
+    <member type="way" ref="675302540" role=""/>
+    <member type="way" ref="116482676" role=""/>
+    <member type="way" ref="116482678" role=""/>
+    <member type="way" ref="23787838" role=""/>
+    <member type="way" ref="478280139" role=""/>
+    <member type="way" ref="675239060" role=""/>
+    <member type="way" ref="478280151" role=""/>
+    <member type="way" ref="478280121" role=""/>
+    <member type="way" ref="901800001" role=""/>
+    <member type="way" ref="901800006" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="52:00"/>
+    <tag k="from" v="Миријево 4"/>
+    <tag k="from:sr-Latn" v="Mirijevo 4"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="10027"/>
+    <tag k="gtfs:shape_id" v="10027_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="666095"/>
+    <tag k="interval" v="07:00"/>
+    <tag k="name" v="27E: Миријево 4 =&gt; Нови Београд (Блок 20)"/>
+    <tag k="name:sr-Latn" v="27E: Mirijevo 4 =&gt; Novi Beograd (Blok 20)"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="27E"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Нови Београд (Блок 20)"/>
+    <tag k="to:sr-Latn" v="Novi Beograd (Blok 20)"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631236" version="86" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="8211280916" role="platform_entry_only"/>
+    <member type="node" ref="1769947073" role="platform"/>
+    <member type="node" ref="4663174177" role="platform"/>
+    <member type="node" ref="2884498375" role="platform"/>
+    <member type="node" ref="4663191479" role="platform"/>
+    <member type="node" ref="4663215379" role="platform"/>
+    <member type="node" ref="4685615229" role="platform"/>
+    <member type="node" ref="3174676705" role="platform"/>
+    <member type="node" ref="2903522297" role="platform"/>
+    <member type="node" ref="507047264" role="platform"/>
+    <member type="node" ref="2077480379" role="platform"/>
+    <member type="node" ref="2165543291" role="platform"/>
+    <member type="node" ref="4658236196" role="platform"/>
+    <member type="node" ref="4658245524" role="platform"/>
+    <member type="node" ref="1124739236" role="platform"/>
+    <member type="node" ref="8151261236" role="platform_exit_only"/>
+    <member type="way" ref="881419949" role=""/>
+    <member type="way" ref="478290594" role=""/>
+    <member type="way" ref="677167310" role=""/>
+    <member type="way" ref="677167328" role=""/>
+    <member type="way" ref="677167297" role=""/>
+    <member type="way" ref="677167305" role=""/>
+    <member type="way" ref="677167285" role=""/>
+    <member type="way" ref="526007428" role=""/>
+    <member type="way" ref="677167271" role=""/>
+    <member type="way" ref="136094805" role=""/>
+    <member type="way" ref="196715612" role=""/>
+    <member type="way" ref="198644170" role=""/>
+    <member type="way" ref="677175878" role=""/>
+    <member type="way" ref="677175875" role=""/>
+    <member type="way" ref="43930317" role=""/>
+    <member type="way" ref="677175868" role=""/>
+    <member type="way" ref="677175871" role=""/>
+    <member type="way" ref="677175865" role=""/>
+    <member type="way" ref="298473420" role=""/>
+    <member type="way" ref="526312482" role=""/>
+    <member type="way" ref="677175861" role=""/>
+    <member type="way" ref="675242029" role=""/>
+    <member type="way" ref="677175858" role=""/>
+    <member type="way" ref="675242028" role=""/>
+    <member type="way" ref="10505622" role=""/>
+    <member type="way" ref="841289745" role=""/>
+    <member type="way" ref="692969525" role=""/>
+    <member type="way" ref="195144199" role=""/>
+    <member type="way" ref="721905913" role=""/>
+    <member type="way" ref="841292655" role=""/>
+    <member type="way" ref="721905912" role=""/>
+    <member type="way" ref="43929065" role=""/>
+    <member type="way" ref="721905911" role=""/>
+    <member type="way" ref="721905914" role=""/>
+    <member type="way" ref="674218907" role=""/>
+    <member type="way" ref="195144196" role=""/>
+    <member type="way" ref="721905915" role=""/>
+    <member type="way" ref="195144202" role=""/>
+    <member type="way" ref="165454890" role=""/>
+    <member type="way" ref="675464950" role=""/>
+    <member type="way" ref="675477681" role=""/>
+    <member type="way" ref="41411817" role=""/>
+    <member type="way" ref="675475387" role=""/>
+    <member type="way" ref="675475388" role=""/>
+    <member type="way" ref="339948798" role=""/>
+    <member type="way" ref="355758678" role=""/>
+    <member type="way" ref="541623553" role=""/>
+    <member type="way" ref="808883808" role=""/>
+    <member type="way" ref="676355524" role=""/>
+    <member type="way" ref="477551227" role=""/>
+    <member type="way" ref="474200724" role=""/>
+    <member type="way" ref="391815707" role=""/>
+    <member type="way" ref="541623551" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="23786175" role=""/>
+    <member type="way" ref="676885138" role=""/>
+    <member type="way" ref="721794451" role=""/>
+    <member type="way" ref="155396485" role=""/>
+    <member type="way" ref="289959026" role=""/>
+    <member type="way" ref="680974973" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="135929794" role=""/>
+    <member type="way" ref="82203841" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="35:00"/>
+    <tag k="from" v="Коњарник"/>
+    <tag k="from:sr-Latn" v="Konjarnik"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00031"/>
+    <tag k="gtfs:shape_id" v="00031_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="687270"/>
+    <tag k="interval" v="05:00"/>
+    <tag k="name" v="31: Коњарник =&gt; Студентски Трг"/>
+    <tag k="name:sr-Latn" v="31: Konjarnik =&gt; Studentski Trg"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="31"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Студентски Трг"/>
+    <tag k="to:sr-Latn" v="Studentski Trg"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631237" version="92" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="957069821" role="platform_entry_only"/>
+    <member type="node" ref="4359066192" role="platform"/>
+    <member type="node" ref="4658245523" role="platform"/>
+    <member type="node" ref="2077480521" role="platform"/>
+    <member type="node" ref="2165543108" role="platform"/>
+    <member type="node" ref="2077480369" role="platform"/>
+    <member type="node" ref="2914235152" role="platform"/>
+    <member type="node" ref="3174676704" role="platform"/>
+    <member type="node" ref="2884498368" role="platform"/>
+    <member type="node" ref="4663191480" role="platform"/>
+    <member type="node" ref="2884498374" role="platform"/>
+    <member type="node" ref="4663175608" role="platform"/>
+    <member type="node" ref="2059956599" role="platform"/>
+    <member type="node" ref="1769947072" role="platform"/>
+    <member type="node" ref="5116144222" role="platform_exit_only"/>
+    <member type="way" ref="135929796" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="122976428" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="391815708" role=""/>
+    <member type="way" ref="474200724" role=""/>
+    <member type="way" ref="6121445" role=""/>
+    <member type="way" ref="834023363" role=""/>
+    <member type="way" ref="606131083" role=""/>
+    <member type="way" ref="541623559" role=""/>
+    <member type="way" ref="676355525" role=""/>
+    <member type="way" ref="195576446" role=""/>
+    <member type="way" ref="355758680" role=""/>
+    <member type="way" ref="882971735" role=""/>
+    <member type="way" ref="675477679" role=""/>
+    <member type="way" ref="351606830" role=""/>
+    <member type="way" ref="721798129" role=""/>
+    <member type="way" ref="721798130" role=""/>
+    <member type="way" ref="675477680" role=""/>
+    <member type="way" ref="23786225" role=""/>
+    <member type="way" ref="834023362" role=""/>
+    <member type="way" ref="721905910" role=""/>
+    <member type="way" ref="721905909" role=""/>
+    <member type="way" ref="23786290" role=""/>
+    <member type="way" ref="382475081" role=""/>
+    <member type="way" ref="675464952" role=""/>
+    <member type="way" ref="195144114" role=""/>
+    <member type="way" ref="23786376" role=""/>
+    <member type="way" ref="195144200" role=""/>
+    <member type="way" ref="195144193" role=""/>
+    <member type="way" ref="675234663" role=""/>
+    <member type="way" ref="675234664" role=""/>
+    <member type="way" ref="841292654" role=""/>
+    <member type="way" ref="675242030" role=""/>
+    <member type="way" ref="195144199" role=""/>
+    <member type="way" ref="692969525" role=""/>
+    <member type="way" ref="841289745" role=""/>
+    <member type="way" ref="10505622" role=""/>
+    <member type="way" ref="675242028" role=""/>
+    <member type="way" ref="677175858" role=""/>
+    <member type="way" ref="675242029" role=""/>
+    <member type="way" ref="677175861" role=""/>
+    <member type="way" ref="526312482" role=""/>
+    <member type="way" ref="298473420" role=""/>
+    <member type="way" ref="677175865" role=""/>
+    <member type="way" ref="677175871" role=""/>
+    <member type="way" ref="677175868" role=""/>
+    <member type="way" ref="43930317" role=""/>
+    <member type="way" ref="677175875" role=""/>
+    <member type="way" ref="677175878" role=""/>
+    <member type="way" ref="136094800" role=""/>
+    <member type="way" ref="43929055" role=""/>
+    <member type="way" ref="195144192" role=""/>
+    <member type="way" ref="677167266" role=""/>
+    <member type="way" ref="196715611" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="36:00"/>
+    <tag k="from" v="Студентски Трг"/>
+    <tag k="from:sr-Latn" v="Studentski Trg"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00031"/>
+    <tag k="gtfs:shape_id" v="00031_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="687839"/>
+    <tag k="interval" v="05:00"/>
+    <tag k="name" v="31: Студентски Трг =&gt; Коњарник"/>
+    <tag k="name:sr-Latn" v="31: Studentski Trg =&gt; Konjarnik"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="31"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Коњарник"/>
+    <tag k="to:sr-Latn" v="Konjarnik"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631241" version="73" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="4687661858" role="platform_entry_only"/>
+    <member type="node" ref="4687661856" role="platform"/>
+    <member type="node" ref="4687661853" role="platform"/>
+    <member type="node" ref="4572180133" role="platform"/>
+    <member type="node" ref="4572180120" role="platform"/>
+    <member type="node" ref="4572180121" role="platform"/>
+    <member type="node" ref="4572180102" role="platform"/>
+    <member type="node" ref="4572180003" role="platform"/>
+    <member type="node" ref="4572178781" role="platform"/>
+    <member type="node" ref="4572179991" role="platform"/>
+    <member type="node" ref="4572179995" role="platform"/>
+    <member type="node" ref="1796210257" role="platform"/>
+    <member type="node" ref="1796210294" role="platform"/>
+    <member type="node" ref="2055938849" role="platform"/>
+    <member type="node" ref="2055938851" role="platform"/>
+    <member type="node" ref="1618717623" role="platform"/>
+    <member type="node" ref="1618643103" role="platform"/>
+    <member type="node" ref="8149703049" role="platform_exit_only"/>
+    <member type="way" ref="23152639" role=""/>
+    <member type="way" ref="23152640" role=""/>
+    <member type="way" ref="41201842" role=""/>
+    <member type="way" ref="195576448" role=""/>
+    <member type="way" ref="676631566" role=""/>
+    <member type="way" ref="169044345" role=""/>
+    <member type="way" ref="526362755" role=""/>
+    <member type="way" ref="526362752" role=""/>
+    <member type="way" ref="679915803" role=""/>
+    <member type="way" ref="679915802" role=""/>
+    <member type="way" ref="478481943" role=""/>
+    <member type="way" ref="680930897" role=""/>
+    <member type="way" ref="656733526" role=""/>
+    <member type="way" ref="676631562" role=""/>
+    <member type="way" ref="676631555" role=""/>
+    <member type="way" ref="656733525" role=""/>
+    <member type="way" ref="676139572" role=""/>
+    <member type="way" ref="676139573" role=""/>
+    <member type="way" ref="41201421" role=""/>
+    <member type="way" ref="676631539" role=""/>
+    <member type="way" ref="647344755" role=""/>
+    <member type="way" ref="676663863" role=""/>
+    <member type="way" ref="685870724" role=""/>
+    <member type="way" ref="200423286" role=""/>
+    <member type="way" ref="465772552" role=""/>
+    <member type="way" ref="459873725" role=""/>
+    <member type="way" ref="200423289" role=""/>
+    <member type="way" ref="291559250" role=""/>
+    <member type="way" ref="200724860" role=""/>
+    <member type="way" ref="478468906" role=""/>
+    <member type="way" ref="200724862" role=""/>
+    <member type="way" ref="675555278" role=""/>
+    <member type="way" ref="574867478" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="684356845" role=""/>
+    <member type="way" ref="619005684" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="686663563" role=""/>
+    <member type="way" ref="23073203" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="34:00"/>
+    <tag k="from" v="Вишњица"/>
+    <tag k="from:sr-Latn" v="Višnjica"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="10032"/>
+    <tag k="gtfs:shape_id" v="10032_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="690430"/>
+    <tag k="interval" v="32:00"/>
+    <tag k="name" v="32E: Вишњица =&gt; Трг Републике"/>
+    <tag k="name:sr-Latn" v="32E: Višnjica =&gt; Trg Republike"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="32E"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Трг Републике"/>
+    <tag k="to:sr-Latn" v="Trg Republike"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631246" version="84" timestamp="2021-01-29T22:50:19Z" changeset="98393097" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="8151261232" role="platform_entry_only"/>
+    <member type="node" ref="2066417343" role="platform"/>
+    <member type="node" ref="2053079432" role="platform"/>
+    <member type="node" ref="1685509555" role="platform"/>
+    <member type="node" ref="1618643087" role="platform"/>
+    <member type="node" ref="1618643091" role="platform"/>
+    <member type="node" ref="1618713347" role="platform"/>
+    <member type="node" ref="2055938848" role="platform"/>
+    <member type="node" ref="1796210280" role="platform"/>
+    <member type="node" ref="1796210252" role="platform"/>
+    <member type="node" ref="4572179996" role="platform"/>
+    <member type="node" ref="4572180015" role="platform"/>
+    <member type="node" ref="4572178782" role="platform"/>
+    <member type="node" ref="4572180077" role="platform"/>
+    <member type="node" ref="4572178778" role="platform"/>
+    <member type="node" ref="4572178776" role="platform"/>
+    <member type="node" ref="4572178774" role="platform"/>
+    <member type="node" ref="4572178772" role="platform"/>
+    <member type="node" ref="4712104281" role="platform"/>
+    <member type="node" ref="4572178771" role="platform"/>
+    <member type="node" ref="4378876107" role="platform_entry_only"/>
+    <member type="way" ref="901800004" role=""/>
+    <member type="way" ref="901800002" role=""/>
+    <member type="way" ref="901800008" role=""/>
+    <member type="way" ref="901800003" role=""/>
+    <member type="way" ref="901800005" role=""/>
+    <member type="way" ref="478280153" role=""/>
+    <member type="way" ref="675239060" role=""/>
+    <member type="way" ref="478280139" role=""/>
+    <member type="way" ref="675302535" role=""/>
+    <member type="way" ref="478280129" role=""/>
+    <member type="way" ref="116482674" role=""/>
+    <member type="way" ref="473795254" role=""/>
+    <member type="way" ref="680727271" role=""/>
+    <member type="way" ref="23720049" role=""/>
+    <member type="way" ref="471317420" role=""/>
+    <member type="way" ref="705363889" role=""/>
+    <member type="way" ref="23650408" role=""/>
+    <member type="way" ref="705363890" role=""/>
+    <member type="way" ref="822320892" role=""/>
+    <member type="way" ref="114682422" role=""/>
+    <member type="way" ref="41235874" role=""/>
+    <member type="way" ref="822320897" role=""/>
+    <member type="way" ref="41235877" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23672600" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="195576438" role=""/>
+    <member type="way" ref="680489364" role=""/>
+    <member type="way" ref="679908018" role=""/>
+    <member type="way" ref="200423289" role=""/>
+    <member type="way" ref="459873725" role=""/>
+    <member type="way" ref="465772552" role=""/>
+    <member type="way" ref="381522648" role=""/>
+    <member type="way" ref="23152597" role=""/>
+    <member type="way" ref="679915798" role=""/>
+    <member type="way" ref="381494686" role=""/>
+    <member type="way" ref="647344748" role=""/>
+    <member type="way" ref="461754338" role=""/>
+    <member type="way" ref="676142030" role=""/>
+    <member type="way" ref="679915800" role=""/>
+    <member type="way" ref="475963065" role=""/>
+    <member type="way" ref="680930896" role=""/>
+    <member type="way" ref="676631560" role=""/>
+    <member type="way" ref="676404433" role=""/>
+    <member type="way" ref="676404431" role=""/>
+    <member type="way" ref="656733528" role=""/>
+    <member type="way" ref="676404430" role=""/>
+    <member type="way" ref="676631565" role=""/>
+    <member type="way" ref="676055463" role=""/>
+    <member type="way" ref="474849983" role=""/>
+    <member type="way" ref="676631567" role=""/>
+    <member type="way" ref="412841972" role=""/>
+    <member type="way" ref="725285987" role=""/>
+    <member type="way" ref="412841970" role=""/>
+    <member type="way" ref="412806285" role=""/>
+    <member type="way" ref="39668300" role=""/>
+    <member type="way" ref="205347468" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="47:00"/>
+    <tag k="from" v="Нови Београд (Блок 20)"/>
+    <tag k="from:sr-Latn" v="Novi Beograd (Blok 20)"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00035"/>
+    <tag k="gtfs:shape_id" v="00035_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="803179"/>
+    <tag k="interval" v="08:00"/>
+    <tag k="name" v="35: Нови Београд (Блок 20) =&gt; Лешће /Гробље/"/>
+    <tag k="name:sr-Latn" v="35: Novi Beograd (Blok 20) =&gt; Lešće /Groblje/"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="35"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Лешће /Гробље/"/>
+    <tag k="to:sr-Latn" v="Lešće /Groblje/"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631247" version="90" timestamp="2021-01-29T22:50:19Z" changeset="98393097" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="4378876107" role="platform_entry_only"/>
+    <member type="node" ref="4572178770" role="platform"/>
+    <member type="node" ref="4712104280" role="platform"/>
+    <member type="node" ref="4572178773" role="platform"/>
+    <member type="node" ref="4572178775" role="platform"/>
+    <member type="node" ref="4572178777" role="platform"/>
+    <member type="node" ref="4572180102" role="platform"/>
+    <member type="node" ref="4572180003" role="platform"/>
+    <member type="node" ref="4572178781" role="platform"/>
+    <member type="node" ref="4572179991" role="platform"/>
+    <member type="node" ref="4572179995" role="platform"/>
+    <member type="node" ref="1796210257" role="platform"/>
+    <member type="node" ref="1796210294" role="platform"/>
+    <member type="node" ref="2055938849" role="platform"/>
+    <member type="node" ref="2055938851" role="platform"/>
+    <member type="node" ref="1618717623" role="platform"/>
+    <member type="node" ref="1618643103" role="platform"/>
+    <member type="node" ref="1618643110" role="platform"/>
+    <member type="node" ref="1685509556" role="platform"/>
+    <member type="node" ref="2053079440" role="platform"/>
+    <member type="node" ref="4715143477" role="platform"/>
+    <member type="node" ref="8151261233" role="platform_exit_only"/>
+    <member type="way" ref="526365517" role=""/>
+    <member type="way" ref="474861266" role=""/>
+    <member type="way" ref="474861262" role=""/>
+    <member type="way" ref="412806285" role=""/>
+    <member type="way" ref="195576475" role=""/>
+    <member type="way" ref="39668299" role=""/>
+    <member type="way" ref="195576448" role=""/>
+    <member type="way" ref="676631566" role=""/>
+    <member type="way" ref="169044345" role=""/>
+    <member type="way" ref="526362755" role=""/>
+    <member type="way" ref="526362752" role=""/>
+    <member type="way" ref="679915803" role=""/>
+    <member type="way" ref="679915802" role=""/>
+    <member type="way" ref="478481943" role=""/>
+    <member type="way" ref="680930897" role=""/>
+    <member type="way" ref="656733526" role=""/>
+    <member type="way" ref="676631562" role=""/>
+    <member type="way" ref="676631555" role=""/>
+    <member type="way" ref="656733525" role=""/>
+    <member type="way" ref="676139572" role=""/>
+    <member type="way" ref="676139573" role=""/>
+    <member type="way" ref="41201421" role=""/>
+    <member type="way" ref="676631539" role=""/>
+    <member type="way" ref="647344755" role=""/>
+    <member type="way" ref="676663863" role=""/>
+    <member type="way" ref="685870724" role=""/>
+    <member type="way" ref="200423286" role=""/>
+    <member type="way" ref="465772552" role=""/>
+    <member type="way" ref="459873725" role=""/>
+    <member type="way" ref="200423289" role=""/>
+    <member type="way" ref="291559250" role=""/>
+    <member type="way" ref="200724860" role=""/>
+    <member type="way" ref="478468906" role=""/>
+    <member type="way" ref="200724862" role=""/>
+    <member type="way" ref="675555278" role=""/>
+    <member type="way" ref="574867478" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23672662" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="290012969" role=""/>
+    <member type="way" ref="290012968" role=""/>
+    <member type="way" ref="675220726" role=""/>
+    <member type="way" ref="675220727" role=""/>
+    <member type="way" ref="41235876" role=""/>
+    <member type="way" ref="41235875" role=""/>
+    <member type="way" ref="205987189" role=""/>
+    <member type="way" ref="822320893" role=""/>
+    <member type="way" ref="676108741" role=""/>
+    <member type="way" ref="26826000" role=""/>
+    <member type="way" ref="25311886" role=""/>
+    <member type="way" ref="473759843" role=""/>
+    <member type="way" ref="675302539" role=""/>
+    <member type="way" ref="26825996" role=""/>
+    <member type="way" ref="648042149" role=""/>
+    <member type="way" ref="816973147" role=""/>
+    <member type="way" ref="675302541" role=""/>
+    <member type="way" ref="675302540" role=""/>
+    <member type="way" ref="116482676" role=""/>
+    <member type="way" ref="116482678" role=""/>
+    <member type="way" ref="23787838" role=""/>
+    <member type="way" ref="478280139" role=""/>
+    <member type="way" ref="675239060" role=""/>
+    <member type="way" ref="478280151" role=""/>
+    <member type="way" ref="478280121" role=""/>
+    <member type="way" ref="901800001" role=""/>
+    <member type="way" ref="901800002" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="45:00"/>
+    <tag k="from" v="Лешће /Гробље/"/>
+    <tag k="from:sr-Latn" v="Lešće /Groblje/"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00035"/>
+    <tag k="gtfs:shape_id" v="00035_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="803177"/>
+    <tag k="interval" v="08:00"/>
+    <tag k="name" v="35: Лешће /Гробље/ =&gt; Нови Београд (Блок 20)"/>
+    <tag k="name:sr-Latn" v="35: Lešće /Groblje/ =&gt; Novi Beograd (Blok 20)"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="35"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Нови Београд (Блок 20)"/>
+    <tag k="to:sr-Latn" v="Novi Beograd (Blok 20)"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2631249" version="6" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2631247" role=""/>
+    <member type="relation" ref="2631246" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00035"/>
+    <tag k="name" v="35"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="35"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2631251" version="4" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2631230" role=""/>
+    <member type="relation" ref="2631231" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00027"/>
+    <tag k="name" v="27"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="27"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2631252" version="9" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2631237" role=""/>
+    <member type="relation" ref="2631236" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00031"/>
+    <tag k="name" v="31"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="31"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2631253" version="4" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2631241" role=""/>
+    <member type="relation" ref="2631240" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="10032"/>
+    <tag k="name" v="32E"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="32E"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2631254" version="4" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2631232" role=""/>
+    <member type="relation" ref="2631233" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="10027"/>
+    <tag k="name" v="27E"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="27E"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2631255" version="4" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2631224" role=""/>
+    <member type="relation" ref="2631223" role=""/>
+    <tag k="colour" v="#008000"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00024"/>
+    <tag k="name" v="24"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="24"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2643182" version="128" timestamp="2021-03-08T12:05:53Z" changeset="100636051" uid="212196" user="BrackoNe">
+    <member type="node" ref="8301445151" role="platform_entry_only"/>
+    <member type="node" ref="2055938851" role="platform"/>
+    <member type="node" ref="1618717623" role="platform"/>
+    <member type="node" ref="1618643103" role="platform"/>
+    <member type="node" ref="1618643110" role="platform"/>
+    <member type="node" ref="2148659246" role="platform"/>
+    <member type="node" ref="2059750330" role="platform"/>
+    <member type="node" ref="5116045641" role="platform"/>
+    <member type="node" ref="1858130486" role="platform"/>
+    <member type="node" ref="462529782" role="platform"/>
+    <member type="node" ref="5116005559" role="platform"/>
+    <member type="node" ref="5119930331" role="platform"/>
+    <member type="node" ref="2059750503" role="platform"/>
+    <member type="node" ref="1790354844" role="platform"/>
+    <member type="node" ref="2059750403" role="platform"/>
+    <member type="node" ref="5119930330" role="platform"/>
+    <member type="node" ref="1348386525" role="platform"/>
+    <member type="node" ref="1348386553" role="platform"/>
+    <member type="node" ref="1348386518" role="platform"/>
+    <member type="node" ref="4706940976" role="platform"/>
+    <member type="node" ref="4706940975" role="platform"/>
+    <member type="node" ref="4706940974" role="platform"/>
+    <member type="node" ref="4706940973" role="platform"/>
+    <member type="node" ref="4706940972" role="platform"/>
+    <member type="node" ref="4706940971" role="platform"/>
+    <member type="node" ref="4718137753" role="platform"/>
+    <member type="node" ref="4160099072" role="platform"/>
+    <member type="node" ref="4709092170" role="platform"/>
+    <member type="node" ref="4708788510" role="platform"/>
+    <member type="node" ref="4709092168" role="platform"/>
+    <member type="node" ref="4709092165" role="platform"/>
+    <member type="node" ref="4159781897" role="platform_exit_only"/>
+    <member type="way" ref="893184453" role=""/>
+    <member type="way" ref="893184452" role=""/>
+    <member type="way" ref="198723963" role=""/>
+    <member type="way" ref="195576428" role=""/>
+    <member type="way" ref="487184930" role=""/>
+    <member type="way" ref="195576430" role=""/>
+    <member type="way" ref="195576433" role=""/>
+    <member type="way" ref="487184929" role=""/>
+    <member type="way" ref="472147025" role=""/>
+    <member type="way" ref="23115351" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="230065295" role=""/>
+    <member type="way" ref="23098071" role=""/>
+    <member type="way" ref="676663793" role=""/>
+    <member type="way" ref="23078558" role=""/>
+    <member type="way" ref="768510156" role=""/>
+    <member type="way" ref="150899568" role=""/>
+    <member type="way" ref="291575507" role=""/>
+    <member type="way" ref="676862084" role=""/>
+    <member type="way" ref="195576480" role=""/>
+    <member type="way" ref="676671124" role=""/>
+    <member type="way" ref="676671123" role=""/>
+    <member type="way" ref="150899586" role=""/>
+    <member type="way" ref="196715565" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="24282347" role=""/>
+    <member type="way" ref="22762705" role=""/>
+    <member type="way" ref="676097202" role=""/>
+    <member type="way" ref="23893460" role=""/>
+    <member type="way" ref="41234382" role=""/>
+    <member type="way" ref="198723955" role=""/>
+    <member type="way" ref="41234376" role=""/>
+    <member type="way" ref="677728908" role=""/>
+    <member type="way" ref="871350131" role=""/>
+    <member type="way" ref="895734447" role=""/>
+    <member type="way" ref="677728907" role=""/>
+    <member type="way" ref="677908729" role=""/>
+    <member type="way" ref="677908727" role=""/>
+    <member type="way" ref="179926017" role=""/>
+    <member type="way" ref="680218901" role=""/>
+    <member type="way" ref="255071891" role=""/>
+    <member type="way" ref="299215329" role=""/>
+    <member type="way" ref="255071888" role=""/>
+    <member type="way" ref="519104329" role=""/>
+    <member type="way" ref="914681003" role=""/>
+    <member type="way" ref="41171338" role=""/>
+    <member type="way" ref="41171339" role=""/>
+    <member type="way" ref="914681002" role=""/>
+    <member type="way" ref="519095964" role=""/>
+    <member type="way" ref="518899497" role=""/>
+    <member type="way" ref="577591594" role=""/>
+    <member type="way" ref="725380092" role=""/>
+    <member type="way" ref="255075865" role=""/>
+    <member type="way" ref="518911054" role=""/>
+    <member type="way" ref="519110526" role=""/>
+    <member type="way" ref="830057382" role=""/>
+    <member type="way" ref="676846414" role=""/>
+    <member type="way" ref="519358222" role=""/>
+    <member type="way" ref="519179021" role=""/>
+    <member type="way" ref="196715593" role=""/>
+    <member type="way" ref="676828559" role=""/>
+    <member type="way" ref="31799862" role=""/>
+    <member type="way" ref="473589574" role=""/>
+    <member type="way" ref="702642455" role=""/>
+    <member type="way" ref="702642456" role=""/>
+    <member type="way" ref="703835091" role=""/>
+    <member type="way" ref="702643025" role=""/>
+    <member type="way" ref="702643109" role=""/>
+    <member type="way" ref="390451882" role=""/>
+    <member type="way" ref="677918495" role=""/>
+    <member type="way" ref="677918496" role=""/>
+    <member type="way" ref="702643985" role=""/>
+    <member type="way" ref="677918494" role=""/>
+    <member type="way" ref="677918493" role=""/>
+    <member type="way" ref="677918492" role=""/>
+    <member type="way" ref="196715591" role=""/>
+    <member type="way" ref="677918491" role=""/>
+    <member type="way" ref="677918490" role=""/>
+    <member type="way" ref="526004436" role=""/>
+    <member type="way" ref="196715590" role=""/>
+    <member type="way" ref="196715592" role=""/>
+    <member type="way" ref="9478792" role=""/>
+    <member type="way" ref="677918489" role=""/>
+    <member type="way" ref="677754236" role=""/>
+    <member type="way" ref="677754235" role=""/>
+    <member type="way" ref="526006102" role=""/>
+    <member type="way" ref="382014461" role=""/>
+    <member type="way" ref="381706294" role=""/>
+    <member type="way" ref="678009516" role=""/>
+    <member type="way" ref="678009515" role=""/>
+    <member type="way" ref="678009514" role=""/>
+    <member type="way" ref="381706297" role=""/>
+    <member type="way" ref="413699991" role=""/>
+    <member type="way" ref="413699992" role=""/>
+    <member type="way" ref="196715543" role=""/>
+    <member type="way" ref="121770698" role=""/>
+    <member type="way" ref="677991479" role=""/>
+    <member type="way" ref="121770695" role=""/>
+    <member type="way" ref="121770964" role=""/>
+    <member type="way" ref="196715575" role=""/>
+    <member type="way" ref="414868384" role=""/>
+    <member type="way" ref="676950370" role=""/>
+    <member type="way" ref="676866373" role=""/>
+    <member type="way" ref="676866372" role=""/>
+    <member type="way" ref="196715574" role=""/>
+    <member type="way" ref="837201914" role=""/>
+    <member type="way" ref="837201915" role=""/>
+    <member type="way" ref="196715576" role=""/>
+    <member type="way" ref="676952780" role=""/>
+    <member type="way" ref="676952782" role=""/>
+    <member type="way" ref="725402463" role=""/>
+    <member type="way" ref="413990497" role=""/>
+    <member type="way" ref="478938916" role=""/>
+    <member type="way" ref="196715594" role=""/>
+    <member type="way" ref="122050788" role=""/>
+    <member type="way" ref="725281491" role=""/>
+    <member type="way" ref="725281490" role=""/>
+    <member type="way" ref="661867214" role=""/>
+    <member type="way" ref="196715520" role=""/>
+    <member type="way" ref="677089590" role=""/>
+    <member type="way" ref="42991704" role=""/>
+    <member type="way" ref="661867212" role=""/>
+    <member type="way" ref="121914241" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="65:00"/>
+    <tag k="from" v="ЖС Панчевачки мост"/>
+    <tag k="from:sr-Latn" v="ŽS Pančevački most"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00058"/>
+    <tag k="gtfs:shape_id" v="00058_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="689087"/>
+    <tag k="interval" v="14:00"/>
+    <tag k="name" v="58: ЖС Панчевачки мост =&gt; Нови Железник"/>
+    <tag k="name:sr-Latn" v="58: ŽS Pančevački most =&gt; Novi Železnik"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="58"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Нови Железник"/>
+    <tag k="to:sr-Latn" v="Novi Železnik"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2643183" version="138" timestamp="2021-03-16T17:27:55Z" changeset="101136058" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="8241591663" role="platform"/>
+    <member type="node" ref="4709092164" role="platform"/>
+    <member type="node" ref="4709092167" role="platform"/>
+    <member type="node" ref="6324434453" role="platform"/>
+    <member type="node" ref="4709092169" role="platform"/>
+    <member type="node" ref="4718137752" role="platform"/>
+    <member type="node" ref="4718137754" role="platform"/>
+    <member type="node" ref="4708788513" role="platform"/>
+    <member type="node" ref="4708788514" role="platform"/>
+    <member type="node" ref="4708810878" role="platform"/>
+    <member type="node" ref="4708810879" role="platform"/>
+    <member type="node" ref="4708810880" role="platform"/>
+    <member type="node" ref="4708810881" role="platform"/>
+    <member type="node" ref="78980179" role="platform"/>
+    <member type="node" ref="72775646" role="platform"/>
+    <member type="node" ref="1348386532" role="platform"/>
+    <member type="node" ref="5119930329" role="platform"/>
+    <member type="node" ref="2059750409" role="platform"/>
+    <member type="node" ref="2059750352" role="platform"/>
+    <member type="node" ref="2059750504" role="platform"/>
+    <member type="node" ref="2059750393" role="platform"/>
+    <member type="node" ref="2059750326" role="platform"/>
+    <member type="node" ref="6593166765" role="platform"/>
+    <member type="node" ref="8149703056" role="platform"/>
+    <member type="node" ref="2077480548" role="platform"/>
+    <member type="node" ref="2059750485" role="platform"/>
+    <member type="node" ref="2059750422" role="platform"/>
+    <member type="node" ref="5116045644" role="platform"/>
+    <member type="node" ref="2059750331" role="platform"/>
+    <member type="node" ref="2059750410" role="platform"/>
+    <member type="node" ref="4663473498" role="platform"/>
+    <member type="node" ref="1618643087" role="platform"/>
+    <member type="node" ref="1618643091" role="platform"/>
+    <member type="node" ref="4718204530" role="platform"/>
+    <member type="node" ref="3851652389" role="platform"/>
+    <member type="node" ref="3851616096" role="platform_exit_only"/>
+    <member type="way" ref="414841013" role=""/>
+    <member type="way" ref="196715555" role=""/>
+    <member type="way" ref="661867212" role=""/>
+    <member type="way" ref="42991704" role=""/>
+    <member type="way" ref="677089590" role=""/>
+    <member type="way" ref="196715520" role=""/>
+    <member type="way" ref="677089599" role=""/>
+    <member type="way" ref="677089600" role=""/>
+    <member type="way" ref="122050804" role=""/>
+    <member type="way" ref="196715596" role=""/>
+    <member type="way" ref="196715594" role=""/>
+    <member type="way" ref="477948402" role=""/>
+    <member type="way" ref="477586670" role=""/>
+    <member type="way" ref="478938914" role=""/>
+    <member type="way" ref="837201915" role=""/>
+    <member type="way" ref="837201914" role=""/>
+    <member type="way" ref="196715574" role=""/>
+    <member type="way" ref="676950371" role=""/>
+    <member type="way" ref="676864942" role=""/>
+    <member type="way" ref="414868384" role=""/>
+    <member type="way" ref="196715575" role=""/>
+    <member type="way" ref="121770964" role=""/>
+    <member type="way" ref="121770692" role=""/>
+    <member type="way" ref="121770697" role=""/>
+    <member type="way" ref="677991477" role=""/>
+    <member type="way" ref="196715543" role=""/>
+    <member type="way" ref="413699992" role=""/>
+    <member type="way" ref="413699991" role=""/>
+    <member type="way" ref="381706297" role=""/>
+    <member type="way" ref="678009514" role=""/>
+    <member type="way" ref="678009515" role=""/>
+    <member type="way" ref="678009516" role=""/>
+    <member type="way" ref="38997056" role=""/>
+    <member type="way" ref="196715542" role=""/>
+    <member type="way" ref="38997476" role=""/>
+    <member type="way" ref="196715524" role=""/>
+    <member type="way" ref="31804425" role=""/>
+    <member type="way" ref="196715592" role=""/>
+    <member type="way" ref="196715590" role=""/>
+    <member type="way" ref="526004436" role=""/>
+    <member type="way" ref="677918490" role=""/>
+    <member type="way" ref="677918491" role=""/>
+    <member type="way" ref="196715591" role=""/>
+    <member type="way" ref="677918492" role=""/>
+    <member type="way" ref="677918493" role=""/>
+    <member type="way" ref="677918494" role=""/>
+    <member type="way" ref="702643985" role=""/>
+    <member type="way" ref="677918496" role=""/>
+    <member type="way" ref="677918495" role=""/>
+    <member type="way" ref="390451882" role=""/>
+    <member type="way" ref="702643109" role=""/>
+    <member type="way" ref="702643025" role=""/>
+    <member type="way" ref="703835091" role=""/>
+    <member type="way" ref="702642456" role=""/>
+    <member type="way" ref="702642455" role=""/>
+    <member type="way" ref="473589574" role=""/>
+    <member type="way" ref="512275836" role=""/>
+    <member type="way" ref="365353304" role=""/>
+    <member type="way" ref="725274093" role=""/>
+    <member type="way" ref="677753067" role=""/>
+    <member type="way" ref="725274094" role=""/>
+    <member type="way" ref="725274095" role=""/>
+    <member type="way" ref="678736470" role=""/>
+    <member type="way" ref="725274092" role=""/>
+    <member type="way" ref="678736471" role=""/>
+    <member type="way" ref="678736469" role=""/>
+    <member type="way" ref="678736468" role=""/>
+    <member type="way" ref="678736466" role=""/>
+    <member type="way" ref="725274089" role=""/>
+    <member type="way" ref="38909275" role=""/>
+    <member type="way" ref="725274091" role=""/>
+    <member type="way" ref="678736465" role=""/>
+    <member type="way" ref="830466528" role=""/>
+    <member type="way" ref="31799780" role=""/>
+    <member type="way" ref="677925756" role=""/>
+    <member type="way" ref="692594453" role=""/>
+    <member type="way" ref="195551211" role=""/>
+    <member type="way" ref="677925755" role=""/>
+    <member type="way" ref="845427686" role=""/>
+    <member type="way" ref="36950716" role=""/>
+    <member type="way" ref="477929225" role=""/>
+    <member type="way" ref="195551203" role=""/>
+    <member type="way" ref="473641226" role=""/>
+    <member type="way" ref="917939159" role=""/>
+    <member type="way" ref="41171348" role=""/>
+    <member type="way" ref="593948562" role=""/>
+    <member type="way" ref="895174662" role=""/>
+    <member type="way" ref="41171349" role=""/>
+    <member type="way" ref="835225082" role=""/>
+    <member type="way" ref="677908731" role=""/>
+    <member type="way" ref="834023366" role=""/>
+    <member type="way" ref="677740989" role=""/>
+    <member type="way" ref="437072200" role=""/>
+    <member type="way" ref="834023365" role=""/>
+    <member type="way" ref="681396491" role=""/>
+    <member type="way" ref="677911257" role=""/>
+    <member type="way" ref="677912884" role=""/>
+    <member type="way" ref="23893355" role=""/>
+    <member type="way" ref="677912881" role=""/>
+    <member type="way" ref="677912886" role=""/>
+    <member type="way" ref="198723956" role=""/>
+    <member type="way" ref="23893387" role=""/>
+    <member type="way" ref="38922658" role=""/>
+    <member type="way" ref="41234379" role=""/>
+    <member type="way" ref="65399798" role=""/>
+    <member type="way" ref="200366255" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="472134922" role=""/>
+    <member type="way" ref="289953743" role=""/>
+    <member type="way" ref="289953739" role=""/>
+    <member type="way" ref="289953742" role=""/>
+    <member type="way" ref="472134926" role=""/>
+    <member type="way" ref="169037914" role=""/>
+    <member type="way" ref="768510156" role=""/>
+    <member type="way" ref="23078558" role=""/>
+    <member type="way" ref="676663793" role=""/>
+    <member type="way" ref="23098071" role=""/>
+    <member type="way" ref="230065295" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="23897512" role=""/>
+    <member type="way" ref="676287469" role=""/>
+    <member type="way" ref="23115346" role=""/>
+    <member type="way" ref="676130931" role=""/>
+    <member type="way" ref="525997333" role=""/>
+    <member type="way" ref="195576430" role=""/>
+    <member type="way" ref="487184930" role=""/>
+    <member type="way" ref="195576428" role=""/>
+    <member type="way" ref="198723963" role=""/>
+    <member type="way" ref="893184452" role=""/>
+    <member type="way" ref="195576431" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="65:00"/>
+    <tag k="from" v="Нови Железник"/>
+    <tag k="from:sr-Latn" v="Novi železnik"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00058"/>
+    <tag k="gtfs:shape_id" v="00058_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="686348"/>
+    <tag k="interval" v="14:00"/>
+    <tag k="name" v="58: Нови Железник =&gt; ЖС Панчевачки мост"/>
+    <tag k="name:sr-Latn" v="58: Novi Železnik =&gt; ŽS Pančevački most"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="58"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="ЖС Панчевачки мост"/>
+    <tag k="to:sr-Latn" v="ŽS Pančevački most"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2648168" version="89" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="4690427932" role="platform_entry_only"/>
+    <member type="node" ref="2053079146" role="platform"/>
+    <member type="node" ref="2053079123" role="platform"/>
+    <member type="node" ref="2053079905" role="platform"/>
+    <member type="node" ref="2053079095" role="platform"/>
+    <member type="node" ref="2053079528" role="platform"/>
+    <member type="node" ref="2053079670" role="platform"/>
+    <member type="node" ref="2053079285" role="platform"/>
+    <member type="node" ref="2053079033" role="platform"/>
+    <member type="node" ref="2053080345" role="platform"/>
+    <member type="node" ref="2053079462" role="platform"/>
+    <member type="node" ref="2051798519" role="platform"/>
+    <member type="node" ref="2066297402" role="platform"/>
+    <member type="node" ref="2059956587" role="platform"/>
+    <member type="node" ref="1331577978" role="platform"/>
+    <member type="node" ref="1808382560" role="platform"/>
+    <member type="node" ref="1808382561" role="platform"/>
+    <member type="node" ref="2053079432" role="platform"/>
+    <member type="node" ref="1685509555" role="platform"/>
+    <member type="node" ref="1541542019" role="platform"/>
+    <member type="node" ref="4682176364" role="platform"/>
+    <member type="node" ref="4715251009" role="platform"/>
+    <member type="node" ref="1541440613" role="platform"/>
+    <member type="node" ref="4718244094" role="platform"/>
+    <member type="node" ref="3634267425" role="platform"/>
+    <member type="node" ref="2411053737" role="platform"/>
+    <member type="node" ref="1997191240" role="platform"/>
+    <member type="node" ref="8242408683" role="platform"/>
+    <member type="node" ref="4694415787" role="platform"/>
+    <member type="node" ref="4313349054" role="platform"/>
+    <member type="node" ref="3853818492" role="platform"/>
+    <member type="node" ref="3853818480" role="platform_exit_only"/>
+    <member type="way" ref="733069169" role=""/>
+    <member type="way" ref="475276331" role=""/>
+    <member type="way" ref="475276330" role=""/>
+    <member type="way" ref="849268325" role=""/>
+    <member type="way" ref="500190603" role=""/>
+    <member type="way" ref="676405569" role=""/>
+    <member type="way" ref="196297259" role=""/>
+    <member type="way" ref="676405565" role=""/>
+    <member type="way" ref="526212739" role=""/>
+    <member type="way" ref="526212735" role=""/>
+    <member type="way" ref="676609957" role=""/>
+    <member type="way" ref="526212731" role=""/>
+    <member type="way" ref="676609956" role=""/>
+    <member type="way" ref="526212727" role=""/>
+    <member type="way" ref="676609955" role=""/>
+    <member type="way" ref="680908044" role=""/>
+    <member type="way" ref="196297263" role=""/>
+    <member type="way" ref="676609954" role=""/>
+    <member type="way" ref="676627921" role=""/>
+    <member type="way" ref="676627920" role=""/>
+    <member type="way" ref="680913996" role=""/>
+    <member type="way" ref="680913995" role=""/>
+    <member type="way" ref="26500482" role=""/>
+    <member type="way" ref="679839392" role=""/>
+    <member type="way" ref="675224915" role=""/>
+    <member type="way" ref="33456654" role=""/>
+    <member type="way" ref="679844165" role=""/>
+    <member type="way" ref="526498190" role=""/>
+    <member type="way" ref="676127245" role=""/>
+    <member type="way" ref="163314696" role=""/>
+    <member type="way" ref="196297231" role=""/>
+    <member type="way" ref="679327483" role=""/>
+    <member type="way" ref="197158274" role=""/>
+    <member type="way" ref="676326146" role=""/>
+    <member type="way" ref="52783925" role=""/>
+    <member type="way" ref="52783910" role=""/>
+    <member type="way" ref="675064689" role=""/>
+    <member type="way" ref="676294659" role=""/>
+    <member type="way" ref="679600749" role=""/>
+    <member type="way" ref="676294661" role=""/>
+    <member type="way" ref="676294660" role=""/>
+    <member type="way" ref="675064688" role=""/>
+    <member type="way" ref="195144147" role=""/>
+    <member type="way" ref="195144173" role=""/>
+    <member type="way" ref="675260093" role=""/>
+    <member type="way" ref="685724188" role=""/>
+    <member type="way" ref="675260095" role=""/>
+    <member type="way" ref="195109737" role=""/>
+    <member type="way" ref="675260094" role=""/>
+    <member type="way" ref="24844511" role=""/>
+    <member type="way" ref="835639937" role=""/>
+    <member type="way" ref="675275513" role=""/>
+    <member type="way" ref="675275514" role=""/>
+    <member type="way" ref="675275515" role=""/>
+    <member type="way" ref="417006296" role=""/>
+    <member type="way" ref="196297234" role=""/>
+    <member type="way" ref="675320912" role=""/>
+    <member type="way" ref="740027655" role=""/>
+    <member type="way" ref="675320911" role=""/>
+    <member type="way" ref="679788255" role=""/>
+    <member type="way" ref="679788256" role=""/>
+    <member type="way" ref="622354859" role=""/>
+    <member type="way" ref="622354840" role=""/>
+    <member type="way" ref="740027654" role=""/>
+    <member type="way" ref="622354855" role=""/>
+    <member type="way" ref="676065810" role=""/>
+    <member type="way" ref="740027653" role=""/>
+    <member type="way" ref="740027652" role=""/>
+    <member type="way" ref="196297237" role=""/>
+    <member type="way" ref="675302536" role=""/>
+    <member type="way" ref="116482670" role=""/>
+    <member type="way" ref="116482674" role=""/>
+    <member type="way" ref="473795254" role=""/>
+    <member type="way" ref="680727271" role=""/>
+    <member type="way" ref="23720049" role=""/>
+    <member type="way" ref="471317420" role=""/>
+    <member type="way" ref="705363889" role=""/>
+    <member type="way" ref="23650408" role=""/>
+    <member type="way" ref="705363890" role=""/>
+    <member type="way" ref="822320892" role=""/>
+    <member type="way" ref="114682422" role=""/>
+    <member type="way" ref="41235874" role=""/>
+    <member type="way" ref="822320897" role=""/>
+    <member type="way" ref="41235877" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23672600" role=""/>
+    <member type="way" ref="23098073" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="676379849" role=""/>
+    <member type="way" ref="23098147" role=""/>
+    <member type="way" ref="289911805" role=""/>
+    <member type="way" ref="478706097" role=""/>
+    <member type="way" ref="839469579" role=""/>
+    <member type="way" ref="80581172" role=""/>
+    <member type="way" ref="839469610" role=""/>
+    <member type="way" ref="676414346" role=""/>
+    <member type="way" ref="839469609" role=""/>
+    <member type="way" ref="676414348" role=""/>
+    <member type="way" ref="676100120" role=""/>
+    <member type="way" ref="839469606" role=""/>
+    <member type="way" ref="839469578" role=""/>
+    <member type="way" ref="23098163" role=""/>
+    <member type="way" ref="839469599" role=""/>
+    <member type="way" ref="839469605" role=""/>
+    <member type="way" ref="839469586" role=""/>
+    <member type="way" ref="839469603" role=""/>
+    <member type="way" ref="676100121" role=""/>
+    <member type="way" ref="839469604" role=""/>
+    <member type="way" ref="289948617" role=""/>
+    <member type="way" ref="121005674" role=""/>
+    <member type="way" ref="291575506" role=""/>
+    <member type="way" ref="676088136" role=""/>
+    <member type="way" ref="289663742" role=""/>
+    <member type="way" ref="676606147" role=""/>
+    <member type="way" ref="289778700" role=""/>
+    <member type="way" ref="676923529" role=""/>
+    <member type="way" ref="676923530" role=""/>
+    <member type="way" ref="676923528" role=""/>
+    <member type="way" ref="289905491" role=""/>
+    <member type="way" ref="205598208" role=""/>
+    <member type="way" ref="675315243" role=""/>
+    <member type="way" ref="675315244" role=""/>
+    <member type="way" ref="25999098" role=""/>
+    <member type="way" ref="176074325" role=""/>
+    <member type="way" ref="197158288" role=""/>
+    <member type="way" ref="677684313" role=""/>
+    <member type="way" ref="37088424" role=""/>
+    <member type="way" ref="37088426" role=""/>
+    <member type="way" ref="37088427" role=""/>
+    <member type="way" ref="188449378" role=""/>
+    <member type="way" ref="478605672" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="61:00"/>
+    <tag k="from" v="Ново Бежанијско Гробље"/>
+    <tag k="from:sr-Latn" v="Novo Bežanijsko Groblje"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00065"/>
+    <tag k="gtfs:shape_id" v="00065_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="668728"/>
+    <tag k="interval" v="08:00"/>
+    <tag k="name" v="65: Ново Бежанијско Гробље =&gt; Звездара 2"/>
+    <tag k="name:sr-Latn" v="65: Novo Bežanijsko Groblje =&gt; Zvezdara 2"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="65"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Звездара 2"/>
+    <tag k="to:sr-Latn" v="Zvezdara 2"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2648169" version="100" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="3853818481" role="platform_entry_only"/>
+    <member type="node" ref="3853818493" role="platform"/>
+    <member type="node" ref="1989920795" role="platform"/>
+    <member type="node" ref="4694415786" role="platform"/>
+    <member type="node" ref="8242408684" role="platform"/>
+    <member type="node" ref="1997191231" role="platform"/>
+    <member type="node" ref="3889654149" role="platform"/>
+    <member type="node" ref="2411053733" role="platform"/>
+    <member type="node" ref="3634267424" role="platform"/>
+    <member type="node" ref="4718244095" role="platform"/>
+    <member type="node" ref="1541440631" role="platform"/>
+    <member type="node" ref="8275982698" role="platform"/>
+    <member type="node" ref="8278923906" role="platform"/>
+    <member type="node" ref="1541542031" role="platform"/>
+    <member type="node" ref="1685509556" role="platform"/>
+    <member type="node" ref="2053079440" role="platform"/>
+    <member type="node" ref="1808382562" role="platform"/>
+    <member type="node" ref="1808382559" role="platform"/>
+    <member type="node" ref="1331577993" role="platform"/>
+    <member type="node" ref="2059956590" role="platform"/>
+    <member type="node" ref="2051798518" role="platform"/>
+    <member type="node" ref="2053080401" role="platform"/>
+    <member type="node" ref="2053080354" role="platform"/>
+    <member type="node" ref="2053079029" role="platform"/>
+    <member type="node" ref="2053080015" role="platform"/>
+    <member type="node" ref="2053079677" role="platform"/>
+    <member type="node" ref="2053079536" role="platform"/>
+    <member type="node" ref="2053079102" role="platform"/>
+    <member type="node" ref="2053079117" role="platform"/>
+    <member type="node" ref="2053079140" role="platform"/>
+    <member type="node" ref="4690427933" role="platform_exit_only"/>
+    <member type="way" ref="478605671" role=""/>
+    <member type="way" ref="188449378" role=""/>
+    <member type="way" ref="37088427" role=""/>
+    <member type="way" ref="37088426" role=""/>
+    <member type="way" ref="37088424" role=""/>
+    <member type="way" ref="677684313" role=""/>
+    <member type="way" ref="197158288" role=""/>
+    <member type="way" ref="176074325" role=""/>
+    <member type="way" ref="25999098" role=""/>
+    <member type="way" ref="675315244" role=""/>
+    <member type="way" ref="675315243" role=""/>
+    <member type="way" ref="205598208" role=""/>
+    <member type="way" ref="289905491" role=""/>
+    <member type="way" ref="676923528" role=""/>
+    <member type="way" ref="676923530" role=""/>
+    <member type="way" ref="676923529" role=""/>
+    <member type="way" ref="289778700" role=""/>
+    <member type="way" ref="676606147" role=""/>
+    <member type="way" ref="289663742" role=""/>
+    <member type="way" ref="676088136" role=""/>
+    <member type="way" ref="291575506" role=""/>
+    <member type="way" ref="289948616" role=""/>
+    <member type="way" ref="839469604" role=""/>
+    <member type="way" ref="839469602" role=""/>
+    <member type="way" ref="839469600" role=""/>
+    <member type="way" ref="839469586" role=""/>
+    <member type="way" ref="839469605" role=""/>
+    <member type="way" ref="839469607" role=""/>
+    <member type="way" ref="839469598" role=""/>
+    <member type="way" ref="839469578" role=""/>
+    <member type="way" ref="839469606" role=""/>
+    <member type="way" ref="676100120" role=""/>
+    <member type="way" ref="676414348" role=""/>
+    <member type="way" ref="839469609" role=""/>
+    <member type="way" ref="839469611" role=""/>
+    <member type="way" ref="839469608" role=""/>
+    <member type="way" ref="80581172" role=""/>
+    <member type="way" ref="839469579" role=""/>
+    <member type="way" ref="80581173" role=""/>
+    <member type="way" ref="289911807" role=""/>
+    <member type="way" ref="23098147" role=""/>
+    <member type="way" ref="779973176" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="751959844" role=""/>
+    <member type="way" ref="751959845" role=""/>
+    <member type="way" ref="195576461" role=""/>
+    <member type="way" ref="676637001" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23672662" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="290012969" role=""/>
+    <member type="way" ref="290012968" role=""/>
+    <member type="way" ref="675220726" role=""/>
+    <member type="way" ref="675220727" role=""/>
+    <member type="way" ref="41235876" role=""/>
+    <member type="way" ref="41235875" role=""/>
+    <member type="way" ref="205987189" role=""/>
+    <member type="way" ref="822320893" role=""/>
+    <member type="way" ref="676108741" role=""/>
+    <member type="way" ref="26826000" role=""/>
+    <member type="way" ref="131952994" role=""/>
+    <member type="way" ref="680727272" role=""/>
+    <member type="way" ref="92469728" role=""/>
+    <member type="way" ref="675478314" role=""/>
+    <member type="way" ref="116482680" role=""/>
+    <member type="way" ref="116482672" role=""/>
+    <member type="way" ref="675312233" role=""/>
+    <member type="way" ref="196297236" role=""/>
+    <member type="way" ref="675484789" role=""/>
+    <member type="way" ref="675484790" role=""/>
+    <member type="way" ref="622354847" role=""/>
+    <member type="way" ref="675485549" role=""/>
+    <member type="way" ref="675485546" role=""/>
+    <member type="way" ref="622354851" role=""/>
+    <member type="way" ref="675320913" role=""/>
+    <member type="way" ref="675320914" role=""/>
+    <member type="way" ref="417006301" role=""/>
+    <member type="way" ref="675486047" role=""/>
+    <member type="way" ref="675486046" role=""/>
+    <member type="way" ref="196297235" role=""/>
+    <member type="way" ref="473641212" role=""/>
+    <member type="way" ref="473641214" role=""/>
+    <member type="way" ref="23578167" role=""/>
+    <member type="way" ref="675488303" role=""/>
+    <member type="way" ref="476171277" role=""/>
+    <member type="way" ref="675489764" role=""/>
+    <member type="way" ref="675489761" role=""/>
+    <member type="way" ref="23578174" role=""/>
+    <member type="way" ref="195144147" role=""/>
+    <member type="way" ref="675064688" role=""/>
+    <member type="way" ref="676294660" role=""/>
+    <member type="way" ref="676294661" role=""/>
+    <member type="way" ref="679600749" role=""/>
+    <member type="way" ref="676294659" role=""/>
+    <member type="way" ref="675064689" role=""/>
+    <member type="way" ref="52783910" role=""/>
+    <member type="way" ref="52783925" role=""/>
+    <member type="way" ref="676326146" role=""/>
+    <member type="way" ref="197158255" role=""/>
+    <member type="way" ref="676326145" role=""/>
+    <member type="way" ref="676326394" role=""/>
+    <member type="way" ref="675563474" role=""/>
+    <member type="way" ref="195666426" role=""/>
+    <member type="way" ref="676389750" role=""/>
+    <member type="way" ref="526498193" role=""/>
+    <member type="way" ref="538606801" role=""/>
+    <member type="way" ref="26500464" role=""/>
+    <member type="way" ref="538606799" role=""/>
+    <member type="way" ref="676627913" role=""/>
+    <member type="way" ref="676627912" role=""/>
+    <member type="way" ref="526501622" role=""/>
+    <member type="way" ref="676627917" role=""/>
+    <member type="way" ref="526501623" role=""/>
+    <member type="way" ref="676627916" role=""/>
+    <member type="way" ref="680908036" role=""/>
+    <member type="way" ref="676627922" role=""/>
+    <member type="way" ref="26500480" role=""/>
+    <member type="way" ref="526501646" role=""/>
+    <member type="way" ref="683764093" role=""/>
+    <member type="way" ref="526501645" role=""/>
+    <member type="way" ref="196297262" role=""/>
+    <member type="way" ref="676386556" role=""/>
+    <member type="way" ref="676386555" role=""/>
+    <member type="way" ref="526501647" role=""/>
+    <member type="way" ref="526501648" role=""/>
+    <member type="way" ref="676609958" role=""/>
+    <member type="way" ref="526501643" role=""/>
+    <member type="way" ref="526501642" role=""/>
+    <member type="way" ref="676405566" role=""/>
+    <member type="way" ref="196297261" role=""/>
+    <member type="way" ref="196297260" role=""/>
+    <member type="way" ref="833667139" role=""/>
+    <member type="way" ref="475276330" role=""/>
+    <member type="way" ref="849268324" role=""/>
+    <member type="way" ref="733069169" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="55:00"/>
+    <tag k="from" v="Звездара 2"/>
+    <tag k="from:sr-Latn" v="Zvezdara 2"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00065"/>
+    <tag k="gtfs:shape_id" v="00065_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="668727"/>
+    <tag k="interval" v="07:00"/>
+    <tag k="name" v="65: Звездара 2 =&gt; Ново Бежанијско Гробље"/>
+    <tag k="name:sr-Latn" v="65: Zvezdara 2 =&gt; Novo Bežanijsko Groblje"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="65"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Ново Бежанијско Гробље"/>
+    <tag k="to:sr-Latn" v="Novo Bežanijsko Groblje"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2648176" version="79" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="556057663" role="platform_entry_only"/>
+    <member type="node" ref="2053079400" role="platform"/>
+    <member type="node" ref="2053079701" role="platform"/>
+    <member type="node" ref="2053080206" role="platform"/>
+    <member type="node" ref="2053080274" role="platform"/>
+    <member type="node" ref="2053080264" role="platform"/>
+    <member type="node" ref="2051798519" role="platform"/>
+    <member type="node" ref="2066297402" role="platform"/>
+    <member type="node" ref="2059956587" role="platform"/>
+    <member type="node" ref="1331577978" role="platform"/>
+    <member type="node" ref="1808382560" role="platform"/>
+    <member type="node" ref="1808382561" role="platform"/>
+    <member type="node" ref="2053079432" role="platform"/>
+    <member type="node" ref="1685509555" role="platform"/>
+    <member type="node" ref="1541542019" role="platform"/>
+    <member type="node" ref="4682176364" role="platform"/>
+    <member type="node" ref="3452883251" role="platform"/>
+    <member type="node" ref="4016399425" role="platform"/>
+    <member type="node" ref="1541510121" role="platform"/>
+    <member type="node" ref="1541510109" role="platform"/>
+    <member type="node" ref="1541510132" role="platform"/>
+    <member type="node" ref="6551419003" role="platform"/>
+    <member type="node" ref="1541510115" role="platform"/>
+    <member type="node" ref="5152183601" role="platform_exit_only"/>
+    <member type="way" ref="526501620" role=""/>
+    <member type="way" ref="196297291" role=""/>
+    <member type="way" ref="595040415" role=""/>
+    <member type="way" ref="196297290" role=""/>
+    <member type="way" ref="505529645" role=""/>
+    <member type="way" ref="867755713" role=""/>
+    <member type="way" ref="25182083" role=""/>
+    <member type="way" ref="505529804" role=""/>
+    <member type="way" ref="675450849" role=""/>
+    <member type="way" ref="163316445" role=""/>
+    <member type="way" ref="675451975" role=""/>
+    <member type="way" ref="679600750" role=""/>
+    <member type="way" ref="196297289" role=""/>
+    <member type="way" ref="676538486" role=""/>
+    <member type="way" ref="676538485" role=""/>
+    <member type="way" ref="195144169" role=""/>
+    <member type="way" ref="195144173" role=""/>
+    <member type="way" ref="675260093" role=""/>
+    <member type="way" ref="685724188" role=""/>
+    <member type="way" ref="675260095" role=""/>
+    <member type="way" ref="195109737" role=""/>
+    <member type="way" ref="675260094" role=""/>
+    <member type="way" ref="24844511" role=""/>
+    <member type="way" ref="835639937" role=""/>
+    <member type="way" ref="675275513" role=""/>
+    <member type="way" ref="675275514" role=""/>
+    <member type="way" ref="675275515" role=""/>
+    <member type="way" ref="417006296" role=""/>
+    <member type="way" ref="196297234" role=""/>
+    <member type="way" ref="675320912" role=""/>
+    <member type="way" ref="740027655" role=""/>
+    <member type="way" ref="675320911" role=""/>
+    <member type="way" ref="679788255" role=""/>
+    <member type="way" ref="679788256" role=""/>
+    <member type="way" ref="622354859" role=""/>
+    <member type="way" ref="622354840" role=""/>
+    <member type="way" ref="740027654" role=""/>
+    <member type="way" ref="622354855" role=""/>
+    <member type="way" ref="676065810" role=""/>
+    <member type="way" ref="740027653" role=""/>
+    <member type="way" ref="740027652" role=""/>
+    <member type="way" ref="196297237" role=""/>
+    <member type="way" ref="675302536" role=""/>
+    <member type="way" ref="116482670" role=""/>
+    <member type="way" ref="116482674" role=""/>
+    <member type="way" ref="473795254" role=""/>
+    <member type="way" ref="680727271" role=""/>
+    <member type="way" ref="23720049" role=""/>
+    <member type="way" ref="471317420" role=""/>
+    <member type="way" ref="705363889" role=""/>
+    <member type="way" ref="23650408" role=""/>
+    <member type="way" ref="705363890" role=""/>
+    <member type="way" ref="822320892" role=""/>
+    <member type="way" ref="114682422" role=""/>
+    <member type="way" ref="41235874" role=""/>
+    <member type="way" ref="822320897" role=""/>
+    <member type="way" ref="41235877" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23672600" role=""/>
+    <member type="way" ref="23098073" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="676379849" role=""/>
+    <member type="way" ref="23098147" role=""/>
+    <member type="way" ref="289911805" role=""/>
+    <member type="way" ref="478706097" role=""/>
+    <member type="way" ref="839469579" role=""/>
+    <member type="way" ref="80581172" role=""/>
+    <member type="way" ref="839469610" role=""/>
+    <member type="way" ref="676414346" role=""/>
+    <member type="way" ref="839469609" role=""/>
+    <member type="way" ref="676414348" role=""/>
+    <member type="way" ref="676103774" role=""/>
+    <member type="way" ref="676651115" role=""/>
+    <member type="way" ref="676651114" role=""/>
+    <member type="way" ref="391677797" role=""/>
+    <member type="way" ref="391677784" role=""/>
+    <member type="way" ref="676651116" role=""/>
+    <member type="way" ref="676415908" role=""/>
+    <member type="way" ref="676415907" role=""/>
+    <member type="way" ref="675319420" role=""/>
+    <member type="way" ref="473657978" role=""/>
+    <member type="way" ref="675316529" role=""/>
+    <member type="way" ref="205598210" role=""/>
+    <member type="way" ref="23102985" role=""/>
+    <member type="way" ref="680389472" role=""/>
+    <member type="way" ref="677695986" role=""/>
+    <member type="way" ref="677695985" role=""/>
+    <member type="way" ref="677695982" role=""/>
+    <member type="way" ref="677695980" role=""/>
+    <member type="way" ref="677695978" role=""/>
+    <member type="way" ref="677695977" role=""/>
+    <member type="way" ref="677695970" role=""/>
+    <member type="way" ref="677695966" role=""/>
+    <member type="way" ref="677695962" role=""/>
+    <member type="way" ref="677695960" role=""/>
+    <member type="way" ref="205598203" role=""/>
+    <member type="way" ref="871154993" role=""/>
+    <member type="way" ref="705360568" role=""/>
+    <member type="way" ref="705360569" role=""/>
+    <member type="way" ref="705360567" role=""/>
+    <member type="way" ref="705360566" role=""/>
+    <member type="way" ref="680391877" role=""/>
+    <member type="way" ref="680391878" role=""/>
+    <member type="way" ref="871156114" role=""/>
+    <member type="way" ref="677697515" role=""/>
+    <member type="way" ref="135929799" role=""/>
+    <member type="way" ref="23103010" role=""/>
+    <member type="way" ref="400293418" role=""/>
+    <member type="way" ref="850225631" role=""/>
+    <member type="way" ref="478158039" role=""/>
+    <member type="way" ref="478158040" role=""/>
+    <member type="way" ref="135929800" role=""/>
+    <member type="way" ref="627370436" role=""/>
+    <member type="way" ref="265703017" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="53:00"/>
+    <tag k="from" v="Бежанијска Коса"/>
+    <tag k="from:sr-Latn" v="Bežanijska Kosa"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00077"/>
+    <tag k="gtfs:shape_id" v="00077_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="685163"/>
+    <tag k="interval" v="11:00"/>
+    <tag k="name" v="77: Бежанијска Коса =&gt; Звездара"/>
+    <tag k="name:sr-Latn" v="77: Bežanijska Kosa =&gt; Zvezdara"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="77"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Звездара"/>
+    <tag k="to:sr-Latn" v="Zvezdara"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2648177" version="86" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="2713215326" role="platform_entry_only"/>
+    <member type="node" ref="4714130115" role="platform"/>
+    <member type="node" ref="475064480" role="platform"/>
+    <member type="node" ref="1541510130" role="platform"/>
+    <member type="node" ref="1541510133" role="platform"/>
+    <member type="node" ref="1541510112" role="platform"/>
+    <member type="node" ref="1541510118" role="platform"/>
+    <member type="node" ref="3452883252" role="platform"/>
+    <member type="node" ref="8278923906" role="platform"/>
+    <member type="node" ref="1541542031" role="platform"/>
+    <member type="node" ref="1685509556" role="platform"/>
+    <member type="node" ref="2053079440" role="platform"/>
+    <member type="node" ref="1808382562" role="platform"/>
+    <member type="node" ref="1808382559" role="platform"/>
+    <member type="node" ref="1331577993" role="platform"/>
+    <member type="node" ref="2059956590" role="platform"/>
+    <member type="node" ref="2051798518" role="platform"/>
+    <member type="node" ref="2051798520" role="platform"/>
+    <member type="node" ref="2053080257" role="platform"/>
+    <member type="node" ref="2053080279" role="platform"/>
+    <member type="node" ref="2053079705" role="platform"/>
+    <member type="node" ref="2053080164" role="platform"/>
+    <member type="node" ref="2053079557" role="platform"/>
+    <member type="node" ref="2053079409" role="platform"/>
+    <member type="node" ref="556057663" role="platform"/>
+    <member type="way" ref="265703017" role=""/>
+    <member type="way" ref="63204498" role=""/>
+    <member type="way" ref="478158040" role=""/>
+    <member type="way" ref="478158039" role=""/>
+    <member type="way" ref="850225631" role=""/>
+    <member type="way" ref="400293418" role=""/>
+    <member type="way" ref="23103010" role=""/>
+    <member type="way" ref="23103030" role=""/>
+    <member type="way" ref="676849764" role=""/>
+    <member type="way" ref="680391879" role=""/>
+    <member type="way" ref="680391880" role=""/>
+    <member type="way" ref="676849763" role=""/>
+    <member type="way" ref="676855352" role=""/>
+    <member type="way" ref="676855351" role=""/>
+    <member type="way" ref="676855342" role=""/>
+    <member type="way" ref="680389471" role=""/>
+    <member type="way" ref="680389470" role=""/>
+    <member type="way" ref="36947117" role=""/>
+    <member type="way" ref="205598204" role=""/>
+    <member type="way" ref="23098118" role=""/>
+    <member type="way" ref="205598215" role=""/>
+    <member type="way" ref="675318442" role=""/>
+    <member type="way" ref="675318441" role=""/>
+    <member type="way" ref="197158259" role=""/>
+    <member type="way" ref="675319419" role=""/>
+    <member type="way" ref="676415905" role=""/>
+    <member type="way" ref="104869476" role=""/>
+    <member type="way" ref="391677797" role=""/>
+    <member type="way" ref="676651114" role=""/>
+    <member type="way" ref="676651115" role=""/>
+    <member type="way" ref="676103774" role=""/>
+    <member type="way" ref="676414348" role=""/>
+    <member type="way" ref="839469609" role=""/>
+    <member type="way" ref="839469611" role=""/>
+    <member type="way" ref="839469608" role=""/>
+    <member type="way" ref="80581172" role=""/>
+    <member type="way" ref="839469579" role=""/>
+    <member type="way" ref="80581173" role=""/>
+    <member type="way" ref="289911807" role=""/>
+    <member type="way" ref="23098147" role=""/>
+    <member type="way" ref="779973176" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="751959844" role=""/>
+    <member type="way" ref="751959845" role=""/>
+    <member type="way" ref="195576461" role=""/>
+    <member type="way" ref="676637001" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23672662" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="290012969" role=""/>
+    <member type="way" ref="290012968" role=""/>
+    <member type="way" ref="675220726" role=""/>
+    <member type="way" ref="675220727" role=""/>
+    <member type="way" ref="41235876" role=""/>
+    <member type="way" ref="41235875" role=""/>
+    <member type="way" ref="205987189" role=""/>
+    <member type="way" ref="822320893" role=""/>
+    <member type="way" ref="676108741" role=""/>
+    <member type="way" ref="26826000" role=""/>
+    <member type="way" ref="131952994" role=""/>
+    <member type="way" ref="680727272" role=""/>
+    <member type="way" ref="92469728" role=""/>
+    <member type="way" ref="675478314" role=""/>
+    <member type="way" ref="116482680" role=""/>
+    <member type="way" ref="116482672" role=""/>
+    <member type="way" ref="675312233" role=""/>
+    <member type="way" ref="196297236" role=""/>
+    <member type="way" ref="675484789" role=""/>
+    <member type="way" ref="675484790" role=""/>
+    <member type="way" ref="622354847" role=""/>
+    <member type="way" ref="675485549" role=""/>
+    <member type="way" ref="675485546" role=""/>
+    <member type="way" ref="622354851" role=""/>
+    <member type="way" ref="675320913" role=""/>
+    <member type="way" ref="675320914" role=""/>
+    <member type="way" ref="417006301" role=""/>
+    <member type="way" ref="675486047" role=""/>
+    <member type="way" ref="675486046" role=""/>
+    <member type="way" ref="196297235" role=""/>
+    <member type="way" ref="473641212" role=""/>
+    <member type="way" ref="473641214" role=""/>
+    <member type="way" ref="23578167" role=""/>
+    <member type="way" ref="675488303" role=""/>
+    <member type="way" ref="476171277" role=""/>
+    <member type="way" ref="675489764" role=""/>
+    <member type="way" ref="675489761" role=""/>
+    <member type="way" ref="195144168" role=""/>
+    <member type="way" ref="675493531" role=""/>
+    <member type="way" ref="195144184" role=""/>
+    <member type="way" ref="196297289" role=""/>
+    <member type="way" ref="679600750" role=""/>
+    <member type="way" ref="675451975" role=""/>
+    <member type="way" ref="163316445" role=""/>
+    <member type="way" ref="675450849" role=""/>
+    <member type="way" ref="505529804" role=""/>
+    <member type="way" ref="25182083" role=""/>
+    <member type="way" ref="867755713" role=""/>
+    <member type="way" ref="505529645" role=""/>
+    <member type="way" ref="196297290" role=""/>
+    <member type="way" ref="595040415" role=""/>
+    <member type="way" ref="686357615" role=""/>
+    <member type="way" ref="686357614" role=""/>
+    <member type="way" ref="262481825" role=""/>
+    <member type="way" ref="686357615" role=""/>
+    <member type="way" ref="196297291" role=""/>
+    <member type="way" ref="526501620" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="52:00"/>
+    <tag k="from" v="Звездара"/>
+    <tag k="from:sr-Latn" v="Zvezdara"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00077"/>
+    <tag k="gtfs:shape_id" v="00077_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="685164"/>
+    <tag k="interval" v="11:00"/>
+    <tag k="name" v="77: Звездара =&gt; Бежанијска Коса"/>
+    <tag k="name:sr-Latn" v="77: Zvezdara =&gt; Bežanijska Kosa"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="77"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Бежанијска Коса"/>
+    <tag k="to:sr-Latn" v="Bežanijska Kosa"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2648179" version="3" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2648169" role=""/>
+    <member type="relation" ref="2648168" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00065"/>
+    <tag k="name" v="65"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="65"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2648180" version="3" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2648176" role=""/>
+    <member type="relation" ref="2648177" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00077"/>
+    <tag k="name" v="77"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="77"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="2655310" version="76" timestamp="2021-03-25T16:42:12Z" changeset="101734046" uid="622084" user="ITineris">
+    <member type="node" ref="4694419224" role="platform_entry_only"/>
+    <member type="node" ref="4694419225" role="platform"/>
+    <member type="node" ref="4694419222" role="platform"/>
+    <member type="node" ref="4694419228" role="platform"/>
+    <member type="node" ref="3825511872" role="platform"/>
+    <member type="node" ref="3825511877" role="platform"/>
+    <member type="node" ref="3825511910" role="platform"/>
+    <member type="node" ref="1796210294" role="platform"/>
+    <member type="node" ref="2055938849" role="platform"/>
+    <member type="node" ref="2055938851" role="platform"/>
+    <member type="node" ref="1618717623" role="platform"/>
+    <member type="node" ref="1618643103" role="platform"/>
+    <member type="node" ref="4359064383" role="platform_exit_only"/>
+    <member type="way" ref="475717841" role=""/>
+    <member type="way" ref="25915844" role=""/>
+    <member type="way" ref="442327951" role=""/>
+    <member type="way" ref="25912619" role=""/>
+    <member type="way" ref="442208072" role=""/>
+    <member type="way" ref="307151744" role=""/>
+    <member type="way" ref="25912616" role=""/>
+    <member type="way" ref="379180614" role=""/>
+    <member type="way" ref="116422940" role=""/>
+    <member type="way" ref="725287336" role=""/>
+    <member type="way" ref="725287334" role=""/>
+    <member type="way" ref="725287333" role=""/>
+    <member type="way" ref="56691942" role=""/>
+    <member type="way" ref="204868099" role=""/>
+    <member type="way" ref="722007195" role=""/>
+    <member type="way" ref="204868097" role=""/>
+    <member type="way" ref="24624974" role=""/>
+    <member type="way" ref="116372420" role=""/>
+    <member type="way" ref="23428571" role=""/>
+    <member type="way" ref="919864848" role=""/>
+    <member type="way" ref="23428523" role=""/>
+    <member type="way" ref="23428570" role=""/>
+    <member type="way" ref="381956945" role=""/>
+    <member type="way" ref="200724862" role=""/>
+    <member type="way" ref="675555278" role=""/>
+    <member type="way" ref="574867478" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="684356845" role=""/>
+    <member type="way" ref="619005684" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="686663563" role=""/>
+    <member type="way" ref="23073203" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="35:00"/>
+    <tag k="from" v="Котеж"/>
+    <tag k="from:sr-Latn" v="Kotež"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00043"/>
+    <tag k="gtfs:shape_id" v="00043_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="804172"/>
+    <tag k="interval" v="06:00"/>
+    <tag k="name" v="43: Котеж =&gt; Трг Републике"/>
+    <tag k="name:sr-Latn" v="43: Kotež =&gt; Trg Republike"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="43"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Трг Републике"/>
+    <tag k="to:sr-Latn" v="Trg Republike"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2655312" version="119" timestamp="2021-03-20T21:15:48Z" changeset="101418279" uid="10993864" user="MapperNews">
+    <member type="node" ref="1657430216" role="platform_entry_only"/>
+    <member type="node" ref="1657430265" role="platform"/>
+    <member type="node" ref="2053080457" role="platform"/>
+    <member type="node" ref="2053079802" role="platform"/>
+    <member type="node" ref="2053079857" role="platform"/>
+    <member type="node" ref="2053079840" role="platform"/>
+    <member type="node" ref="2053079830" role="platform"/>
+    <member type="node" ref="1974639078" role="platform"/>
+    <member type="node" ref="1974600402" role="platform"/>
+    <member type="node" ref="1974600410" role="platform"/>
+    <member type="node" ref="1974648824" role="platform"/>
+    <member type="node" ref="4715094001" role="platform"/>
+    <member type="node" ref="4678287901" role="platform"/>
+    <member type="node" ref="1937578107" role="platform"/>
+    <member type="node" ref="2077480559" role="platform"/>
+    <member type="node" ref="2066417343" role="platform"/>
+    <member type="node" ref="2053079432" role="platform"/>
+    <member type="node" ref="1685509555" role="platform"/>
+    <member type="node" ref="1618643087" role="platform"/>
+    <member type="node" ref="1618643091" role="platform"/>
+    <member type="node" ref="1618713347" role="platform"/>
+    <member type="node" ref="2055938848" role="platform"/>
+    <member type="node" ref="1796210280" role="platform"/>
+    <member type="node" ref="267686072" role="platform"/>
+    <member type="node" ref="3825511909" role="platform"/>
+    <member type="node" ref="1331729514" role="platform"/>
+    <member type="node" ref="3825511054" role="platform"/>
+    <member type="node" ref="1331729459" role="platform"/>
+    <member type="node" ref="253736260" role="platform"/>
+    <member type="node" ref="1331729536" role="platform"/>
+    <member type="node" ref="1331729447" role="platform"/>
+    <member type="node" ref="283599826" role="platform"/>
+    <member type="node" ref="4694194068" role="platform"/>
+    <member type="node" ref="1379431230" role="platform"/>
+    <member type="node" ref="1331729502" role="platform"/>
+    <member type="node" ref="1331729461" role="platform"/>
+    <member type="node" ref="1331729537" role="platform"/>
+    <member type="node" ref="1331729439" role="platform"/>
+    <member type="node" ref="1331729517" role="platform_exit_only"/>
+    <member type="way" ref="26490973" role=""/>
+    <member type="way" ref="832177899" role=""/>
+    <member type="way" ref="729700731" role=""/>
+    <member type="way" ref="26490975" role=""/>
+    <member type="way" ref="675310346" role=""/>
+    <member type="way" ref="675310347" role=""/>
+    <member type="way" ref="675310348" role=""/>
+    <member type="way" ref="153018113" role=""/>
+    <member type="way" ref="675310343" role=""/>
+    <member type="way" ref="676259783" role=""/>
+    <member type="way" ref="390662124" role=""/>
+    <member type="way" ref="572710743" role=""/>
+    <member type="way" ref="390662218" role=""/>
+    <member type="way" ref="256988635" role=""/>
+    <member type="way" ref="572710746" role=""/>
+    <member type="way" ref="196297254" role=""/>
+    <member type="way" ref="676289832" role=""/>
+    <member type="way" ref="153006231" role=""/>
+    <member type="way" ref="197772495" role=""/>
+    <member type="way" ref="676272235" role=""/>
+    <member type="way" ref="676272234" role=""/>
+    <member type="way" ref="676272233" role=""/>
+    <member type="way" ref="676272231" role=""/>
+    <member type="way" ref="676272232" role=""/>
+    <member type="way" ref="676272230" role=""/>
+    <member type="way" ref="676272229" role=""/>
+    <member type="way" ref="676272227" role=""/>
+    <member type="way" ref="676272226" role=""/>
+    <member type="way" ref="676272225" role=""/>
+    <member type="way" ref="676272224" role=""/>
+    <member type="way" ref="676274842" role=""/>
+    <member type="way" ref="676274838" role=""/>
+    <member type="way" ref="676274835" role=""/>
+    <member type="way" ref="197772496" role=""/>
+    <member type="way" ref="675457758" role=""/>
+    <member type="way" ref="675457754" role=""/>
+    <member type="way" ref="675457768" role=""/>
+    <member type="way" ref="675457751" role=""/>
+    <member type="way" ref="675507991" role=""/>
+    <member type="way" ref="892752497" role=""/>
+    <member type="way" ref="46597342" role=""/>
+    <member type="way" ref="892752496" role=""/>
+    <member type="way" ref="675297513" role=""/>
+    <member type="way" ref="892752495" role=""/>
+    <member type="way" ref="675297512" role=""/>
+    <member type="way" ref="676076690" role=""/>
+    <member type="way" ref="676076686" role=""/>
+    <member type="way" ref="197772508" role=""/>
+    <member type="way" ref="277209204" role=""/>
+    <member type="way" ref="277209203" role=""/>
+    <member type="way" ref="196297219" role=""/>
+    <member type="way" ref="277209200" role=""/>
+    <member type="way" ref="676080627" role=""/>
+    <member type="way" ref="676080628" role=""/>
+    <member type="way" ref="207641661" role=""/>
+    <member type="way" ref="196297218" role=""/>
+    <member type="way" ref="677660165" role=""/>
+    <member type="way" ref="677660164" role=""/>
+    <member type="way" ref="207641662" role=""/>
+    <member type="way" ref="871164281" role=""/>
+    <member type="way" ref="871164280" role=""/>
+    <member type="way" ref="207641657" role=""/>
+    <member type="way" ref="677660680" role=""/>
+    <member type="way" ref="676385934" role=""/>
+    <member type="way" ref="676385935" role=""/>
+    <member type="way" ref="473641216" role=""/>
+    <member type="way" ref="677660928" role=""/>
+    <member type="way" ref="399333134" role=""/>
+    <member type="way" ref="41205061" role=""/>
+    <member type="way" ref="399328394" role=""/>
+    <member type="way" ref="399328400" role=""/>
+    <member type="way" ref="401782410" role=""/>
+    <member type="way" ref="679851359" role=""/>
+    <member type="way" ref="199914546" role=""/>
+    <member type="way" ref="677669669" role=""/>
+    <member type="way" ref="401781664" role=""/>
+    <member type="way" ref="401781660" role=""/>
+    <member type="way" ref="677669668" role=""/>
+    <member type="way" ref="23788656" role=""/>
+    <member type="way" ref="198424206" role=""/>
+    <member type="way" ref="399343061" role=""/>
+    <member type="way" ref="399343064" role=""/>
+    <member type="way" ref="118917601" role=""/>
+    <member type="way" ref="677669667" role=""/>
+    <member type="way" ref="677669666" role=""/>
+    <member type="way" ref="23578387" role=""/>
+    <member type="way" ref="23578267" role=""/>
+    <member type="way" ref="676002071" role=""/>
+    <member type="way" ref="470739714" role=""/>
+    <member type="way" ref="52783876" role=""/>
+    <member type="way" ref="470739711" role=""/>
+    <member type="way" ref="675540194" role=""/>
+    <member type="way" ref="675540193" role=""/>
+    <member type="way" ref="725329129" role=""/>
+    <member type="way" ref="725329128" role=""/>
+    <member type="way" ref="725329127" role=""/>
+    <member type="way" ref="52783877" role=""/>
+    <member type="way" ref="725329126" role=""/>
+    <member type="way" ref="196297264" role=""/>
+    <member type="way" ref="675239061" role=""/>
+    <member type="way" ref="675302535" role=""/>
+    <member type="way" ref="478280129" role=""/>
+    <member type="way" ref="116482674" role=""/>
+    <member type="way" ref="473795254" role=""/>
+    <member type="way" ref="680727271" role=""/>
+    <member type="way" ref="23720049" role=""/>
+    <member type="way" ref="471317420" role=""/>
+    <member type="way" ref="705363889" role=""/>
+    <member type="way" ref="23650408" role=""/>
+    <member type="way" ref="705363890" role=""/>
+    <member type="way" ref="822320892" role=""/>
+    <member type="way" ref="114682422" role=""/>
+    <member type="way" ref="41235874" role=""/>
+    <member type="way" ref="822320897" role=""/>
+    <member type="way" ref="41235877" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23672600" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="195576438" role=""/>
+    <member type="way" ref="680489364" role=""/>
+    <member type="way" ref="286312169" role=""/>
+    <member type="way" ref="292376562" role=""/>
+    <member type="way" ref="381956950" role=""/>
+    <member type="way" ref="23428520" role=""/>
+    <member type="way" ref="41202293" role=""/>
+    <member type="way" ref="919864847" role=""/>
+    <member type="way" ref="23428586" role=""/>
+    <member type="way" ref="23428601" role=""/>
+    <member type="way" ref="23152015" role=""/>
+    <member type="way" ref="240849451" role=""/>
+    <member type="way" ref="24624948" role=""/>
+    <member type="way" ref="722007196" role=""/>
+    <member type="way" ref="204868098" role=""/>
+    <member type="way" ref="204868096" role=""/>
+    <member type="way" ref="725287330" role=""/>
+    <member type="way" ref="725287331" role=""/>
+    <member type="way" ref="725287335" role=""/>
+    <member type="way" ref="56691941" role=""/>
+    <member type="way" ref="725287340" role=""/>
+    <member type="way" ref="424772304" role=""/>
+    <member type="way" ref="35393726" role=""/>
+    <member type="way" ref="35393725" role=""/>
+    <member type="way" ref="475695573" role=""/>
+    <member type="way" ref="475695574" role=""/>
+    <member type="way" ref="475695571" role=""/>
+    <member type="way" ref="427088589" role=""/>
+    <member type="way" ref="427088596" role=""/>
+    <member type="way" ref="25917039" role=""/>
+    <member type="way" ref="31433549" role=""/>
+    <member type="way" ref="538798630" role=""/>
+    <member type="way" ref="538798631" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="78:00"/>
+    <tag k="from" v="Блок 45"/>
+    <tag k="from:sr-Latn" v="Blok 45"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00095"/>
+    <tag k="gtfs:shape_id" v="00095_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="708507"/>
+    <tag k="interval" v="06:00"/>
+    <tag k="name" v="95: Блок 45 =&gt; Борча 3"/>
+    <tag k="name:sr-Latn" v="95: Blok 45 =&gt; Borča 3"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="95"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Борча 3"/>
+    <tag k="to:sr-Latn" v="Borča 3"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2655313" version="131" timestamp="2021-03-25T16:42:12Z" changeset="101734046" uid="622084" user="ITineris">
+    <member type="node" ref="8256048603" role="platform_entry_only"/>
+    <member type="node" ref="1331729480" role="platform"/>
+    <member type="node" ref="4357253069" role="platform"/>
+    <member type="node" ref="3087213022" role="platform"/>
+    <member type="node" ref="4485071883" role="platform"/>
+    <member type="node" ref="1331729464" role="platform"/>
+    <member type="node" ref="1331729456" role="platform"/>
+    <member type="node" ref="253736359" role="platform"/>
+    <member type="node" ref="1331729522" role="platform"/>
+    <member type="node" ref="1331729475" role="platform"/>
+    <member type="node" ref="1331729483" role="platform"/>
+    <member type="node" ref="1331729535" role="platform"/>
+    <member type="node" ref="3825511872" role="platform"/>
+    <member type="node" ref="3825511877" role="platform"/>
+    <member type="node" ref="3825511910" role="platform"/>
+    <member type="node" ref="1796210294" role="platform"/>
+    <member type="node" ref="2055938849" role="platform"/>
+    <member type="node" ref="2055938851" role="platform"/>
+    <member type="node" ref="1618717623" role="platform"/>
+    <member type="node" ref="1618643103" role="platform"/>
+    <member type="node" ref="1618643110" role="platform"/>
+    <member type="node" ref="1685509556" role="platform"/>
+    <member type="node" ref="2053079440" role="platform"/>
+    <member type="node" ref="2066417344" role="platform"/>
+    <member type="node" ref="2077480553" role="platform"/>
+    <member type="node" ref="1937578108" role="platform"/>
+    <member type="node" ref="2053079947" role="platform"/>
+    <member type="node" ref="2053079644" role="platform"/>
+    <member type="node" ref="2053079291" role="platform"/>
+    <member type="node" ref="4715415981" role="platform"/>
+    <member type="node" ref="1974648828" role="platform"/>
+    <member type="node" ref="1974600414" role="platform"/>
+    <member type="node" ref="1974600406" role="platform"/>
+    <member type="node" ref="2053079505" role="platform"/>
+    <member type="node" ref="2053079819" role="platform"/>
+    <member type="node" ref="2053079849" role="platform"/>
+    <member type="node" ref="2053079863" role="platform"/>
+    <member type="node" ref="2053079810" role="platform"/>
+    <member type="node" ref="2053079321" role="platform"/>
+    <member type="node" ref="2053080043" role="platform"/>
+    <member type="node" ref="1657430273" role="platform"/>
+    <member type="node" ref="1657430204" role="platform_exit_only"/>
+    <member type="way" ref="538798631" role=""/>
+    <member type="way" ref="25917058" role=""/>
+    <member type="way" ref="334752734" role=""/>
+    <member type="way" ref="538798632" role=""/>
+    <member type="way" ref="146421261" role=""/>
+    <member type="way" ref="31434387" role=""/>
+    <member type="way" ref="538798630" role=""/>
+    <member type="way" ref="31433549" role=""/>
+    <member type="way" ref="25917039" role=""/>
+    <member type="way" ref="427088596" role=""/>
+    <member type="way" ref="427088590" role=""/>
+    <member type="way" ref="475695576" role=""/>
+    <member type="way" ref="35393723" role=""/>
+    <member type="way" ref="35393724" role=""/>
+    <member type="way" ref="725287341" role=""/>
+    <member type="way" ref="424772305" role=""/>
+    <member type="way" ref="725287339" role=""/>
+    <member type="way" ref="379180618" role=""/>
+    <member type="way" ref="725287334" role=""/>
+    <member type="way" ref="725287333" role=""/>
+    <member type="way" ref="56691942" role=""/>
+    <member type="way" ref="204868099" role=""/>
+    <member type="way" ref="722007195" role=""/>
+    <member type="way" ref="204868097" role=""/>
+    <member type="way" ref="24624974" role=""/>
+    <member type="way" ref="116372420" role=""/>
+    <member type="way" ref="23428571" role=""/>
+    <member type="way" ref="919864848" role=""/>
+    <member type="way" ref="23428523" role=""/>
+    <member type="way" ref="23428570" role=""/>
+    <member type="way" ref="381956945" role=""/>
+    <member type="way" ref="200724862" role=""/>
+    <member type="way" ref="675555278" role=""/>
+    <member type="way" ref="574867478" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23672662" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="290012969" role=""/>
+    <member type="way" ref="290012968" role=""/>
+    <member type="way" ref="675220726" role=""/>
+    <member type="way" ref="675220727" role=""/>
+    <member type="way" ref="41235876" role=""/>
+    <member type="way" ref="41235875" role=""/>
+    <member type="way" ref="205987189" role=""/>
+    <member type="way" ref="822320893" role=""/>
+    <member type="way" ref="676108741" role=""/>
+    <member type="way" ref="26826000" role=""/>
+    <member type="way" ref="131952994" role=""/>
+    <member type="way" ref="680727272" role=""/>
+    <member type="way" ref="92469728" role=""/>
+    <member type="way" ref="675478314" role=""/>
+    <member type="way" ref="116482680" role=""/>
+    <member type="way" ref="116482676" role=""/>
+    <member type="way" ref="116482678" role=""/>
+    <member type="way" ref="478280109" role=""/>
+    <member type="way" ref="725329125" role=""/>
+    <member type="way" ref="196603667" role=""/>
+    <member type="way" ref="196297265" role=""/>
+    <member type="way" ref="399336315" role=""/>
+    <member type="way" ref="675540191" role=""/>
+    <member type="way" ref="675540192" role=""/>
+    <member type="way" ref="52783881" role=""/>
+    <member type="way" ref="676004114" role=""/>
+    <member type="way" ref="676004115" role=""/>
+    <member type="way" ref="52783882" role=""/>
+    <member type="way" ref="676000250" role=""/>
+    <member type="way" ref="39621926" role=""/>
+    <member type="way" ref="677670650" role=""/>
+    <member type="way" ref="677670649" role=""/>
+    <member type="way" ref="118917597" role=""/>
+    <member type="way" ref="677670647" role=""/>
+    <member type="way" ref="677670648" role=""/>
+    <member type="way" ref="199914552" role=""/>
+    <member type="way" ref="41205351" role=""/>
+    <member type="way" ref="399333138" role=""/>
+    <member type="way" ref="199914551" role=""/>
+    <member type="way" ref="399333136" role=""/>
+    <member type="way" ref="399333135" role=""/>
+    <member type="way" ref="33455163" role=""/>
+    <member type="way" ref="41205058" role=""/>
+    <member type="way" ref="676385936" role=""/>
+    <member type="way" ref="473641217" role=""/>
+    <member type="way" ref="188128384" role=""/>
+    <member type="way" ref="188128385" role=""/>
+    <member type="way" ref="679869918" role=""/>
+    <member type="way" ref="679500271" role=""/>
+    <member type="way" ref="207641659" role=""/>
+    <member type="way" ref="207641663" role=""/>
+    <member type="way" ref="679869916" role=""/>
+    <member type="way" ref="679869914" role=""/>
+    <member type="way" ref="679869917" role=""/>
+    <member type="way" ref="679869915" role=""/>
+    <member type="way" ref="207641660" role=""/>
+    <member type="way" ref="392951764" role=""/>
+    <member type="way" ref="196297217" role=""/>
+    <member type="way" ref="208996948" role=""/>
+    <member type="way" ref="676076681" role=""/>
+    <member type="way" ref="197772510" role=""/>
+    <member type="way" ref="675297504" role=""/>
+    <member type="way" ref="197772512" role=""/>
+    <member type="way" ref="675290125" role=""/>
+    <member type="way" ref="675290124" role=""/>
+    <member type="way" ref="197772514" role=""/>
+    <member type="way" ref="675285730" role=""/>
+    <member type="way" ref="631673594" role=""/>
+    <member type="way" ref="631673598" role=""/>
+    <member type="way" ref="525991722" role=""/>
+    <member type="way" ref="707887888" role=""/>
+    <member type="way" ref="707887890" role=""/>
+    <member type="way" ref="676134681" role=""/>
+    <member type="way" ref="707887892" role=""/>
+    <member type="way" ref="676134676" role=""/>
+    <member type="way" ref="676134678" role=""/>
+    <member type="way" ref="714750428" role=""/>
+    <member type="way" ref="676134674" role=""/>
+    <member type="way" ref="676134673" role=""/>
+    <member type="way" ref="676134672" role=""/>
+    <member type="way" ref="676134671" role=""/>
+    <member type="way" ref="676134670" role=""/>
+    <member type="way" ref="676134669" role=""/>
+    <member type="way" ref="197772499" role=""/>
+    <member type="way" ref="714750434" role=""/>
+    <member type="way" ref="714750435" role=""/>
+    <member type="way" ref="714750436" role=""/>
+    <member type="way" ref="714750437" role=""/>
+    <member type="way" ref="676134667" role=""/>
+    <member type="way" ref="676134664" role=""/>
+    <member type="way" ref="676134663" role=""/>
+    <member type="way" ref="676134666" role=""/>
+    <member type="way" ref="667928035" role=""/>
+    <member type="way" ref="676289835" role=""/>
+    <member type="way" ref="478712112" role=""/>
+    <member type="way" ref="667635364" role=""/>
+    <member type="way" ref="676289834" role=""/>
+    <member type="way" ref="676266641" role=""/>
+    <member type="way" ref="676266640" role=""/>
+    <member type="way" ref="667929048" role=""/>
+    <member type="way" ref="256988638" role=""/>
+    <member type="way" ref="676265675" role=""/>
+    <member type="way" ref="676562466" role=""/>
+    <member type="way" ref="197772515" role=""/>
+    <member type="way" ref="676259254" role=""/>
+    <member type="way" ref="572710735" role=""/>
+    <member type="way" ref="196297253" role=""/>
+    <member type="way" ref="676569043" role=""/>
+    <member type="way" ref="676569039" role=""/>
+    <member type="way" ref="676569034" role=""/>
+    <member type="way" ref="572710733" role=""/>
+    <member type="way" ref="675310348" role=""/>
+    <member type="way" ref="675310347" role=""/>
+    <member type="way" ref="675310346" role=""/>
+    <member type="way" ref="26490975" role=""/>
+    <member type="way" ref="729700731" role=""/>
+    <member type="way" ref="26490973" role=""/>
+    <member type="way" ref="832177899" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="80:30"/>
+    <tag k="from" v="Борча 3"/>
+    <tag k="from:sr-Latn" v="Borča 3"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00095"/>
+    <tag k="gtfs:shape_id" v="00095_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="708508"/>
+    <tag k="interval" v="06:00"/>
+    <tag k="name" v="95: Борча 3 =&gt; Блок 45"/>
+    <tag k="name:sr-Latn" v="95: Borča 3 =&gt; Blok 45"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="95"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Блок 45"/>
+    <tag k="to:sr-Latn" v="Blok 45"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2667741" version="142" timestamp="2021-03-08T12:05:53Z" changeset="100636051" uid="212196" user="BrackoNe">
+    <member type="node" ref="8301445151" role="platform_entry_only"/>
+    <member type="node" ref="4663729034" role="platform"/>
+    <member type="node" ref="4663729035" role="platform"/>
+    <member type="node" ref="4663729038" role="platform"/>
+    <member type="node" ref="1618592187" role="platform"/>
+    <member type="node" ref="1119942190" role="platform"/>
+    <member type="node" ref="2148659246" role="platform"/>
+    <member type="node" ref="2059750330" role="platform"/>
+    <member type="node" ref="5116045641" role="platform"/>
+    <member type="node" ref="1858130486" role="platform"/>
+    <member type="node" ref="462529782" role="platform"/>
+    <member type="node" ref="5116005559" role="platform"/>
+    <member type="node" ref="5119930331" role="platform"/>
+    <member type="node" ref="2059750503" role="platform"/>
+    <member type="node" ref="1790354844" role="platform"/>
+    <member type="node" ref="2059750403" role="platform"/>
+    <member type="node" ref="5119930330" role="platform"/>
+    <member type="node" ref="5116005575" role="platform"/>
+    <member type="node" ref="4715454008" role="platform"/>
+    <member type="node" ref="2005216686" role="platform"/>
+    <member type="node" ref="2005216082" role="platform"/>
+    <member type="node" ref="2005216620" role="platform"/>
+    <member type="node" ref="2005216013" role="platform"/>
+    <member type="node" ref="5116005577" role="platform"/>
+    <member type="node" ref="2435556221" role="platform"/>
+    <member type="node" ref="4676666111" role="platform"/>
+    <member type="node" ref="4676666114" role="platform"/>
+    <member type="node" ref="4676666115" role="platform"/>
+    <member type="node" ref="4676684019" role="platform"/>
+    <member type="node" ref="4676684021" role="platform_exit_only"/>
+    <member type="way" ref="893184453" role=""/>
+    <member type="way" ref="893184452" role=""/>
+    <member type="way" ref="198723963" role=""/>
+    <member type="way" ref="195576428" role=""/>
+    <member type="way" ref="487184930" role=""/>
+    <member type="way" ref="195576430" role=""/>
+    <member type="way" ref="525997333" role=""/>
+    <member type="way" ref="676130931" role=""/>
+    <member type="way" ref="676130922" role=""/>
+    <member type="way" ref="23115335" role=""/>
+    <member type="way" ref="804412431" role=""/>
+    <member type="way" ref="676130923" role=""/>
+    <member type="way" ref="676323759" role=""/>
+    <member type="way" ref="478296729" role=""/>
+    <member type="way" ref="676318990" role=""/>
+    <member type="way" ref="676318995" role=""/>
+    <member type="way" ref="676318999" role=""/>
+    <member type="way" ref="676319004" role=""/>
+    <member type="way" ref="23115305" role=""/>
+    <member type="way" ref="676621711" role=""/>
+    <member type="way" ref="478296731" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="23115219" role=""/>
+    <member type="way" ref="694060036" role=""/>
+    <member type="way" ref="619005693" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="23078542" role=""/>
+    <member type="way" ref="768501209" role=""/>
+    <member type="way" ref="122976429" role=""/>
+    <member type="way" ref="150899570" role=""/>
+    <member type="way" ref="195576480" role=""/>
+    <member type="way" ref="676671124" role=""/>
+    <member type="way" ref="676671123" role=""/>
+    <member type="way" ref="150899586" role=""/>
+    <member type="way" ref="196715565" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="24282347" role=""/>
+    <member type="way" ref="22762705" role=""/>
+    <member type="way" ref="676097202" role=""/>
+    <member type="way" ref="23893460" role=""/>
+    <member type="way" ref="41234382" role=""/>
+    <member type="way" ref="198723955" role=""/>
+    <member type="way" ref="41234376" role=""/>
+    <member type="way" ref="677728908" role=""/>
+    <member type="way" ref="871350131" role=""/>
+    <member type="way" ref="895734447" role=""/>
+    <member type="way" ref="677728907" role=""/>
+    <member type="way" ref="677908729" role=""/>
+    <member type="way" ref="677908727" role=""/>
+    <member type="way" ref="179926017" role=""/>
+    <member type="way" ref="680218901" role=""/>
+    <member type="way" ref="255071891" role=""/>
+    <member type="way" ref="299215329" role=""/>
+    <member type="way" ref="255071888" role=""/>
+    <member type="way" ref="519104329" role=""/>
+    <member type="way" ref="914681003" role=""/>
+    <member type="way" ref="41171338" role=""/>
+    <member type="way" ref="41171339" role=""/>
+    <member type="way" ref="914681002" role=""/>
+    <member type="way" ref="519095964" role=""/>
+    <member type="way" ref="518899497" role=""/>
+    <member type="way" ref="577591594" role=""/>
+    <member type="way" ref="725380092" role=""/>
+    <member type="way" ref="255075865" role=""/>
+    <member type="way" ref="518911054" role=""/>
+    <member type="way" ref="519110526" role=""/>
+    <member type="way" ref="830057382" role=""/>
+    <member type="way" ref="676846414" role=""/>
+    <member type="way" ref="519358222" role=""/>
+    <member type="way" ref="519179021" role=""/>
+    <member type="way" ref="196715593" role=""/>
+    <member type="way" ref="676828559" role=""/>
+    <member type="way" ref="31799862" role=""/>
+    <member type="way" ref="473589574" role=""/>
+    <member type="way" ref="702642455" role=""/>
+    <member type="way" ref="702642456" role=""/>
+    <member type="way" ref="703835091" role=""/>
+    <member type="way" ref="702643025" role=""/>
+    <member type="way" ref="702643109" role=""/>
+    <member type="way" ref="390451882" role=""/>
+    <member type="way" ref="677918495" role=""/>
+    <member type="way" ref="677918496" role=""/>
+    <member type="way" ref="702643985" role=""/>
+    <member type="way" ref="677918494" role=""/>
+    <member type="way" ref="677918493" role=""/>
+    <member type="way" ref="677918492" role=""/>
+    <member type="way" ref="196715591" role=""/>
+    <member type="way" ref="677918491" role=""/>
+    <member type="way" ref="677918490" role=""/>
+    <member type="way" ref="526004436" role=""/>
+    <member type="way" ref="196715590" role=""/>
+    <member type="way" ref="196715592" role=""/>
+    <member type="way" ref="9478792" role=""/>
+    <member type="way" ref="677918489" role=""/>
+    <member type="way" ref="677754236" role=""/>
+    <member type="way" ref="677754235" role=""/>
+    <member type="way" ref="526006102" role=""/>
+    <member type="way" ref="382014461" role=""/>
+    <member type="way" ref="381706295" role=""/>
+    <member type="way" ref="679579940" role=""/>
+    <member type="way" ref="196715513" role=""/>
+    <member type="way" ref="677971178" role=""/>
+    <member type="way" ref="677971181" role=""/>
+    <member type="way" ref="677971175" role=""/>
+    <member type="way" ref="525991725" role=""/>
+    <member type="way" ref="677745986" role=""/>
+    <member type="way" ref="199744318" role=""/>
+    <member type="way" ref="248050151" role=""/>
+    <member type="way" ref="196715534" role=""/>
+    <member type="way" ref="196715536" role=""/>
+    <member type="way" ref="677726828" role=""/>
+    <member type="way" ref="677898183" role=""/>
+    <member type="way" ref="29051245" role=""/>
+    <member type="way" ref="34172557" role=""/>
+    <member type="way" ref="678206946" role=""/>
+    <member type="way" ref="678206948" role=""/>
+    <member type="way" ref="678206947" role=""/>
+    <member type="way" ref="196715562" role=""/>
+    <member type="way" ref="365395481" role=""/>
+    <member type="way" ref="196715588" role=""/>
+    <member type="way" ref="286535159" role=""/>
+    <member type="way" ref="871177932" role=""/>
+    <member type="way" ref="871177930" role=""/>
+    <member type="way" ref="677753630" role=""/>
+    <member type="way" ref="677753629" role=""/>
+    <member type="way" ref="286535172" role=""/>
+    <member type="way" ref="677753628" role=""/>
+    <member type="way" ref="677753627" role=""/>
+    <member type="way" ref="293034099" role=""/>
+    <member type="way" ref="198644168" role=""/>
+    <member type="way" ref="198644169" role=""/>
+    <member type="way" ref="286064598" role=""/>
+    <member type="way" ref="114589522" role=""/>
+    <member type="way" ref="114589520" role=""/>
+    <member type="way" ref="30648232" role=""/>
+    <member type="way" ref="196715589" role=""/>
+    <member type="way" ref="198644154" role=""/>
+    <member type="way" ref="406444385" role=""/>
+    <member type="way" ref="679885671" role=""/>
+    <member type="way" ref="287441514" role=""/>
+    <member type="way" ref="677941167" role=""/>
+    <member type="way" ref="198724020" role=""/>
+    <member type="way" ref="677948107" role=""/>
+    <member type="way" ref="28908269" role=""/>
+    <member type="way" ref="677695138" role=""/>
+    <member type="way" ref="677695135" role=""/>
+    <member type="way" ref="677695136" role=""/>
+    <member type="way" ref="198644165" role=""/>
+    <member type="way" ref="198644166" role=""/>
+    <member type="way" ref="712345899" role=""/>
+    <member type="way" ref="198644149" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="64:00"/>
+    <tag k="from" v="ЖС Панчевачки мост"/>
+    <tag k="from:sr-Latn" v="ŽS Pančevački most"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00037"/>
+    <tag k="gtfs:shape_id" v="00037_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="685531"/>
+    <tag k="interval" v="07:00"/>
+    <tag k="name" v="37: ЖС Панчевачки мост =&gt; Кнежевац"/>
+    <tag k="name:sr-Latn" v="37: ŽS Pančevački most =&gt; Kneževac"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="37"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Кнежевац"/>
+    <tag k="to:sr-Latn" v="Kneževac"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2667742" version="162" timestamp="2021-03-16T17:27:55Z" changeset="101136058" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="4676684021" role="platform_entry_only"/>
+    <member type="node" ref="4676684020" role="platform"/>
+    <member type="node" ref="4676666116" role="platform"/>
+    <member type="node" ref="4676666113" role="platform"/>
+    <member type="node" ref="4676666112" role="platform"/>
+    <member type="node" ref="2059750439" role="platform"/>
+    <member type="node" ref="4757774776" role="platform"/>
+    <member type="node" ref="392013505" role="platform"/>
+    <member type="node" ref="2005216393" role="platform"/>
+    <member type="node" ref="2005216280" role="platform"/>
+    <member type="node" ref="2005216477" role="platform"/>
+    <member type="node" ref="3848689721" role="platform"/>
+    <member type="node" ref="5119930329" role="platform"/>
+    <member type="node" ref="2059750409" role="platform"/>
+    <member type="node" ref="2059750352" role="platform"/>
+    <member type="node" ref="2059750504" role="platform"/>
+    <member type="node" ref="2059750393" role="platform"/>
+    <member type="node" ref="2059750326" role="platform"/>
+    <member type="node" ref="6593166765" role="platform"/>
+    <member type="node" ref="8149703056" role="platform"/>
+    <member type="node" ref="2077480548" role="platform"/>
+    <member type="node" ref="2059750485" role="platform"/>
+    <member type="node" ref="2059750422" role="platform"/>
+    <member type="node" ref="5116045644" role="platform"/>
+    <member type="node" ref="2059750331" role="platform"/>
+    <member type="node" ref="2059750410" role="platform"/>
+    <member type="node" ref="4663473498" role="platform"/>
+    <member type="node" ref="4359064380" role="platform"/>
+    <member type="node" ref="4658230790" role="platform"/>
+    <member type="node" ref="4663729037" role="platform"/>
+    <member type="node" ref="4663729036" role="platform"/>
+    <member type="node" ref="3851652389" role="platform"/>
+    <member type="node" ref="3851616096" role="platform_exit_only"/>
+    <member type="way" ref="198644149" role=""/>
+    <member type="way" ref="712345899" role=""/>
+    <member type="way" ref="198644166" role=""/>
+    <member type="way" ref="198644165" role=""/>
+    <member type="way" ref="677695136" role=""/>
+    <member type="way" ref="677695135" role=""/>
+    <member type="way" ref="677695138" role=""/>
+    <member type="way" ref="196715582" role=""/>
+    <member type="way" ref="395713826" role=""/>
+    <member type="way" ref="381175297" role=""/>
+    <member type="way" ref="677948107" role=""/>
+    <member type="way" ref="198724020" role=""/>
+    <member type="way" ref="677941167" role=""/>
+    <member type="way" ref="287441514" role=""/>
+    <member type="way" ref="679885671" role=""/>
+    <member type="way" ref="406444385" role=""/>
+    <member type="way" ref="198644154" role=""/>
+    <member type="way" ref="196715526" role=""/>
+    <member type="way" ref="198644152" role=""/>
+    <member type="way" ref="30648272" role=""/>
+    <member type="way" ref="194877087" role=""/>
+    <member type="way" ref="114589520" role=""/>
+    <member type="way" ref="114589522" role=""/>
+    <member type="way" ref="286064598" role=""/>
+    <member type="way" ref="198644169" role=""/>
+    <member type="way" ref="198644168" role=""/>
+    <member type="way" ref="293034099" role=""/>
+    <member type="way" ref="677753627" role=""/>
+    <member type="way" ref="677753628" role=""/>
+    <member type="way" ref="286535172" role=""/>
+    <member type="way" ref="677753629" role=""/>
+    <member type="way" ref="677753630" role=""/>
+    <member type="way" ref="871177930" role=""/>
+    <member type="way" ref="871177932" role=""/>
+    <member type="way" ref="286535159" role=""/>
+    <member type="way" ref="196715588" role=""/>
+    <member type="way" ref="365395481" role=""/>
+    <member type="way" ref="196715562" role=""/>
+    <member type="way" ref="678206947" role=""/>
+    <member type="way" ref="678206948" role=""/>
+    <member type="way" ref="678206946" role=""/>
+    <member type="way" ref="34172557" role=""/>
+    <member type="way" ref="29051245" role=""/>
+    <member type="way" ref="677898183" role=""/>
+    <member type="way" ref="677726828" role=""/>
+    <member type="way" ref="196715536" role=""/>
+    <member type="way" ref="196715534" role=""/>
+    <member type="way" ref="248050151" role=""/>
+    <member type="way" ref="199744318" role=""/>
+    <member type="way" ref="677745986" role=""/>
+    <member type="way" ref="525991724" role=""/>
+    <member type="way" ref="525991723" role=""/>
+    <member type="way" ref="196715517" role=""/>
+    <member type="way" ref="677754238" role=""/>
+    <member type="way" ref="196715523" role=""/>
+    <member type="way" ref="196715524" role=""/>
+    <member type="way" ref="31804425" role=""/>
+    <member type="way" ref="196715592" role=""/>
+    <member type="way" ref="196715590" role=""/>
+    <member type="way" ref="526004436" role=""/>
+    <member type="way" ref="677918490" role=""/>
+    <member type="way" ref="677918491" role=""/>
+    <member type="way" ref="196715591" role=""/>
+    <member type="way" ref="677918492" role=""/>
+    <member type="way" ref="677918493" role=""/>
+    <member type="way" ref="677918494" role=""/>
+    <member type="way" ref="702643985" role=""/>
+    <member type="way" ref="677918496" role=""/>
+    <member type="way" ref="677918495" role=""/>
+    <member type="way" ref="390451882" role=""/>
+    <member type="way" ref="702643109" role=""/>
+    <member type="way" ref="702643025" role=""/>
+    <member type="way" ref="703835091" role=""/>
+    <member type="way" ref="702642456" role=""/>
+    <member type="way" ref="702642455" role=""/>
+    <member type="way" ref="473589574" role=""/>
+    <member type="way" ref="512275836" role=""/>
+    <member type="way" ref="365353304" role=""/>
+    <member type="way" ref="725274093" role=""/>
+    <member type="way" ref="677753067" role=""/>
+    <member type="way" ref="725274094" role=""/>
+    <member type="way" ref="725274095" role=""/>
+    <member type="way" ref="678736470" role=""/>
+    <member type="way" ref="725274092" role=""/>
+    <member type="way" ref="678736471" role=""/>
+    <member type="way" ref="678736469" role=""/>
+    <member type="way" ref="678736468" role=""/>
+    <member type="way" ref="678736466" role=""/>
+    <member type="way" ref="725274089" role=""/>
+    <member type="way" ref="38909275" role=""/>
+    <member type="way" ref="725274091" role=""/>
+    <member type="way" ref="678736465" role=""/>
+    <member type="way" ref="830466528" role=""/>
+    <member type="way" ref="31799780" role=""/>
+    <member type="way" ref="677925756" role=""/>
+    <member type="way" ref="692594453" role=""/>
+    <member type="way" ref="195551211" role=""/>
+    <member type="way" ref="677925755" role=""/>
+    <member type="way" ref="845427686" role=""/>
+    <member type="way" ref="36950716" role=""/>
+    <member type="way" ref="477929225" role=""/>
+    <member type="way" ref="195551203" role=""/>
+    <member type="way" ref="473641226" role=""/>
+    <member type="way" ref="917939159" role=""/>
+    <member type="way" ref="41171348" role=""/>
+    <member type="way" ref="593948562" role=""/>
+    <member type="way" ref="895174662" role=""/>
+    <member type="way" ref="41171349" role=""/>
+    <member type="way" ref="835225082" role=""/>
+    <member type="way" ref="677908731" role=""/>
+    <member type="way" ref="834023366" role=""/>
+    <member type="way" ref="677740989" role=""/>
+    <member type="way" ref="437072200" role=""/>
+    <member type="way" ref="834023365" role=""/>
+    <member type="way" ref="681396491" role=""/>
+    <member type="way" ref="677911257" role=""/>
+    <member type="way" ref="677912884" role=""/>
+    <member type="way" ref="23893355" role=""/>
+    <member type="way" ref="677912881" role=""/>
+    <member type="way" ref="677912886" role=""/>
+    <member type="way" ref="198723956" role=""/>
+    <member type="way" ref="23893387" role=""/>
+    <member type="way" ref="38922658" role=""/>
+    <member type="way" ref="41234379" role=""/>
+    <member type="way" ref="65399798" role=""/>
+    <member type="way" ref="200366255" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="472134922" role=""/>
+    <member type="way" ref="289953743" role=""/>
+    <member type="way" ref="289953739" role=""/>
+    <member type="way" ref="289953742" role=""/>
+    <member type="way" ref="472134926" role=""/>
+    <member type="way" ref="169037914" role=""/>
+    <member type="way" ref="768510156" role=""/>
+    <member type="way" ref="23078558" role=""/>
+    <member type="way" ref="676663793" role=""/>
+    <member type="way" ref="23098071" role=""/>
+    <member type="way" ref="230065295" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="684356845" role=""/>
+    <member type="way" ref="619005684" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="686663563" role=""/>
+    <member type="way" ref="476367774" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="82204229" role=""/>
+    <member type="way" ref="676318987" role=""/>
+    <member type="way" ref="676319004" role=""/>
+    <member type="way" ref="676318999" role=""/>
+    <member type="way" ref="676318995" role=""/>
+    <member type="way" ref="676318990" role=""/>
+    <member type="way" ref="478296729" role=""/>
+    <member type="way" ref="676323759" role=""/>
+    <member type="way" ref="676323760" role=""/>
+    <member type="way" ref="676323756" role=""/>
+    <member type="way" ref="676323757" role=""/>
+    <member type="way" ref="676130933" role=""/>
+    <member type="way" ref="676130929" role=""/>
+    <member type="way" ref="676130927" role=""/>
+    <member type="way" ref="23115346" role=""/>
+    <member type="way" ref="676130931" role=""/>
+    <member type="way" ref="525997333" role=""/>
+    <member type="way" ref="195576430" role=""/>
+    <member type="way" ref="487184930" role=""/>
+    <member type="way" ref="195576428" role=""/>
+    <member type="way" ref="198723963" role=""/>
+    <member type="way" ref="893184452" role=""/>
+    <member type="way" ref="195576431" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="71:00"/>
+    <tag k="from" v="Кнежевац"/>
+    <tag k="from:sr-Latn" v="Kneževac"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00037"/>
+    <tag k="gtfs:shape_id" v="00037_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="688378"/>
+    <tag k="interval" v="07:00"/>
+    <tag k="name" v="37: Кнежевац =&gt; ЖС Панчевачки мост"/>
+    <tag k="name:sr-Latn" v="37: Kneževac =&gt; ŽS Pančevački most"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="37"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="ЖС Панчевачки мост"/>
+    <tag k="to:sr-Latn" v="ŽS Pančevački most"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2668874" version="88" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="3851652387" role="platform_entry_only"/>
+    <member type="node" ref="3851652389" role="platform"/>
+    <member type="node" ref="4663473496" role="platform"/>
+    <member type="node" ref="4663473494" role="platform"/>
+    <member type="node" ref="2279432873" role="platform"/>
+    <member type="node" ref="4663473493" role="platform"/>
+    <member type="node" ref="4663473491" role="platform"/>
+    <member type="node" ref="8151261237" role="platform"/>
+    <member type="node" ref="4663473488" role="platform"/>
+    <member type="node" ref="4663473486" role="platform"/>
+    <member type="node" ref="1618592187" role="platform"/>
+    <member type="node" ref="1119942190" role="platform"/>
+    <member type="node" ref="2148659246" role="platform"/>
+    <member type="node" ref="2059750330" role="platform"/>
+    <member type="node" ref="5116045641" role="platform"/>
+    <member type="node" ref="4663473500" role="platform"/>
+    <member type="node" ref="4663473501" role="platform"/>
+    <member type="node" ref="4663473503" role="platform"/>
+    <member type="node" ref="4663473505" role="platform"/>
+    <member type="node" ref="4663473507" role="platform"/>
+    <member type="node" ref="4663473511" role="platform_exit_only"/>
+    <member type="way" ref="472147025" role=""/>
+    <member type="way" ref="23115358" role=""/>
+    <member type="way" ref="23115354" role=""/>
+    <member type="way" ref="195576428" role=""/>
+    <member type="way" ref="574867480" role=""/>
+    <member type="way" ref="574867481" role=""/>
+    <member type="way" ref="444460184" role=""/>
+    <member type="way" ref="39366488" role=""/>
+    <member type="way" ref="539433084" role=""/>
+    <member type="way" ref="444460185" role=""/>
+    <member type="way" ref="198724005" role=""/>
+    <member type="way" ref="23897473" role=""/>
+    <member type="way" ref="23897473" role=""/>
+    <member type="way" ref="38959332" role=""/>
+    <member type="way" ref="23708865" role=""/>
+    <member type="way" ref="39550777" role=""/>
+    <member type="way" ref="526069317" role=""/>
+    <member type="way" ref="692737534" role=""/>
+    <member type="way" ref="884441779" role=""/>
+    <member type="way" ref="39550777" role=""/>
+    <member type="way" ref="526069316" role=""/>
+    <member type="way" ref="38963881" role=""/>
+    <member type="way" ref="82204228" role=""/>
+    <member type="way" ref="676621711" role=""/>
+    <member type="way" ref="478296731" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="23115219" role=""/>
+    <member type="way" ref="694060036" role=""/>
+    <member type="way" ref="619005693" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="23078542" role=""/>
+    <member type="way" ref="768501209" role=""/>
+    <member type="way" ref="122976429" role=""/>
+    <member type="way" ref="150899570" role=""/>
+    <member type="way" ref="195576480" role=""/>
+    <member type="way" ref="676671124" role=""/>
+    <member type="way" ref="676671123" role=""/>
+    <member type="way" ref="150899586" role=""/>
+    <member type="way" ref="196715565" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="24282347" role=""/>
+    <member type="way" ref="65399757" role=""/>
+    <member type="way" ref="200366254" role=""/>
+    <member type="way" ref="200366253" role=""/>
+    <member type="way" ref="36930474" role=""/>
+    <member type="way" ref="478250195" role=""/>
+    <member type="way" ref="684411205" role=""/>
+    <member type="way" ref="679504537" role=""/>
+    <member type="way" ref="63204846" role=""/>
+    <member type="way" ref="751312468" role=""/>
+    <member type="way" ref="669592049" role=""/>
+    <member type="way" ref="669592048" role=""/>
+    <member type="way" ref="678459690" role=""/>
+    <member type="way" ref="678459689" role=""/>
+    <member type="way" ref="23291920" role=""/>
+    <member type="way" ref="23291775" role=""/>
+    <member type="way" ref="23291788" role=""/>
+    <member type="way" ref="472116304" role=""/>
+    <member type="way" ref="884441778" role=""/>
+    <member type="way" ref="472116305" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="39:00"/>
+    <tag k="from" v="Жел. Ст. Дунав - Окретница"/>
+    <tag k="from:sr-Latn" v="Жел. Ст. Дунав - Окретница"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00044"/>
+    <tag k="gtfs:shape_id" v="00044_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="687916"/>
+    <tag k="interval" v="20:00"/>
+    <tag k="name" v="44: Жел. Ст. Дунав - Окретница =&gt; Топчидерско Брдо /Сењак/"/>
+    <tag k="name:sr-Latn" v="44: Žel. St. Dunav - Okretnica =&gt; Topčidersko Brdo /Senjak/"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="44"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Топчидерско Брдо /Сењак/"/>
+    <tag k="to:sr-Latn" v="Topčidersko Brdo /Senjak/"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2668875" version="91" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="4663473511" role="platform_entry_only"/>
+    <member type="node" ref="4663473506" role="platform"/>
+    <member type="node" ref="4663473504" role="platform"/>
+    <member type="node" ref="4663473502" role="platform"/>
+    <member type="node" ref="4663473499" role="platform"/>
+    <member type="node" ref="5116045644" role="platform"/>
+    <member type="node" ref="2059750331" role="platform"/>
+    <member type="node" ref="2059750410" role="platform"/>
+    <member type="node" ref="4663473498" role="platform"/>
+    <member type="node" ref="4359064380" role="platform"/>
+    <member type="node" ref="4658230790" role="platform"/>
+    <member type="node" ref="4663473487" role="platform"/>
+    <member type="node" ref="4663473489" role="platform"/>
+    <member type="node" ref="8151261237" role="platform"/>
+    <member type="node" ref="4663473492" role="platform"/>
+    <member type="node" ref="2279432873" role="platform"/>
+    <member type="node" ref="4663473495" role="platform"/>
+    <member type="node" ref="4663473497" role="platform"/>
+    <member type="node" ref="3851652387" role="platform_exit_only"/>
+    <member type="way" ref="307386108" role=""/>
+    <member type="way" ref="472116306" role=""/>
+    <member type="way" ref="472116304" role=""/>
+    <member type="way" ref="23291788" role=""/>
+    <member type="way" ref="472116296" role=""/>
+    <member type="way" ref="23291920" role=""/>
+    <member type="way" ref="678459689" role=""/>
+    <member type="way" ref="678459690" role=""/>
+    <member type="way" ref="669592048" role=""/>
+    <member type="way" ref="658402357" role=""/>
+    <member type="way" ref="678281930" role=""/>
+    <member type="way" ref="286363253" role=""/>
+    <member type="way" ref="63204848" role=""/>
+    <member type="way" ref="684411202" role=""/>
+    <member type="way" ref="24282340" role=""/>
+    <member type="way" ref="65399798" role=""/>
+    <member type="way" ref="200366255" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="472134922" role=""/>
+    <member type="way" ref="289953743" role=""/>
+    <member type="way" ref="289953739" role=""/>
+    <member type="way" ref="289953742" role=""/>
+    <member type="way" ref="472134926" role=""/>
+    <member type="way" ref="169037914" role=""/>
+    <member type="way" ref="768510156" role=""/>
+    <member type="way" ref="23078558" role=""/>
+    <member type="way" ref="676663793" role=""/>
+    <member type="way" ref="23098071" role=""/>
+    <member type="way" ref="230065295" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="684356845" role=""/>
+    <member type="way" ref="619005684" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="686663563" role=""/>
+    <member type="way" ref="476367774" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="82204229" role=""/>
+    <member type="way" ref="676318987" role=""/>
+    <member type="way" ref="478296730" role=""/>
+    <member type="way" ref="38963881" role=""/>
+    <member type="way" ref="526069316" role=""/>
+    <member type="way" ref="39550777" role=""/>
+    <member type="way" ref="884441779" role=""/>
+    <member type="way" ref="692737534" role=""/>
+    <member type="way" ref="526069317" role=""/>
+    <member type="way" ref="39550777" role=""/>
+    <member type="way" ref="23708865" role=""/>
+    <member type="way" ref="38959332" role=""/>
+    <member type="way" ref="23897473" role=""/>
+    <member type="way" ref="23897473" role=""/>
+    <member type="way" ref="198724005" role=""/>
+    <member type="way" ref="444460185" role=""/>
+    <member type="way" ref="539433084" role=""/>
+    <member type="way" ref="39366488" role=""/>
+    <member type="way" ref="444460184" role=""/>
+    <member type="way" ref="574867481" role=""/>
+    <member type="way" ref="574867480" role=""/>
+    <member type="way" ref="195576428" role=""/>
+    <member type="way" ref="487184930" role=""/>
+    <member type="way" ref="195576430" role=""/>
+    <member type="way" ref="195576433" role=""/>
+    <member type="way" ref="487184929" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="41:00"/>
+    <tag k="from" v="Топчидерско Брдо /Сењак/"/>
+    <tag k="from:sr-Latn" v="Topčidersko Brdo /Senjak/"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00044"/>
+    <tag k="gtfs:shape_id" v="00044_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="689343"/>
+    <tag k="interval" v="20:00"/>
+    <tag k="name" v="44: Топчидерско Брдо /Сењак/ =&gt; Жел. Ст. Дунав - Окретница"/>
+    <tag k="name:sr-Latn" v="44: Topčidersko Brdo /Senjak/ =&gt; Žel. St. Dunav - Okretnica"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="44"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Жел. Ст. Дунав - Окретница"/>
+    <tag k="to:sr-Latn" v="Žel. St. Dunav - Okretnica"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="2764744" version="426" timestamp="2021-03-20T21:15:48Z" changeset="101418279" uid="10993864" user="MapperNews">
+    <member type="node" ref="5444520840" role=""/>
+    <member type="node" ref="6707697191" role="guidepost"/>
+    <member type="node" ref="6707697190" role="guidepost"/>
+    <member type="node" ref="7295308073" role="guidepost"/>
+    <member type="node" ref="7295308072" role="guidepost"/>
+    <member type="node" ref="7295308071" role="guidepost"/>
+    <member type="node" ref="7295308070" role="guidepost"/>
+    <member type="way" ref="680503821" role=""/>
+    <member type="way" ref="482726361" role=""/>
+    <member type="way" ref="8848532" role=""/>
+    <member type="way" ref="209086490" role=""/>
+    <member type="way" ref="482686071" role=""/>
+    <member type="way" ref="8686569" role=""/>
+    <member type="way" ref="8617076" role=""/>
+    <member type="way" ref="713405475" role=""/>
+    <member type="way" ref="411076265" role=""/>
+    <member type="way" ref="25179414" role=""/>
+    <member type="way" ref="25309213" role=""/>
+    <member type="way" ref="272562515" role=""/>
+    <member type="way" ref="25309556" role=""/>
+    <member type="way" ref="676926282" role=""/>
+    <member type="way" ref="679873933" role=""/>
+    <member type="way" ref="679873935" role=""/>
+    <member type="way" ref="679873932" role=""/>
+    <member type="way" ref="472091322" role=""/>
+    <member type="way" ref="679901092" role=""/>
+    <member type="way" ref="679901093" role=""/>
+    <member type="way" ref="474805530" role=""/>
+    <member type="way" ref="473641211" role=""/>
+    <member type="way" ref="473641208" role=""/>
+    <member type="way" ref="679901095" role=""/>
+    <member type="way" ref="354344705" role=""/>
+    <member type="way" ref="195144204" role=""/>
+    <member type="way" ref="676612173" role=""/>
+    <member type="way" ref="500406653" role=""/>
+    <member type="way" ref="725395844" role=""/>
+    <member type="way" ref="676612169" role=""/>
+    <member type="way" ref="676612177" role=""/>
+    <member type="way" ref="209086498" role=""/>
+    <member type="way" ref="500523371" role=""/>
+    <member type="way" ref="37859009" role=""/>
+    <member type="way" ref="679901118" role=""/>
+    <member type="way" ref="676918454" role=""/>
+    <member type="way" ref="144714967" role=""/>
+    <member type="way" ref="676662076" role=""/>
+    <member type="way" ref="679901109" role=""/>
+    <member type="way" ref="475269102" role=""/>
+    <member type="way" ref="676848681" role=""/>
+    <member type="way" ref="676848682" role=""/>
+    <member type="way" ref="676848680" role=""/>
+    <member type="way" ref="875103743" role=""/>
+    <member type="way" ref="875103742" role=""/>
+    <member type="way" ref="475307931" role=""/>
+    <member type="way" ref="677099880" role=""/>
+    <member type="way" ref="677099881" role=""/>
+    <member type="way" ref="676869561" role=""/>
+    <member type="way" ref="681281119" role=""/>
+    <member type="way" ref="676869562" role=""/>
+    <member type="way" ref="676869560" role=""/>
+    <member type="way" ref="479019391" role=""/>
+    <member type="way" ref="209086486" role=""/>
+    <member type="way" ref="894908303" role=""/>
+    <member type="way" ref="479019390" role=""/>
+    <member type="way" ref="681282572" role=""/>
+    <member type="way" ref="681403881" role=""/>
+    <member type="way" ref="475307928" role=""/>
+    <member type="way" ref="676869556" role=""/>
+    <member type="way" ref="676869559" role=""/>
+    <member type="way" ref="681403880" role=""/>
+    <member type="way" ref="681405083" role=""/>
+    <member type="way" ref="677099878" role=""/>
+    <member type="way" ref="226682238" role=""/>
+    <member type="way" ref="338968254" role=""/>
+    <member type="way" ref="444473879" role=""/>
+    <member type="way" ref="330469053" role=""/>
+    <member type="way" ref="25208265" role=""/>
+    <member type="way" ref="446529622" role=""/>
+    <member type="way" ref="336621156" role="forward"/>
+    <member type="way" ref="743262258" role="forward"/>
+    <member type="way" ref="743262257" role="forward"/>
+    <member type="way" ref="574867495" role="forward"/>
+    <member type="way" ref="221130492" role="forward"/>
+    <member type="way" ref="775206140" role="forward"/>
+    <member type="way" ref="743262254" role="forward"/>
+    <member type="way" ref="743262253" role="forward"/>
+    <member type="way" ref="221130493" role=""/>
+    <member type="way" ref="655040930" role=""/>
+    <member type="way" ref="28418444" role=""/>
+    <member type="way" ref="532457689" role=""/>
+    <member type="way" ref="42303504" role=""/>
+    <member type="way" ref="532458434" role=""/>
+    <member type="way" ref="38763971" role=""/>
+    <member type="way" ref="87308622" role=""/>
+    <member type="way" ref="532458618" role=""/>
+    <member type="way" ref="87308634" role=""/>
+    <member type="way" ref="713955163" role=""/>
+    <member type="way" ref="703106083" role=""/>
+    <member type="way" ref="232085609" role=""/>
+    <member type="way" ref="28418445" role=""/>
+    <member type="way" ref="703106082" role=""/>
+    <member type="way" ref="232085610" role=""/>
+    <member type="way" ref="545087152" role=""/>
+    <member type="way" ref="545087151" role=""/>
+    <member type="way" ref="232085636" role=""/>
+    <member type="way" ref="232087325" role=""/>
+    <member type="way" ref="232085481" role=""/>
+    <member type="way" ref="232085482" role=""/>
+    <member type="way" ref="232085480" role=""/>
+    <member type="way" ref="232085373" role=""/>
+    <member type="way" ref="232087322" role=""/>
+    <member type="way" ref="232080812" role=""/>
+    <member type="way" ref="28406063" role=""/>
+    <member type="way" ref="491209537" role=""/>
+    <member type="way" ref="491209538" role=""/>
+    <member type="way" ref="232119880" role=""/>
+    <member type="way" ref="490260682" role=""/>
+    <member type="way" ref="174075464" role=""/>
+    <member type="way" ref="174075442" role=""/>
+    <member type="way" ref="87414260" role=""/>
+    <member type="way" ref="87414306" role=""/>
+    <member type="way" ref="664074202" role=""/>
+    <member type="way" ref="100712667" role=""/>
+    <member type="way" ref="87414279" role=""/>
+    <member type="way" ref="664076835" role=""/>
+    <member type="way" ref="87414298" role=""/>
+    <member type="way" ref="664076833" role=""/>
+    <member type="way" ref="87414254" role=""/>
+    <member type="way" ref="664074200" role=""/>
+    <member type="way" ref="664095495" role=""/>
+    <member type="way" ref="232121213" role=""/>
+    <member type="way" ref="867660258" role=""/>
+    <member type="way" ref="661241028" role=""/>
+    <member type="way" ref="714687528" role=""/>
+    <member type="way" ref="389694178" role=""/>
+    <member type="way" ref="28417089" role=""/>
+    <member type="way" ref="134754395" role=""/>
+    <member type="way" ref="134754397" role=""/>
+    <member type="way" ref="134754396" role=""/>
+    <member type="way" ref="28415343" role=""/>
+    <member type="way" ref="119965789" role=""/>
+    <member type="way" ref="822257397" role=""/>
+    <member type="way" ref="822257396" role=""/>
+    <member type="way" ref="113341111" role=""/>
+    <member type="way" ref="113341116" role=""/>
+    <member type="way" ref="119965792" role=""/>
+    <member type="way" ref="113341110" role=""/>
+    <member type="way" ref="112824445" role=""/>
+    <member type="way" ref="112826065" role=""/>
+    <member type="way" ref="112826067" role=""/>
+    <member type="way" ref="885964087" role=""/>
+    <member type="way" ref="38811582" role=""/>
+    <member type="way" ref="885964093" role=""/>
+    <member type="way" ref="885964099" role=""/>
+    <member type="way" ref="885964102" role=""/>
+    <member type="way" ref="119968672" role=""/>
+    <member type="way" ref="38810669" role=""/>
+    <member type="way" ref="885974351" role=""/>
+    <member type="way" ref="797194475" role=""/>
+    <member type="way" ref="875187754" role=""/>
+    <member type="way" ref="174137045" role=""/>
+    <member type="way" ref="340680514" role=""/>
+    <member type="way" ref="174137035" role=""/>
+    <member type="way" ref="307047672" role=""/>
+    <member type="way" ref="307047676" role=""/>
+    <member type="way" ref="115413032" role=""/>
+    <member type="way" ref="39499257" role=""/>
+    <member type="way" ref="205970415" role=""/>
+    <member type="way" ref="712612828" role=""/>
+    <member type="way" ref="712612827" role=""/>
+    <member type="way" ref="712612829" role=""/>
+    <member type="way" ref="609819712" role=""/>
+    <member type="way" ref="609819713" role=""/>
+    <member type="way" ref="28420780" role=""/>
+    <member type="way" ref="425416066" role=""/>
+    <member type="way" ref="425416067" role=""/>
+    <member type="way" ref="84812059" role=""/>
+    <member type="way" ref="84811947" role=""/>
+    <member type="way" ref="144732907" role=""/>
+    <member type="way" ref="174137047" role=""/>
+    <member type="way" ref="174137055" role=""/>
+    <member type="way" ref="144732902" role=""/>
+    <member type="way" ref="174137054" role=""/>
+    <member type="way" ref="174137057" role=""/>
+    <member type="way" ref="174284540" role=""/>
+    <member type="way" ref="676407709" role=""/>
+    <member type="way" ref="676407710" role=""/>
+    <member type="way" ref="174284520" role=""/>
+    <member type="way" ref="692788883" role=""/>
+    <member type="way" ref="692788884" role=""/>
+    <member type="way" ref="174284541" role=""/>
+    <member type="way" ref="221143677" role=""/>
+    <member type="way" ref="221143671" role=""/>
+    <member type="way" ref="221140195" role=""/>
+    <member type="way" ref="221138846" role=""/>
+    <member type="way" ref="221138847" role=""/>
+    <member type="way" ref="221143668" role=""/>
+    <member type="way" ref="532689418" role=""/>
+    <member type="way" ref="119968671" role=""/>
+    <member type="way" ref="120244890" role=""/>
+    <member type="way" ref="120244889" role=""/>
+    <member type="way" ref="100696809" role=""/>
+    <member type="way" ref="680507268" role=""/>
+    <member type="way" ref="174319177" role=""/>
+    <member type="way" ref="174319150" role=""/>
+    <member type="way" ref="174319139" role=""/>
+    <member type="way" ref="120246875" role=""/>
+    <member type="way" ref="885103314" role=""/>
+    <member type="way" ref="80881735" role=""/>
+    <member type="way" ref="885103312" role=""/>
+    <member type="way" ref="814965496" role=""/>
+    <member type="way" ref="164677013" role=""/>
+    <member type="way" ref="885145669" role=""/>
+    <member type="way" ref="885145668" role=""/>
+    <member type="way" ref="885133524" role="forward"/>
+    <member type="way" ref="574867492" role="forward"/>
+    <member type="way" ref="738543900" role="forward"/>
+    <member type="way" ref="885133526" role="forward"/>
+    <member type="way" ref="738543902" role="forward"/>
+    <member type="way" ref="174319119" role="forward"/>
+    <member type="way" ref="174319235" role="forward"/>
+    <member type="way" ref="885145667" role="forward"/>
+    <member type="way" ref="885133525" role="forward"/>
+    <member type="way" ref="738543899" role=""/>
+    <member type="way" ref="738543898" role=""/>
+    <member type="way" ref="813164511" role=""/>
+    <member type="way" ref="813164512" role=""/>
+    <member type="way" ref="205975748" role=""/>
+    <member type="way" ref="738553160" role=""/>
+    <member type="way" ref="738553159" role=""/>
+    <member type="way" ref="738553157" role=""/>
+    <member type="way" ref="738553158" role=""/>
+    <member type="way" ref="738553156" role=""/>
+    <member type="way" ref="738543897" role=""/>
+    <member type="way" ref="738556069" role=""/>
+    <member type="way" ref="738556070" role=""/>
+    <member type="way" ref="791717627" role=""/>
+    <member type="way" ref="791717628" role=""/>
+    <member type="way" ref="78726214" role=""/>
+    <member type="way" ref="115416723" role=""/>
+    <member type="way" ref="641286947" role=""/>
+    <member type="way" ref="685860242" role=""/>
+    <member type="way" ref="115416708" role=""/>
+    <member type="way" ref="263194268" role=""/>
+    <member type="way" ref="115416717" role=""/>
+    <member type="way" ref="721588068" role=""/>
+    <member type="way" ref="721588067" role=""/>
+    <member type="way" ref="722581166" role=""/>
+    <member type="way" ref="115416730" role=""/>
+    <member type="way" ref="125051517" role=""/>
+    <member type="way" ref="574867491" role=""/>
+    <member type="way" ref="191151729" role=""/>
+    <member type="way" ref="574867490" role=""/>
+    <member type="way" ref="205977804" role=""/>
+    <member type="way" ref="174342800" role=""/>
+    <member type="way" ref="147776334" role=""/>
+    <member type="way" ref="144037617" role=""/>
+    <member type="way" ref="174342794" role=""/>
+    <member type="way" ref="147776402" role=""/>
+    <member type="way" ref="174342795" role=""/>
+    <member type="way" ref="144037614" role=""/>
+    <member type="way" ref="144037616" role=""/>
+    <member type="way" ref="93207387" role=""/>
+    <member type="way" ref="93207370" role=""/>
+    <member type="way" ref="107467713" role=""/>
+    <member type="way" ref="107381589" role=""/>
+    <member type="way" ref="107381596" role="forward"/>
+    <member type="way" ref="808855085" role="forward"/>
+    <member type="way" ref="725269684" role="forward"/>
+    <member type="way" ref="725269683" role="forward"/>
+    <member type="way" ref="263827317" role="forward"/>
+    <member type="way" ref="867760153" role="forward"/>
+    <member type="way" ref="867760152" role="forward"/>
+    <member type="way" ref="867763884" role="forward"/>
+    <member type="way" ref="75223339" role="forward"/>
+    <member type="way" ref="867763882" role="forward"/>
+    <member type="way" ref="808855084" role="forward"/>
+    <member type="way" ref="157066815" role="forward"/>
+    <member type="way" ref="107381585" role="forward"/>
+    <member type="way" ref="725416690" role="forward"/>
+    <member type="way" ref="725416689" role="forward"/>
+    <member type="way" ref="725769210" role="forward"/>
+    <member type="way" ref="725416688" role="forward"/>
+    <member type="way" ref="867764687" role="forward"/>
+    <member type="way" ref="107381595" role="forward"/>
+    <member type="way" ref="725416692" role="forward"/>
+    <member type="way" ref="725416691" role="forward"/>
+    <member type="way" ref="725769208" role="forward"/>
+    <member type="way" ref="725769209" role="forward"/>
+    <member type="way" ref="263827318" role="forward"/>
+    <member type="way" ref="725269675" role="forward"/>
+    <member type="way" ref="725269680" role="forward"/>
+    <member type="way" ref="871142842" role=""/>
+    <member type="way" ref="107381597" role=""/>
+    <member type="way" ref="252399089" role=""/>
+    <member type="way" ref="286986911" role=""/>
+    <member type="way" ref="637286511" role=""/>
+    <member type="way" ref="286986486" role=""/>
+    <member type="way" ref="116653527" role=""/>
+    <member type="way" ref="882323091" role=""/>
+    <member type="way" ref="116653516" role=""/>
+    <member type="way" ref="882323093" role=""/>
+    <member type="way" ref="355259841" role=""/>
+    <member type="way" ref="871150183" role=""/>
+    <member type="way" ref="108093343" role=""/>
+    <member type="way" ref="286940405" role=""/>
+    <member type="way" ref="265029689" role=""/>
+    <member type="way" ref="108093337" role=""/>
+    <member type="way" ref="286940415" role="forward"/>
+    <member type="way" ref="286940416" role="backward"/>
+    <member type="way" ref="879257758" role="backward"/>
+    <member type="way" ref="574867489" role="forward"/>
+    <member type="way" ref="286940413" role=""/>
+    <member type="way" ref="175227187" role=""/>
+    <member type="way" ref="771292091" role=""/>
+    <member type="way" ref="771292090" role=""/>
+    <member type="way" ref="741020036" role=""/>
+    <member type="way" ref="75223374" role=""/>
+    <member type="way" ref="152920734" role=""/>
+    <member type="way" ref="827328224" role=""/>
+    <member type="way" ref="697896112" role=""/>
+    <member type="way" ref="152920740" role=""/>
+    <member type="way" ref="152920741" role=""/>
+    <member type="way" ref="722337089" role=""/>
+    <member type="way" ref="722337090" role=""/>
+    <member type="way" ref="48345191" role=""/>
+    <member type="way" ref="32021051" role=""/>
+    <member type="way" ref="338705873" role=""/>
+    <member type="way" ref="175227211" role=""/>
+    <member type="way" ref="175227230" role=""/>
+    <member type="way" ref="48127063" role=""/>
+    <member type="way" ref="721608936" role=""/>
+    <member type="way" ref="721608937" role=""/>
+    <member type="way" ref="723184008" role=""/>
+    <member type="way" ref="721608934" role=""/>
+    <member type="way" ref="721608933" role=""/>
+    <member type="way" ref="721608932" role=""/>
+    <member type="way" ref="48127062" role=""/>
+    <member type="way" ref="675633914" role=""/>
+    <member type="way" ref="675633913" role=""/>
+    <member type="way" ref="338706587" role=""/>
+    <member type="way" ref="338706588" role=""/>
+    <member type="way" ref="737421554" role=""/>
+    <member type="way" ref="737421553" role=""/>
+    <member type="way" ref="737421555" role=""/>
+    <member type="way" ref="737424176" role=""/>
+    <member type="way" ref="737424174" role=""/>
+    <member type="way" ref="647010400" role=""/>
+    <member type="way" ref="73849002" role=""/>
+    <member type="way" ref="31991406" role=""/>
+    <member type="way" ref="73849003" role=""/>
+    <member type="way" ref="73849004" role=""/>
+    <member type="way" ref="72992433" role=""/>
+    <member type="way" ref="107948817" role=""/>
+    <member type="way" ref="23734774" role=""/>
+    <member type="way" ref="693435838" role=""/>
+    <member type="way" ref="107972070" role=""/>
+    <member type="way" ref="48707358" role=""/>
+    <member type="way" ref="107948818" role=""/>
+    <member type="way" ref="73012214" role=""/>
+    <member type="way" ref="73044007" role=""/>
+    <member type="way" ref="297179135" role=""/>
+    <member type="way" ref="297179135" role="forward"/>
+    <member type="way" ref="803684079" role="forward"/>
+    <member type="way" ref="175262551" role="forward"/>
+    <member type="way" ref="175262551" role=""/>
+    <member type="way" ref="803684079" role=""/>
+    <member type="way" ref="175262541" role=""/>
+    <member type="way" ref="175262555" role=""/>
+    <member type="way" ref="521152534" role="forward"/>
+    <member type="way" ref="723254657" role=""/>
+    <member type="way" ref="521152533" role="forward"/>
+    <member type="way" ref="722475968" role=""/>
+    <member type="way" ref="722475967" role=""/>
+    <member type="way" ref="520553269" role=""/>
+    <member type="way" ref="723254658" role=""/>
+    <member type="way" ref="521152537" role="forward"/>
+    <member type="way" ref="521152538" role="forward"/>
+    <member type="way" ref="175262542" role=""/>
+    <member type="way" ref="209086485" role=""/>
+    <member type="way" ref="179934184" role=""/>
+    <member type="way" ref="179934183" role=""/>
+    <member type="way" ref="179934182" role=""/>
+    <member type="way" ref="130344378" role=""/>
+    <member type="way" ref="37859010" role=""/>
+    <member type="way" ref="785527419" role=""/>
+    <member type="way" ref="478097541" role=""/>
+    <member type="way" ref="677099877" role=""/>
+    <member type="way" ref="681405085" role=""/>
+    <member type="way" ref="871110433" role=""/>
+    <member type="way" ref="96346719" role=""/>
+    <member type="way" ref="96346711" role=""/>
+    <member type="way" ref="518433862" role=""/>
+    <member type="way" ref="75215605" role=""/>
+    <member type="way" ref="775905728" role=""/>
+    <member type="way" ref="574867488" role=""/>
+    <member type="way" ref="23654051" role=""/>
+    <member type="way" ref="75214699" role=""/>
+    <member type="way" ref="75214641" role=""/>
+    <member type="way" ref="198825798" role=""/>
+    <member type="way" ref="198825799" role=""/>
+    <member type="way" ref="839009758" role=""/>
+    <member type="way" ref="839023716" role=""/>
+    <member type="way" ref="43942840" role=""/>
+    <member type="way" ref="75215110" role=""/>
+    <member type="way" ref="43942545" role=""/>
+    <member type="way" ref="241778107" role=""/>
+    <member type="way" ref="43942578" role=""/>
+    <member type="way" ref="205990055" role=""/>
+    <member type="way" ref="195576477" role=""/>
+    <member type="way" ref="195576478" role=""/>
+    <member type="way" ref="26833144" role=""/>
+    <member type="way" ref="26833142" role=""/>
+    <member type="way" ref="148788166" role=""/>
+    <member type="way" ref="677899117" role=""/>
+    <member type="way" ref="148788169" role=""/>
+    <member type="way" ref="729156174" role=""/>
+    <member type="way" ref="667112290" role=""/>
+    <member type="way" ref="676840399" role=""/>
+    <member type="way" ref="679603958" role=""/>
+    <member type="way" ref="355758682" role=""/>
+    <member type="way" ref="841314353" role=""/>
+    <member type="way" ref="474193589" role=""/>
+    <member type="way" ref="475958777" role=""/>
+    <member type="way" ref="720375798" role=""/>
+    <member type="way" ref="135929796" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="680974973" role=""/>
+    <member type="way" ref="289959026" role=""/>
+    <member type="way" ref="155396485" role=""/>
+    <member type="way" ref="721794451" role=""/>
+    <member type="way" ref="676885138" role=""/>
+    <member type="way" ref="768501209" role=""/>
+    <member type="way" ref="122976429" role=""/>
+    <member type="way" ref="291575508" role=""/>
+    <member type="way" ref="150899580" role=""/>
+    <member type="way" ref="472134926" role=""/>
+    <member type="way" ref="289953742" role=""/>
+    <member type="way" ref="289953739" role=""/>
+    <member type="way" ref="150899574" role=""/>
+    <member type="way" ref="676370570" role=""/>
+    <member type="way" ref="676370571" role=""/>
+    <member type="way" ref="205990049" role=""/>
+    <member type="way" ref="683691800" role=""/>
+    <member type="way" ref="685872122" role=""/>
+    <member type="way" ref="205990057" role=""/>
+    <member type="way" ref="685870728" role="forward"/>
+    <member type="way" ref="676656295" role="forward"/>
+    <member type="way" ref="205990051" role="forward"/>
+    <member type="way" ref="289911367" role="forward"/>
+    <member type="way" ref="676885851" role="forward"/>
+    <member type="way" ref="806539409" role="forward"/>
+    <member type="way" ref="289911373" role="forward"/>
+    <member type="way" ref="841047450" role="forward"/>
+    <member type="way" ref="676885849" role="forward"/>
+    <member type="way" ref="23098187" role="forward"/>
+    <member type="way" ref="104879985" role="forward"/>
+    <member type="way" ref="841047451" role="forward"/>
+    <member type="way" ref="521052119" role="forward"/>
+    <member type="way" ref="841045563" role="forward"/>
+    <member type="way" ref="480092340" role="forward"/>
+    <member type="way" ref="685870729" role="backward"/>
+    <member type="way" ref="289863501" role="backward"/>
+    <member type="way" ref="178541649" role=""/>
+    <member type="way" ref="676585428" role=""/>
+    <member type="way" ref="751933284" role=""/>
+    <member type="way" ref="121005674" role=""/>
+    <member type="way" ref="291575506" role=""/>
+    <member type="way" ref="676088136" role=""/>
+    <member type="way" ref="289663742" role=""/>
+    <member type="way" ref="676606147" role=""/>
+    <member type="way" ref="289778700" role=""/>
+    <member type="way" ref="676923529" role=""/>
+    <member type="way" ref="676923530" role=""/>
+    <member type="way" ref="676923528" role=""/>
+    <member type="way" ref="289905491" role=""/>
+    <member type="way" ref="205598208" role=""/>
+    <member type="way" ref="675315243" role=""/>
+    <member type="way" ref="675315244" role=""/>
+    <member type="way" ref="675281919" role=""/>
+    <member type="way" ref="675281916" role=""/>
+    <member type="way" ref="675281926" role=""/>
+    <member type="way" ref="675281923" role=""/>
+    <member type="way" ref="197158281" role=""/>
+    <member type="way" ref="675218448" role=""/>
+    <member type="way" ref="675225791" role=""/>
+    <member type="way" ref="675225790" role=""/>
+    <member type="way" ref="675225785" role=""/>
+    <member type="way" ref="675225780" role=""/>
+    <member type="way" ref="23151907" role=""/>
+    <member type="way" ref="675225777" role=""/>
+    <member type="way" ref="556932610" role=""/>
+    <member type="way" ref="556932729" role=""/>
+    <member type="way" ref="556934054" role=""/>
+    <member type="way" ref="289905492" role=""/>
+    <member type="way" ref="381447583" role="forward"/>
+    <member type="way" ref="526359481" role="forward"/>
+    <member type="way" ref="526359480" role="forward"/>
+    <member type="way" ref="526365518" role="forward"/>
+    <member type="way" ref="526359485" role="forward"/>
+    <member type="way" ref="32035230" role="forward"/>
+    <member type="way" ref="121005673" role="forward"/>
+    <member type="way" ref="526535455" role="forward"/>
+    <member type="way" ref="526359484" role="forward"/>
+    <member type="way" ref="381447582" role="forward"/>
+    <member type="way" ref="526359483" role="forward"/>
+    <member type="way" ref="461754341" role=""/>
+    <member type="way" ref="459873724" role=""/>
+    <member type="way" ref="676847931" role=""/>
+    <member type="way" ref="287873247" role="forward"/>
+    <member type="way" ref="685870725" role="backward"/>
+    <member type="way" ref="685870724" role="forward"/>
+    <member type="way" ref="286315255" role="forward"/>
+    <member type="way" ref="32035129" role="forward"/>
+    <member type="way" ref="676863546" role=""/>
+    <member type="way" ref="680502747" role=""/>
+    <member type="way" ref="280434464" role=""/>
+    <member type="way" ref="919864850" role=""/>
+    <member type="way" ref="919864853" role=""/>
+    <member type="way" ref="209161246" role=""/>
+    <member type="way" ref="209161237" role=""/>
+    <member type="way" ref="25916790" role=""/>
+    <member type="way" ref="174915597" role=""/>
+    <member type="way" ref="174915583" role=""/>
+    <member type="way" ref="174915587" role=""/>
+    <member type="way" ref="139485759" role=""/>
+    <member type="way" ref="139485762" role=""/>
+    <member type="way" ref="441888389" role=""/>
+    <member type="way" ref="174915594" role=""/>
+    <member type="way" ref="174915592" role=""/>
+    <member type="way" ref="174915606" role=""/>
+    <member type="way" ref="92858067" role=""/>
+    <member type="way" ref="174915589" role=""/>
+    <member type="way" ref="41170724" role=""/>
+    <member type="way" ref="41170725" role=""/>
+    <member type="way" ref="41170722" role=""/>
+    <member type="way" ref="115101543" role=""/>
+    <member type="way" ref="115101540" role=""/>
+    <member type="way" ref="115101541" role=""/>
+    <member type="way" ref="40401639" role=""/>
+    <member type="way" ref="39006718" role=""/>
+    <member type="way" ref="39006719" role=""/>
+    <member type="way" ref="875150926" role=""/>
+    <member type="way" ref="875150925" role=""/>
+    <member type="way" ref="39006717" role=""/>
+    <member type="way" ref="726861724" role=""/>
+    <member type="way" ref="174964825" role=""/>
+    <member type="way" ref="695752040" role=""/>
+    <member type="way" ref="174964826" role=""/>
+    <member type="way" ref="664950517" role=""/>
+    <member type="way" ref="664950257" role=""/>
+    <member type="way" ref="68324049" role=""/>
+    <member type="way" ref="664950260" role=""/>
+    <member type="way" ref="664950258" role=""/>
+    <member type="way" ref="359766198" role=""/>
+    <member type="way" ref="359766203" role=""/>
+    <member type="way" ref="208937095" role=""/>
+    <member type="way" ref="871958653" role=""/>
+    <member type="way" ref="308841544" role=""/>
+    <member type="way" ref="892019408" role=""/>
+    <member type="way" ref="509063475" role=""/>
+    <member type="way" ref="208937078" role=""/>
+    <member type="way" ref="895065772" role=""/>
+    <member type="way" ref="895065771" role=""/>
+    <member type="way" ref="895065770" role=""/>
+    <member type="way" ref="871958654" role=""/>
+    <member type="way" ref="895065769" role=""/>
+    <member type="way" ref="848539162" role=""/>
+    <member type="way" ref="895065768" role=""/>
+    <member type="way" ref="722329402" role=""/>
+    <member type="way" ref="895065767" role=""/>
+    <member type="way" ref="722329401" role=""/>
+    <member type="way" ref="895065764" role=""/>
+    <member type="way" ref="902416867" role=""/>
+    <member type="way" ref="895065765" role=""/>
+    <member type="way" ref="902416868" role=""/>
+    <member type="way" ref="74217342" role=""/>
+    <member type="way" ref="895065766" role=""/>
+    <member type="way" ref="892472491" role=""/>
+    <member type="way" ref="902423135" role=""/>
+    <member type="way" ref="125048682" role=""/>
+    <member type="way" ref="135398869" role=""/>
+    <member type="way" ref="135398868" role=""/>
+    <member type="way" ref="174804056" role=""/>
+    <member type="way" ref="125048662" role=""/>
+    <member type="way" ref="125048697" role=""/>
+    <member type="way" ref="125048668" role=""/>
+    <member type="way" ref="125048674" role=""/>
+    <member type="way" ref="859274252" role=""/>
+    <member type="way" ref="125048685" role=""/>
+    <member type="way" ref="174790942" role=""/>
+    <member type="way" ref="127497796" role=""/>
+    <member type="way" ref="509063422" role=""/>
+    <member type="way" ref="149947081" role=""/>
+    <member type="way" ref="125088467" role=""/>
+    <member type="way" ref="509063417" role=""/>
+    <member type="way" ref="509063420" role=""/>
+    <member type="way" ref="174807841" role=""/>
+    <member type="way" ref="125501584" role=""/>
+    <member type="way" ref="125501583" role=""/>
+    <member type="way" ref="125088462" role=""/>
+    <member type="way" ref="665354687" role=""/>
+    <member type="way" ref="867726596" role=""/>
+    <member type="way" ref="867726597" role=""/>
+    <member type="way" ref="903895447" role=""/>
+    <member type="way" ref="176016972" role=""/>
+    <member type="way" ref="132029430" role=""/>
+    <member type="way" ref="665354686" role=""/>
+    <member type="way" ref="220779880" role=""/>
+    <member type="way" ref="247724297" role=""/>
+    <member type="way" ref="247724299" role=""/>
+    <member type="way" ref="705440014" role=""/>
+    <member type="way" ref="705440013" role=""/>
+    <member type="way" ref="150968167" role="forward"/>
+    <member type="way" ref="150968174" role="forward"/>
+    <member type="way" ref="150968169" role="forward"/>
+    <member type="way" ref="150968175" role="forward"/>
+    <member type="way" ref="150968170" role="forward"/>
+    <member type="way" ref="150968171" role="forward"/>
+    <member type="way" ref="150968177" role=""/>
+    <member type="way" ref="116238472" role=""/>
+    <member type="way" ref="125501608" role=""/>
+    <member type="way" ref="165318831" role=""/>
+    <member type="way" ref="804366803" role=""/>
+    <member type="way" ref="116238475" role=""/>
+    <member type="way" ref="149947066" role=""/>
+    <member type="way" ref="181454574" role=""/>
+    <member type="way" ref="665350051" role=""/>
+    <member type="way" ref="116238468" role=""/>
+    <member type="way" ref="181454573" role=""/>
+    <member type="way" ref="508249191" role=""/>
+    <member type="way" ref="181454577" role=""/>
+    <member type="way" ref="804728913" role=""/>
+    <member type="way" ref="174944573" role=""/>
+    <member type="way" ref="707066756" role=""/>
+    <member type="way" ref="481298282" role=""/>
+    <member type="way" ref="810017643" role=""/>
+    <member type="way" ref="665349003" role=""/>
+    <member type="way" ref="867728179" role=""/>
+    <member type="way" ref="810017648" role=""/>
+    <member type="way" ref="810017646" role=""/>
+    <member type="way" ref="665349005" role=""/>
+    <member type="way" ref="174806368" role=""/>
+    <member type="way" ref="841486472" role=""/>
+    <member type="way" ref="841486473" role=""/>
+    <member type="way" ref="665345372" role=""/>
+    <member type="way" ref="97008745" role=""/>
+    <member type="way" ref="723561694" role=""/>
+    <member type="way" ref="97008765" role=""/>
+    <member type="way" ref="97008740" role=""/>
+    <member type="way" ref="761938648" role=""/>
+    <member type="way" ref="97008769" role=""/>
+    <member type="way" ref="97008764" role=""/>
+    <member type="way" ref="97008752" role=""/>
+    <member type="way" ref="125088460" role=""/>
+    <member type="way" ref="174814337" role=""/>
+    <member type="way" ref="95214348" role=""/>
+    <member type="way" ref="603992160" role=""/>
+    <member type="way" ref="603992162" role=""/>
+    <member type="way" ref="382640441" role=""/>
+    <member type="way" ref="481303081" role=""/>
+    <member type="way" ref="481303085" role=""/>
+    <member type="way" ref="382640442" role=""/>
+    <member type="way" ref="665338914" role=""/>
+    <member type="way" ref="95962573" role=""/>
+    <member type="way" ref="95962610" role=""/>
+    <member type="way" ref="174867733" role=""/>
+    <member type="way" ref="96339147" role=""/>
+    <member type="way" ref="174868187" role=""/>
+    <member type="way" ref="175097346" role=""/>
+    <member type="way" ref="175097347" role=""/>
+    <member type="way" ref="174868186" role=""/>
+    <member type="way" ref="174868188" role=""/>
+    <member type="way" ref="181442705" role=""/>
+    <member type="way" ref="181442630" role=""/>
+    <member type="way" ref="181442629" role=""/>
+    <member type="way" ref="181443751" role=""/>
+    <member type="way" ref="181443748" role=""/>
+    <member type="way" ref="121641424" role=""/>
+    <member type="way" ref="121641406" role=""/>
+    <member type="way" ref="121641423" role=""/>
+    <member type="way" ref="121641399" role=""/>
+    <member type="way" ref="121641422" role=""/>
+    <member type="way" ref="121641397" role=""/>
+    <member type="way" ref="121641421" role=""/>
+    <member type="way" ref="121641404" role=""/>
+    <member type="way" ref="121641420" role=""/>
+    <member type="way" ref="121641401" role=""/>
+    <member type="way" ref="121641419" role=""/>
+    <member type="way" ref="121641396" role=""/>
+    <member type="way" ref="121641418" role=""/>
+    <member type="way" ref="121641407" role=""/>
+    <member type="way" ref="121641417" role=""/>
+    <member type="way" ref="121641403" role=""/>
+    <member type="way" ref="121641416" role=""/>
+    <member type="way" ref="121641405" role=""/>
+    <member type="way" ref="121641415" role=""/>
+    <member type="way" ref="121641400" role=""/>
+    <member type="way" ref="121641426" role=""/>
+    <member type="way" ref="121641398" role=""/>
+    <member type="way" ref="121641425" role=""/>
+    <member type="way" ref="121641402" role=""/>
+    <member type="way" ref="121636826" role=""/>
+    <member type="way" ref="121636813" role=""/>
+    <member type="way" ref="121636819" role=""/>
+    <member type="way" ref="121636815" role=""/>
+    <member type="way" ref="889301016" role=""/>
+    <member type="way" ref="889301015" role=""/>
+    <member type="way" ref="174647417" role=""/>
+    <member type="way" ref="174647418" role=""/>
+    <member type="way" ref="127504421" role=""/>
+    <member type="way" ref="175103696" role=""/>
+    <member type="way" ref="205999376" role=""/>
+    <member type="way" ref="127504425" role=""/>
+    <member type="way" ref="127504427" role=""/>
+    <member type="way" ref="181450764" role=""/>
+    <member type="way" ref="181440537" role=""/>
+    <member type="way" ref="181440538" role=""/>
+    <member type="way" ref="181464949" role=""/>
+    <member type="way" ref="181464950" role=""/>
+    <member type="way" ref="174868351" role=""/>
+    <member type="way" ref="121636823" role=""/>
+    <member type="way" ref="744502316" role=""/>
+    <member type="way" ref="744502317" role=""/>
+    <member type="way" ref="278732778" role=""/>
+    <member type="way" ref="127511508" role=""/>
+    <member type="way" ref="438541183" role=""/>
+    <member type="way" ref="174868352" role=""/>
+    <member type="way" ref="39585339" role=""/>
+    <member type="way" ref="39658442" role=""/>
+    <member type="way" ref="122094345" role=""/>
+    <member type="way" ref="127511513" role=""/>
+    <member type="way" ref="456156300" role=""/>
+    <member type="way" ref="456156295" role=""/>
+    <member type="way" ref="51192661" role=""/>
+    <member type="way" ref="127511510" role=""/>
+    <member type="way" ref="127511519" role=""/>
+    <member type="way" ref="127511499" role=""/>
+    <member type="way" ref="127511500" role=""/>
+    <member type="way" ref="181460369" role=""/>
+    <member type="way" ref="127507308" role=""/>
+    <member type="way" ref="127507309" role=""/>
+    <member type="way" ref="175717593" role="forward"/>
+    <member type="way" ref="127507313" role="forward"/>
+    <member type="way" ref="175717592" role="forward"/>
+    <member type="way" ref="175717591" role="forward"/>
+    <member type="way" ref="175717597" role="forward"/>
+    <member type="way" ref="175717594" role="forward"/>
+    <member type="way" ref="175717590" role=""/>
+    <member type="way" ref="127507323" role=""/>
+    <member type="way" ref="127507292" role=""/>
+    <member type="way" ref="709374535" role=""/>
+    <member type="way" ref="709374536" role=""/>
+    <member type="way" ref="709374537" role=""/>
+    <member type="way" ref="709374538" role=""/>
+    <member type="way" ref="709374539" role=""/>
+    <member type="way" ref="709374540" role=""/>
+    <member type="way" ref="709374542" role=""/>
+    <member type="way" ref="709374543" role=""/>
+    <member type="way" ref="709374544" role=""/>
+    <member type="way" ref="709374545" role=""/>
+    <member type="way" ref="709371871" role=""/>
+    <member type="way" ref="709371872" role=""/>
+    <member type="way" ref="709371873" role=""/>
+    <member type="way" ref="709371874" role=""/>
+    <member type="way" ref="174868394" role=""/>
+    <member type="way" ref="181464329" role=""/>
+    <member type="way" ref="181464327" role=""/>
+    <member type="way" ref="481572568" role=""/>
+    <member type="way" ref="481572569" role=""/>
+    <member type="way" ref="481573579" role=""/>
+    <member type="way" ref="481573580" role=""/>
+    <member type="way" ref="181992121" role=""/>
+    <member type="way" ref="181992122" role=""/>
+    <member type="way" ref="181993445" role=""/>
+    <member type="way" ref="181993447" role=""/>
+    <member type="way" ref="181993446" role=""/>
+    <member type="way" ref="181993449" role=""/>
+    <member type="way" ref="69341372" role=""/>
+    <member type="way" ref="182000864" role=""/>
+    <member type="way" ref="182000874" role=""/>
+    <member type="way" ref="395007156" role=""/>
+    <member type="way" ref="182000850" role=""/>
+    <member type="way" ref="182000867" role=""/>
+    <member type="way" ref="174868553" role=""/>
+    <member type="way" ref="665294067" role=""/>
+    <member type="way" ref="182000866" role=""/>
+    <member type="way" ref="182000870" role=""/>
+    <member type="way" ref="729110216" role=""/>
+    <member type="way" ref="68849021" role=""/>
+    <member type="way" ref="300842902" role=""/>
+    <member type="way" ref="176209654" role=""/>
+    <member type="way" ref="176209651" role=""/>
+    <member type="way" ref="394759596" role=""/>
+    <member type="way" ref="729110251" role=""/>
+    <member type="way" ref="709026420" role=""/>
+    <member type="way" ref="729110252" role=""/>
+    <member type="way" ref="729110269" role=""/>
+    <member type="way" ref="729110270" role=""/>
+    <member type="way" ref="729110271" role=""/>
+    <member type="way" ref="729110272" role=""/>
+    <member type="way" ref="729110273" role=""/>
+    <member type="way" ref="729110274" role=""/>
+    <member type="way" ref="206011672" role=""/>
+    <member type="way" ref="182002207" role=""/>
+    <member type="way" ref="182002205" role=""/>
+    <member type="way" ref="768803957" role=""/>
+    <member type="way" ref="182007585" role=""/>
+    <member type="way" ref="730241402" role=""/>
+    <member type="way" ref="174868773" role=""/>
+    <member type="way" ref="730241403" role=""/>
+    <member type="way" ref="730241404" role=""/>
+    <member type="way" ref="174868775" role=""/>
+    <member type="way" ref="182007583" role=""/>
+    <member type="way" ref="182007578" role=""/>
+    <member type="way" ref="730241405" role=""/>
+    <member type="way" ref="175907417" role=""/>
+    <member type="way" ref="182007572" role=""/>
+    <member type="way" ref="182007541" role=""/>
+    <member type="way" ref="730241437" role=""/>
+    <member type="way" ref="174868774" role=""/>
+    <member type="way" ref="180414601" role=""/>
+    <member type="way" ref="709825070" role=""/>
+    <member type="way" ref="730241447" role=""/>
+    <member type="way" ref="846920930" role=""/>
+    <member type="way" ref="846920928" role=""/>
+    <member type="way" ref="180414602" role=""/>
+    <member type="way" ref="182007573" role=""/>
+    <member type="way" ref="182007576" role=""/>
+    <member type="way" ref="875122939" role=""/>
+    <member type="way" ref="875122938" role=""/>
+    <member type="way" ref="875088790" role=""/>
+    <member type="way" ref="875088789" role=""/>
+    <member type="way" ref="709825073" role=""/>
+    <member type="way" ref="846920927" role=""/>
+    <member type="way" ref="182027746" role=""/>
+    <member type="way" ref="875111694" role=""/>
+    <member type="way" ref="875111692" role=""/>
+    <member type="way" ref="182027745" role=""/>
+    <member type="way" ref="299042669" role="forward"/>
+    <member type="way" ref="299042666" role="forward"/>
+    <member type="way" ref="299042667" role="forward"/>
+    <member type="way" ref="176820924" role="backward"/>
+    <member type="way" ref="299042668" role="forward"/>
+    <member type="way" ref="299042670" role="backward"/>
+    <member type="way" ref="176820905" role=""/>
+    <member type="way" ref="182027750" role=""/>
+    <member type="way" ref="182027753" role=""/>
+    <member type="way" ref="123658253" role=""/>
+    <member type="way" ref="665208360" role=""/>
+    <member type="way" ref="123658203" role=""/>
+    <member type="way" ref="123658221" role=""/>
+    <member type="way" ref="710356030" role=""/>
+    <member type="way" ref="182027747" role=""/>
+    <member type="way" ref="182027752" role=""/>
+    <member type="way" ref="123658215" role=""/>
+    <member type="way" ref="123658243" role=""/>
+    <member type="way" ref="123658263" role=""/>
+    <member type="way" ref="123658249" role=""/>
+    <member type="way" ref="123658219" role=""/>
+    <member type="way" ref="123658257" role=""/>
+    <member type="way" ref="123658252" role=""/>
+    <member type="way" ref="123658207" role=""/>
+    <member type="way" ref="123658214" role=""/>
+    <member type="way" ref="123658264" role=""/>
+    <member type="way" ref="299042664" role=""/>
+    <member type="way" ref="69337789" role=""/>
+    <member type="way" ref="680504851" role=""/>
+    <member type="way" ref="68996979" role=""/>
+    <member type="way" ref="68996992" role=""/>
+    <member type="way" ref="68651909" role=""/>
+    <member type="way" ref="70130552" role=""/>
+    <member type="way" ref="39534964" role=""/>
+    <member type="way" ref="182027754" role=""/>
+    <member type="way" ref="665207634" role=""/>
+    <member type="way" ref="39611911" role=""/>
+    <member type="way" ref="665207632" role=""/>
+    <member type="way" ref="39763619" role=""/>
+    <member type="way" ref="39611909" role=""/>
+    <member type="way" ref="68651932" role=""/>
+    <member type="way" ref="39611915" role=""/>
+    <member type="way" ref="69963022" role=""/>
+    <member type="way" ref="69963028" role=""/>
+    <member type="way" ref="482815621" role=""/>
+    <member type="way" ref="182029954" role=""/>
+    <member type="way" ref="69963024" role=""/>
+    <member type="way" ref="69963020" role=""/>
+    <member type="way" ref="69963021" role=""/>
+    <member type="way" ref="70031698" role=""/>
+    <member type="way" ref="70031759" role=""/>
+    <member type="way" ref="70031722" role=""/>
+    <member type="way" ref="70031703" role=""/>
+    <member type="way" ref="174962267" role=""/>
+    <member type="way" ref="767630942" role=""/>
+    <member type="way" ref="767630941" role=""/>
+    <member type="way" ref="39558898" role=""/>
+    <member type="way" ref="39558896" role=""/>
+    <member type="way" ref="39654833" role=""/>
+    <member type="way" ref="767630939" role=""/>
+    <member type="way" ref="767630940" role=""/>
+    <member type="way" ref="68830582" role=""/>
+    <member type="way" ref="68830580" role=""/>
+    <member type="way" ref="187900138" role=""/>
+    <tag k="colour" v="#003399"/>
+    <tag k="cycle_network" v="EuroVelo"/>
+    <tag k="icn_ref" v="6"/>
+    <tag k="name" v="EuroVelo 6 - Atlantic-Black Sea - part Serbia"/>
+    <tag k="name:cs" v="EuroVelo 6 - Atlantik-Černé moře - sekce Srbsko"/>
+    <tag k="name:de" v="EuroVelo 6 - Atlantik-Schwarzes Meer - teil Serbien"/>
+    <tag k="name:en" v="EuroVelo 6 - Atlantic-Black Sea - part Serbia"/>
+    <tag k="name:fr" v="EuroVelo 6 - Atlantique-Mer Noire - tronçon Serbie"/>
+    <tag k="name:hr" v="EuroVelo 6 - Atlantik-Crno More - dio Srbija"/>
+    <tag k="name:hu" v="EuroVelo 6 - Szerbiai szakasz"/>
+    <tag k="name:pl" v="EuroVelo 6 - Atlantyk-Morze Czarne - część Serbia"/>
+    <tag k="name:sk" v="EuroVelo 6 - Atlantik-Čierne more - sekcia Srbsko"/>
+    <tag k="name:sr" v="ЕуроВело 6 - део Србија"/>
+    <tag k="name:sr-Latn" v="EuroVelo 6 - deo Srbija"/>
+    <tag k="network" v="icn"/>
+    <tag k="ref" v="EV6"/>
+    <tag k="route" v="bicycle"/>
+    <tag k="type" v="route"/>
+    <tag k="website" v="http://www.eurovelo.com/en/eurovelos/eurovelo-6/countries/serbia"/>
+  </relation>
+  <relation id="3084607" version="2" timestamp="2019-03-13T22:14:34Z" changeset="68116571" uid="8759590" user="daFisch">
+    <member type="way" ref="98993994" role="from"/>
+    <member type="node" ref="583586884" role="via"/>
+    <member type="way" ref="23098071" role="to"/>
+    <tag k="restriction" v="only_right_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="3851961" version="1" timestamp="2014-06-26T22:56:02Z" changeset="23203372" uid="2145201" user="OSM_Popler">
+    <member type="way" ref="23672600" role="from"/>
+    <member type="node" ref="249342979" role="via"/>
+    <member type="way" ref="230065295" role="to"/>
+    <tag k="restriction" v="no_right_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="5311629" version="1" timestamp="2015-06-23T14:39:35Z" changeset="32163105" uid="3008162" user="Ignjat">
+    <member type="way" ref="9473985" role="from"/>
+    <member type="node" ref="36471163" role="via"/>
+    <member type="way" ref="9473985" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="5311630" version="1" timestamp="2015-06-23T14:39:35Z" changeset="32163105" uid="3008162" user="Ignjat">
+    <member type="way" ref="355758663" role="from"/>
+    <member type="node" ref="36471163" role="via"/>
+    <member type="way" ref="355758664" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="5311631" version="1" timestamp="2015-06-23T14:39:35Z" changeset="32163105" uid="3008162" user="Ignjat">
+    <member type="way" ref="355758663" role="from"/>
+    <member type="node" ref="36471163" role="via"/>
+    <member type="way" ref="355758663" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="5334067" version="1" timestamp="2015-07-02T09:47:30Z" changeset="32350283" uid="3008162" user="Ignjat">
+    <member type="way" ref="230065295" role="from"/>
+    <member type="node" ref="249342979" role="via"/>
+    <member type="way" ref="230065295" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="5334068" version="1" timestamp="2015-07-02T09:47:30Z" changeset="32350283" uid="3008162" user="Ignjat">
+    <member type="way" ref="23073170" role="from"/>
+    <member type="node" ref="249342979" role="via"/>
+    <member type="way" ref="23672600" role="to"/>
+    <tag k="restriction" v="no_right_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="5334069" version="1" timestamp="2015-07-02T09:47:31Z" changeset="32350283" uid="3008162" user="Ignjat">
+    <member type="way" ref="23073170" role="from"/>
+    <member type="node" ref="249342979" role="via"/>
+    <member type="way" ref="23098073" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="5334070" version="1" timestamp="2015-07-02T09:47:31Z" changeset="32350283" uid="3008162" user="Ignjat">
+    <member type="way" ref="23073170" role="from"/>
+    <member type="node" ref="249342979" role="via"/>
+    <member type="way" ref="23073170" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="5334071" version="1" timestamp="2015-07-02T09:47:31Z" changeset="32350283" uid="3008162" user="Ignjat">
+    <member type="way" ref="23672600" role="from"/>
+    <member type="node" ref="249342979" role="via"/>
+    <member type="way" ref="23672600" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="5334072" version="2" timestamp="2019-03-11T17:41:32Z" changeset="68031673" uid="9414390" user="Gr8fulDead">
+    <member type="node" ref="256769331" role="via"/>
+    <member type="way" ref="676068916" role="from"/>
+    <member type="way" ref="676068916" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243746" version="1" timestamp="2016-05-22T05:11:57Z" changeset="39480476" uid="3462214" user="Medic Momcilo">
+    <member type="way" ref="23672600" role="from"/>
+    <member type="node" ref="256368843" role="via"/>
+    <member type="way" ref="23712727" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243747" version="1" timestamp="2016-05-22T05:11:58Z" changeset="39480476" uid="3462214" user="Medic Momcilo">
+    <member type="way" ref="23672600" role="from"/>
+    <member type="node" ref="256368843" role="via"/>
+    <member type="way" ref="23672600" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243748" version="1" timestamp="2016-05-22T05:11:58Z" changeset="39480476" uid="3462214" user="Medic Momcilo">
+    <member type="way" ref="23672662" role="from"/>
+    <member type="node" ref="256368843" role="via"/>
+    <member type="way" ref="23672600" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243749" version="1" timestamp="2016-05-22T05:11:58Z" changeset="39480476" uid="3462214" user="Medic Momcilo">
+    <member type="way" ref="23672662" role="from"/>
+    <member type="node" ref="256368843" role="via"/>
+    <member type="way" ref="23712727" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243750" version="1" timestamp="2016-05-22T05:11:58Z" changeset="39480476" uid="3462214" user="Medic Momcilo">
+    <member type="way" ref="23672605" role="from"/>
+    <member type="node" ref="256368843" role="via"/>
+    <member type="way" ref="23672605" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243751" version="1" timestamp="2016-05-22T05:11:58Z" changeset="39480476" uid="3462214" user="Medic Momcilo">
+    <member type="way" ref="23073170" role="from"/>
+    <member type="node" ref="256769331" role="via"/>
+    <member type="way" ref="23073170" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243752" version="1" timestamp="2016-05-22T05:11:58Z" changeset="39480476" uid="3462214" user="Medic Momcilo">
+    <member type="way" ref="23073170" role="from"/>
+    <member type="node" ref="256769331" role="via"/>
+    <member type="way" ref="23672662" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243753" version="1" timestamp="2016-05-22T05:11:58Z" changeset="39480476" uid="3462214" user="Medic Momcilo">
+    <member type="way" ref="230065295" role="from"/>
+    <member type="node" ref="583586884" role="via"/>
+    <member type="way" ref="230065295" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243754" version="2" timestamp="2019-03-13T22:14:34Z" changeset="68116571" uid="8759590" user="daFisch">
+    <member type="way" ref="23098071" role="from"/>
+    <member type="node" ref="583586884" role="via"/>
+    <member type="way" ref="23098071" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243778" version="3" timestamp="2020-05-30T11:13:57Z" changeset="85978653" uid="5569366" user="TXBG">
+    <member type="way" ref="684356845" role="from"/>
+    <member type="node" ref="249024039" role="via"/>
+    <member type="way" ref="195576449" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="6243779" version="3" timestamp="2020-05-30T11:13:57Z" changeset="85978653" uid="5569366" user="TXBG">
+    <member type="way" ref="684356845" role="from"/>
+    <member type="node" ref="249024039" role="via"/>
+    <member type="way" ref="684356845" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="7028697" version="51" timestamp="2021-03-17T20:44:31Z" changeset="101213091" uid="12771584" user="pPetrovic">
+    <member type="node" ref="4692084015" role="platform_entry_only"/>
+    <member type="node" ref="702297257" role="platform"/>
+    <member type="node" ref="4676720720" role="platform"/>
+    <member type="node" ref="4699257474" role="platform"/>
+    <member type="node" ref="4676720721" role="platform"/>
+    <member type="node" ref="4663473498" role="platform"/>
+    <member type="node" ref="1685509556" role="platform"/>
+    <member type="node" ref="2053079440" role="platform"/>
+    <member type="node" ref="2066417344" role="platform"/>
+    <member type="node" ref="2053079932" role="platform"/>
+    <member type="node" ref="2051798496" role="platform"/>
+    <member type="node" ref="8529953136" role="platform"/>
+    <member type="node" ref="2053079956" role="platform"/>
+    <member type="node" ref="8151330291" role="platform"/>
+    <member type="node" ref="2066417345" role="platform"/>
+    <member type="node" ref="8151330292" role="platform_exit_only"/>
+    <member type="way" ref="290607501" role=""/>
+    <member type="way" ref="195576458" role=""/>
+    <member type="way" ref="676602678" role=""/>
+    <member type="way" ref="71510070" role=""/>
+    <member type="way" ref="195576444" role=""/>
+    <member type="way" ref="676603730" role=""/>
+    <member type="way" ref="104879985" role=""/>
+    <member type="way" ref="841047451" role=""/>
+    <member type="way" ref="521052119" role=""/>
+    <member type="way" ref="841045563" role=""/>
+    <member type="way" ref="480092339" role=""/>
+    <member type="way" ref="205990048" role=""/>
+    <member type="way" ref="806539410" role=""/>
+    <member type="way" ref="676603333" role=""/>
+    <member type="way" ref="676603330" role=""/>
+    <member type="way" ref="195576445" role=""/>
+    <member type="way" ref="676671125" role=""/>
+    <member type="way" ref="700929590" role=""/>
+    <member type="way" ref="205990049" role=""/>
+    <member type="way" ref="676370571" role=""/>
+    <member type="way" ref="676370570" role=""/>
+    <member type="way" ref="150899574" role=""/>
+    <member type="way" ref="289953739" role=""/>
+    <member type="way" ref="289953742" role=""/>
+    <member type="way" ref="472134926" role=""/>
+    <member type="way" ref="169037914" role=""/>
+    <member type="way" ref="768510156" role=""/>
+    <member type="way" ref="23078558" role=""/>
+    <member type="way" ref="676663793" role=""/>
+    <member type="way" ref="23098071" role=""/>
+    <member type="way" ref="230065295" role=""/>
+    <member type="way" ref="23672600" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="290012969" role=""/>
+    <member type="way" ref="290012968" role=""/>
+    <member type="way" ref="675220726" role=""/>
+    <member type="way" ref="675220727" role=""/>
+    <member type="way" ref="41235876" role=""/>
+    <member type="way" ref="41235875" role=""/>
+    <member type="way" ref="205987189" role=""/>
+    <member type="way" ref="822320893" role=""/>
+    <member type="way" ref="676108741" role=""/>
+    <member type="way" ref="26826000" role=""/>
+    <member type="way" ref="131952994" role=""/>
+    <member type="way" ref="680727272" role=""/>
+    <member type="way" ref="92469728" role=""/>
+    <member type="way" ref="675478314" role=""/>
+    <member type="way" ref="116482680" role=""/>
+    <member type="way" ref="116482676" role=""/>
+    <member type="way" ref="116482678" role=""/>
+    <member type="way" ref="478280109" role=""/>
+    <member type="way" ref="725329125" role=""/>
+    <member type="way" ref="196603665" role=""/>
+    <member type="way" ref="196603664" role=""/>
+    <member type="way" ref="675242580" role=""/>
+    <member type="way" ref="195144093" role=""/>
+    <member type="way" ref="526510359" role=""/>
+    <member type="way" ref="195144053" role=""/>
+    <member type="way" ref="675478052" role=""/>
+    <member type="way" ref="675478053" role=""/>
+    <member type="way" ref="225151346" role=""/>
+    <member type="way" ref="721951830" role=""/>
+    <member type="way" ref="474804754" role=""/>
+    <member type="way" ref="722135437" role=""/>
+    <member type="way" ref="26491872" role=""/>
+    <member type="way" ref="676051097" role=""/>
+    <member type="way" ref="676051096" role=""/>
+    <member type="way" ref="225151356" role=""/>
+    <member type="way" ref="725335202" role=""/>
+    <member type="way" ref="183385950" role=""/>
+    <member type="way" ref="675507698" role=""/>
+    <member type="way" ref="675507697" role=""/>
+    <member type="way" ref="202745230" role=""/>
+    <member type="way" ref="677091243" role=""/>
+    <member type="way" ref="478106629" role=""/>
+    <member type="way" ref="26491891" role=""/>
+    <member type="way" ref="676061675" role=""/>
+    <member type="way" ref="484386952" role=""/>
+    <member type="way" ref="676061674" role=""/>
+    <member type="way" ref="724345974" role=""/>
+    <member type="way" ref="196297213" role=""/>
+    <member type="way" ref="671796526" role=""/>
+    <member type="way" ref="671796525" role=""/>
+    <member type="way" ref="506055977" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="47:00"/>
+    <tag k="from" v="Вуков Споменик"/>
+    <tag k="from:sr-Latn" v="Vukov Spomenik"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="40101"/>
+    <tag k="gtfs:shape_id" v="40101_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="1258996"/>
+    <tag k="interval" v="24:00"/>
+    <tag k="name" v="EKO1: Вуков Споменик =&gt; Насеље Белвил"/>
+    <tag k="name:sr-Latn" v="EKO1: Vukov Spomenik =&gt; Naselje Belvil"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="EKO1"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Насеље Белвил"/>
+    <tag k="to:sr-Latn" v="Naselje Belvil"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="7028698" version="46" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="2053079521" role="platform_entry_only"/>
+    <member type="node" ref="2053080221" role="platform"/>
+    <member type="node" ref="2053080090" role="platform"/>
+    <member type="node" ref="2053079476" role="platform"/>
+    <member type="node" ref="2053080440" role="platform"/>
+    <member type="node" ref="2053079963" role="platform"/>
+    <member type="node" ref="2053079235" role="platform"/>
+    <member type="node" ref="2051798498" role="platform"/>
+    <member type="node" ref="2053079927" role="platform"/>
+    <member type="node" ref="2066417343" role="platform"/>
+    <member type="node" ref="2053079432" role="platform"/>
+    <member type="node" ref="1685509555" role="platform"/>
+    <member type="node" ref="2148659246" role="platform"/>
+    <member type="node" ref="4676720722" role="platform"/>
+    <member type="node" ref="4676720723" role="platform"/>
+    <member type="node" ref="4676720724" role="platform"/>
+    <member type="node" ref="1493551533" role="platform_exit_only"/>
+    <member type="way" ref="676386625" role=""/>
+    <member type="way" ref="676386624" role=""/>
+    <member type="way" ref="478106630" role=""/>
+    <member type="way" ref="676386623" role=""/>
+    <member type="way" ref="188125264" role=""/>
+    <member type="way" ref="679497379" role=""/>
+    <member type="way" ref="679497374" role=""/>
+    <member type="way" ref="196297281" role=""/>
+    <member type="way" ref="681192586" role=""/>
+    <member type="way" ref="680914981" role=""/>
+    <member type="way" ref="505534353" role=""/>
+    <member type="way" ref="505534365" role=""/>
+    <member type="way" ref="681176487" role=""/>
+    <member type="way" ref="679327484" role=""/>
+    <member type="way" ref="203424519" role=""/>
+    <member type="way" ref="676046295" role=""/>
+    <member type="way" ref="676046293" role=""/>
+    <member type="way" ref="196297228" role=""/>
+    <member type="way" ref="677063986" role=""/>
+    <member type="way" ref="675507701" role=""/>
+    <member type="way" ref="675507700" role=""/>
+    <member type="way" ref="477480824" role=""/>
+    <member type="way" ref="677091242" role=""/>
+    <member type="way" ref="675507699" role=""/>
+    <member type="way" ref="679852863" role=""/>
+    <member type="way" ref="199914553" role=""/>
+    <member type="way" ref="399333137" role=""/>
+    <member type="way" ref="41205349" role=""/>
+    <member type="way" ref="199914548" role=""/>
+    <member type="way" ref="676051099" role=""/>
+    <member type="way" ref="676051098" role=""/>
+    <member type="way" ref="225151350" role=""/>
+    <member type="way" ref="476165010" role=""/>
+    <member type="way" ref="474804755" role=""/>
+    <member type="way" ref="474804753" role=""/>
+    <member type="way" ref="196914688" role=""/>
+    <member type="way" ref="675473783" role=""/>
+    <member type="way" ref="675473784" role=""/>
+    <member type="way" ref="225151353" role=""/>
+    <member type="way" ref="675478050" role=""/>
+    <member type="way" ref="195144085" role=""/>
+    <member type="way" ref="725329130" role=""/>
+    <member type="way" ref="675283555" role=""/>
+    <member type="way" ref="399336311" role=""/>
+    <member type="way" ref="725329126" role=""/>
+    <member type="way" ref="196297264" role=""/>
+    <member type="way" ref="675239061" role=""/>
+    <member type="way" ref="675302535" role=""/>
+    <member type="way" ref="478280129" role=""/>
+    <member type="way" ref="116482674" role=""/>
+    <member type="way" ref="473795254" role=""/>
+    <member type="way" ref="680727271" role=""/>
+    <member type="way" ref="23720049" role=""/>
+    <member type="way" ref="471317420" role=""/>
+    <member type="way" ref="705363889" role=""/>
+    <member type="way" ref="23650408" role=""/>
+    <member type="way" ref="705363890" role=""/>
+    <member type="way" ref="822320892" role=""/>
+    <member type="way" ref="114682422" role=""/>
+    <member type="way" ref="41235874" role=""/>
+    <member type="way" ref="822320897" role=""/>
+    <member type="way" ref="41235877" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23712727" role=""/>
+    <member type="way" ref="98993994" role=""/>
+    <member type="way" ref="23098071" role=""/>
+    <member type="way" ref="676663793" role=""/>
+    <member type="way" ref="23078558" role=""/>
+    <member type="way" ref="768510156" role=""/>
+    <member type="way" ref="150899568" role=""/>
+    <member type="way" ref="291575507" role=""/>
+    <member type="way" ref="676862084" role=""/>
+    <member type="way" ref="195576480" role=""/>
+    <member type="way" ref="676671124" role=""/>
+    <member type="way" ref="676671123" role=""/>
+    <member type="way" ref="196715609" role=""/>
+    <member type="way" ref="23078641" role=""/>
+    <member type="way" ref="289953738" role=""/>
+    <member type="way" ref="289953744" role=""/>
+    <member type="way" ref="676612785" role=""/>
+    <member type="way" ref="197158258" role=""/>
+    <member type="way" ref="476316512" role=""/>
+    <member type="way" ref="676866522" role=""/>
+    <member type="way" ref="195576443" role=""/>
+    <member type="way" ref="676612784" role=""/>
+    <member type="way" ref="676885851" role=""/>
+    <member type="way" ref="806539409" role=""/>
+    <member type="way" ref="289911373" role=""/>
+    <member type="way" ref="841047450" role=""/>
+    <member type="way" ref="676885849" role=""/>
+    <member type="way" ref="23098187" role=""/>
+    <member type="way" ref="178541649" role=""/>
+    <member type="way" ref="676585428" role=""/>
+    <member type="way" ref="751933284" role=""/>
+    <member type="way" ref="676606164" role=""/>
+    <member type="way" ref="475468513" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="47:00"/>
+    <tag k="from" v="Гаража Нови Београд"/>
+    <tag k="from:sr-Latn" v="Garaža Novi Beograd"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="40101"/>
+    <tag k="gtfs:shape_id" v="40101_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="1258997"/>
+    <tag k="interval" v="24:00"/>
+    <tag k="name" v="EKO1: Гаража Нови Београд =&gt; Вуков Споменик"/>
+    <tag k="name:sr-Latn" v="EKO1: Garaža Novi Beograd =&gt; Vukov Spomenik"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="EKO1"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Вуков Споменик"/>
+    <tag k="to:sr-Latn" v="Vukov Spomenik"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="7029050" version="57" timestamp="2021-03-07T22:33:43Z" changeset="100594602" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="2041567126" role="platform_entry_only"/>
+    <member type="node" ref="4682111488" role="platform"/>
+    <member type="node" ref="957069821" role="platform"/>
+    <member type="node" ref="4359066192" role="platform"/>
+    <member type="node" ref="1119942190" role="platform"/>
+    <member type="node" ref="4658245523" role="platform"/>
+    <member type="node" ref="2077480521" role="platform"/>
+    <member type="node" ref="1541440679" role="platform"/>
+    <member type="node" ref="2077480369" role="platform"/>
+    <member type="node" ref="3104648612" role="platform"/>
+    <member type="node" ref="4049278992" role="platform"/>
+    <member type="node" ref="4049286569" role="platform"/>
+    <member type="node" ref="4049286571" role="platform"/>
+    <member type="node" ref="4049286573" role="platform"/>
+    <member type="node" ref="4049286575" role="platform"/>
+    <member type="node" ref="4119241489" role="platform"/>
+    <member type="node" ref="4119257424" role="platform"/>
+    <member type="node" ref="853511565" role="platform"/>
+    <member type="node" ref="2793775103" role="platform"/>
+    <member type="node" ref="1721151937" role="platform"/>
+    <member type="node" ref="849461863" role="platform"/>
+    <member type="node" ref="849462012" role="platform"/>
+    <member type="node" ref="3135016193" role="platform"/>
+    <member type="node" ref="1803286497" role="platform"/>
+    <member type="node" ref="2738212307" role="platform"/>
+    <member type="node" ref="4705124201" role="platform"/>
+    <member type="node" ref="2793803868" role="platform"/>
+    <member type="node" ref="4705124205" role="platform"/>
+    <member type="node" ref="4705124209" role="platform_exit_only"/>
+    <member type="way" ref="474206817" role=""/>
+    <member type="way" ref="195576478" role=""/>
+    <member type="way" ref="26833144" role=""/>
+    <member type="way" ref="26833142" role=""/>
+    <member type="way" ref="148788166" role=""/>
+    <member type="way" ref="23066742" role=""/>
+    <member type="way" ref="677899115" role=""/>
+    <member type="way" ref="675324015" role=""/>
+    <member type="way" ref="675324016" role=""/>
+    <member type="way" ref="395684568" role=""/>
+    <member type="way" ref="675324014" role=""/>
+    <member type="way" ref="148788173" role=""/>
+    <member type="way" ref="865790869" role=""/>
+    <member type="way" ref="23115215" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="135929794" role=""/>
+    <member type="way" ref="82203841" role=""/>
+    <member type="way" ref="474193588" role=""/>
+    <member type="way" ref="474193587" role=""/>
+    <member type="way" ref="475958777" role=""/>
+    <member type="way" ref="720375798" role=""/>
+    <member type="way" ref="135929796" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="122976428" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="391815708" role=""/>
+    <member type="way" ref="474200724" role=""/>
+    <member type="way" ref="6121445" role=""/>
+    <member type="way" ref="834023363" role=""/>
+    <member type="way" ref="606131083" role=""/>
+    <member type="way" ref="541623559" role=""/>
+    <member type="way" ref="676355525" role=""/>
+    <member type="way" ref="195576446" role=""/>
+    <member type="way" ref="355758680" role=""/>
+    <member type="way" ref="882971735" role=""/>
+    <member type="way" ref="675477679" role=""/>
+    <member type="way" ref="351606830" role=""/>
+    <member type="way" ref="721798129" role=""/>
+    <member type="way" ref="721798130" role=""/>
+    <member type="way" ref="675477680" role=""/>
+    <member type="way" ref="23786225" role=""/>
+    <member type="way" ref="834023362" role=""/>
+    <member type="way" ref="721905910" role=""/>
+    <member type="way" ref="721905909" role=""/>
+    <member type="way" ref="23786282" role=""/>
+    <member type="way" ref="721867181" role=""/>
+    <member type="way" ref="41411818" role=""/>
+    <member type="way" ref="41411814" role=""/>
+    <member type="way" ref="195144120" role=""/>
+    <member type="way" ref="883978392" role=""/>
+    <member type="way" ref="883978391" role=""/>
+    <member type="way" ref="881442251" role=""/>
+    <member type="way" ref="884516529" role=""/>
+    <member type="way" ref="871189958" role=""/>
+    <member type="way" ref="152969963" role=""/>
+    <member type="way" ref="871189959" role=""/>
+    <member type="way" ref="34943859" role=""/>
+    <member type="way" ref="152974757" role=""/>
+    <member type="way" ref="808953602" role=""/>
+    <member type="way" ref="808953603" role=""/>
+    <member type="way" ref="679515693" role=""/>
+    <member type="way" ref="679344284" role=""/>
+    <member type="way" ref="808953605" role=""/>
+    <member type="way" ref="808953606" role=""/>
+    <member type="way" ref="679515689" role=""/>
+    <member type="way" ref="679515690" role=""/>
+    <member type="way" ref="679515685" role=""/>
+    <member type="way" ref="679515686" role=""/>
+    <member type="way" ref="679515683" role=""/>
+    <member type="way" ref="679515682" role=""/>
+    <member type="way" ref="678702135" role=""/>
+    <member type="way" ref="678702134" role=""/>
+    <member type="way" ref="678702133" role=""/>
+    <member type="way" ref="678702132" role=""/>
+    <member type="way" ref="679515680" role=""/>
+    <member type="way" ref="679515679" role=""/>
+    <member type="way" ref="392295584" role=""/>
+    <member type="way" ref="678154031" role=""/>
+    <member type="way" ref="282783255" role=""/>
+    <member type="way" ref="113616481" role=""/>
+    <member type="way" ref="702624369" role=""/>
+    <member type="way" ref="681422146" role=""/>
+    <member type="way" ref="685136265" role=""/>
+    <member type="way" ref="392295573" role=""/>
+    <member type="way" ref="677128923" role=""/>
+    <member type="way" ref="478300506" role=""/>
+    <member type="way" ref="677128922" role=""/>
+    <member type="way" ref="229183006" role=""/>
+    <member type="way" ref="676850390" role=""/>
+    <member type="way" ref="198644146" role=""/>
+    <member type="way" ref="892774278" role=""/>
+    <member type="way" ref="198644147" role=""/>
+    <member type="way" ref="478301897" role=""/>
+    <member type="way" ref="169044346" role=""/>
+    <member type="way" ref="169044347" role=""/>
+    <member type="way" ref="677104503" role=""/>
+    <member type="way" ref="34951035" role=""/>
+    <member type="way" ref="477111303" role=""/>
+    <tag k="from" v="Дорћол /СРЦ Милан Гале Мушкатировић/"/>
+    <tag k="from:sr-Latn" v="Dorćol /SRC Milan Gale Muškatirović/"/>
+    <tag k="lineRef" v="333"/>
+    <tag k="name" v="E9 Дорћол /СРЦ Милан Гале Мушкатировић/ - Кумодраж"/>
+    <tag k="name:sr-Latn" v="E9 Dorćol /SRC Milan Gale Muškatirović/ - Kumodraž"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="E9"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Кумодраж"/>
+    <tag k="to:sr-Latn" v="Kumodraž"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="7029051" version="67" timestamp="2021-01-16T01:02:39Z" changeset="97588001" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="4705124208" role="platform_entry_only"/>
+    <member type="node" ref="4705124203" role="platform"/>
+    <member type="node" ref="2793803872" role="platform"/>
+    <member type="node" ref="4705124202" role="platform"/>
+    <member type="node" ref="1803254397" role="platform"/>
+    <member type="node" ref="1803286498" role="platform"/>
+    <member type="node" ref="1255328184" role="platform"/>
+    <member type="node" ref="849462000" role="platform"/>
+    <member type="node" ref="849464715" role="platform"/>
+    <member type="node" ref="3935001365" role="platform"/>
+    <member type="node" ref="1721151936" role="platform"/>
+    <member type="node" ref="853513235" role="platform"/>
+    <member type="node" ref="2077480565" role="platform"/>
+    <member type="node" ref="1826622409" role="platform"/>
+    <member type="node" ref="4049286574" role="platform"/>
+    <member type="node" ref="4049286572" role="platform"/>
+    <member type="node" ref="4049286570" role="platform"/>
+    <member type="node" ref="4049286568" role="platform"/>
+    <member type="node" ref="4049278991" role="platform"/>
+    <member type="node" ref="507047264" role="platform"/>
+    <member type="node" ref="2077480379" role="platform"/>
+    <member type="node" ref="2165543291" role="platform"/>
+    <member type="node" ref="4658236196" role="platform"/>
+    <member type="node" ref="4658245524" role="platform"/>
+    <member type="node" ref="5866599807" role="platform"/>
+    <member type="node" ref="957069819" role="platform"/>
+    <member type="node" ref="5782135213" role="platform"/>
+    <member type="node" ref="2041567126" role="platform_exit_only"/>
+    <member type="way" ref="477111303" role=""/>
+    <member type="way" ref="34951035" role=""/>
+    <member type="way" ref="677104503" role=""/>
+    <member type="way" ref="169044347" role=""/>
+    <member type="way" ref="169044346" role=""/>
+    <member type="way" ref="478301897" role=""/>
+    <member type="way" ref="198644147" role=""/>
+    <member type="way" ref="892774278" role=""/>
+    <member type="way" ref="198644146" role=""/>
+    <member type="way" ref="676850390" role=""/>
+    <member type="way" ref="229183006" role=""/>
+    <member type="way" ref="677128922" role=""/>
+    <member type="way" ref="478300506" role=""/>
+    <member type="way" ref="677128923" role=""/>
+    <member type="way" ref="392295573" role=""/>
+    <member type="way" ref="685136265" role=""/>
+    <member type="way" ref="681422146" role=""/>
+    <member type="way" ref="678702141" role=""/>
+    <member type="way" ref="392295574" role=""/>
+    <member type="way" ref="477915918" role=""/>
+    <member type="way" ref="678509895" role=""/>
+    <member type="way" ref="678509894" role=""/>
+    <member type="way" ref="678702140" role=""/>
+    <member type="way" ref="678702139" role=""/>
+    <member type="way" ref="678702138" role=""/>
+    <member type="way" ref="678702137" role=""/>
+    <member type="way" ref="392295578" role=""/>
+    <member type="way" ref="679515684" role=""/>
+    <member type="way" ref="402130287" role=""/>
+    <member type="way" ref="679515687" role=""/>
+    <member type="way" ref="679515692" role=""/>
+    <member type="way" ref="679515691" role=""/>
+    <member type="way" ref="808953609" role=""/>
+    <member type="way" ref="808953604" role=""/>
+    <member type="way" ref="808953601" role=""/>
+    <member type="way" ref="409290706" role=""/>
+    <member type="way" ref="883353303" role=""/>
+    <member type="way" ref="881442250" role=""/>
+    <member type="way" ref="23786310" role=""/>
+    <member type="way" ref="721867518" role=""/>
+    <member type="way" ref="41411820" role=""/>
+    <member type="way" ref="195144117" role=""/>
+    <member type="way" ref="23786341" role=""/>
+    <member type="way" ref="804690433" role=""/>
+    <member type="way" ref="882967088" role=""/>
+    <member type="way" ref="165454890" role=""/>
+    <member type="way" ref="675464950" role=""/>
+    <member type="way" ref="675477681" role=""/>
+    <member type="way" ref="41411817" role=""/>
+    <member type="way" ref="675475387" role=""/>
+    <member type="way" ref="675475388" role=""/>
+    <member type="way" ref="339948798" role=""/>
+    <member type="way" ref="355758678" role=""/>
+    <member type="way" ref="541623553" role=""/>
+    <member type="way" ref="808883808" role=""/>
+    <member type="way" ref="676355524" role=""/>
+    <member type="way" ref="477551227" role=""/>
+    <member type="way" ref="474200724" role=""/>
+    <member type="way" ref="391815707" role=""/>
+    <member type="way" ref="541623551" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="23786175" role=""/>
+    <member type="way" ref="676885138" role=""/>
+    <member type="way" ref="721794451" role=""/>
+    <member type="way" ref="155396485" role=""/>
+    <member type="way" ref="289959026" role=""/>
+    <member type="way" ref="680974973" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="135929794" role=""/>
+    <member type="way" ref="82203841" role=""/>
+    <member type="way" ref="474193588" role=""/>
+    <member type="way" ref="474193587" role=""/>
+    <member type="way" ref="474193589" role=""/>
+    <member type="way" ref="841314353" role=""/>
+    <member type="way" ref="355758682" role=""/>
+    <member type="way" ref="679603958" role=""/>
+    <member type="way" ref="676840399" role=""/>
+    <member type="way" ref="667112290" role=""/>
+    <member type="way" ref="729156174" role=""/>
+    <member type="way" ref="148788169" role=""/>
+    <member type="way" ref="677899117" role=""/>
+    <member type="way" ref="148788166" role=""/>
+    <member type="way" ref="26833142" role=""/>
+    <member type="way" ref="26833144" role=""/>
+    <member type="way" ref="195576478" role=""/>
+    <member type="way" ref="195576477" role=""/>
+    <member type="way" ref="474206816" role=""/>
+    <tag k="from" v="Кумодраж"/>
+    <tag k="from:sr-Latn" v="Kumodraž"/>
+    <tag k="lineRef" v="333"/>
+    <tag k="name" v="E9 Кумодраж - Дорћол /СРЦ Милан Гале Мушкатировић/"/>
+    <tag k="name:sr-Latn" v="E9 Kumodraž - Dorćol /SRC Milan Gale Muškatirović/"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="E9"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Дорћол /СРЦ Милан Гале Мушкатировић/"/>
+    <tag k="to:sr-Latn" v="Dorćol /SRC Milan Gale Muškatirović/"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="7031646" version="85" timestamp="2021-03-16T17:27:55Z" changeset="101136058" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="4709166258" role="platform_entry_only"/>
+    <member type="node" ref="4076726571" role="platform"/>
+    <member type="node" ref="4709157837" role="platform"/>
+    <member type="node" ref="3985532689" role="platform"/>
+    <member type="node" ref="1582997967" role="platform"/>
+    <member type="node" ref="4587701091" role="platform"/>
+    <member type="node" ref="4073191640" role="platform"/>
+    <member type="node" ref="5116005578" role="platform"/>
+    <member type="node" ref="2059750339" role="platform"/>
+    <member type="node" ref="2059750414" role="platform"/>
+    <member type="node" ref="2059750439" role="platform"/>
+    <member type="node" ref="5110436203" role="platform"/>
+    <member type="node" ref="8149080412" role="platform"/>
+    <member type="node" ref="2059750489" role="platform"/>
+    <member type="node" ref="5110436209" role="platform"/>
+    <member type="node" ref="5110436207" role="platform"/>
+    <member type="node" ref="5116045654" role="platform"/>
+    <member type="node" ref="2059750409" role="platform"/>
+    <member type="node" ref="2059750352" role="platform"/>
+    <member type="node" ref="2059750504" role="platform"/>
+    <member type="node" ref="2059750393" role="platform"/>
+    <member type="node" ref="2059750326" role="platform"/>
+    <member type="node" ref="6593166765" role="platform"/>
+    <member type="node" ref="2077480548" role="platform"/>
+    <member type="node" ref="2059750485" role="platform"/>
+    <member type="node" ref="2059750422" role="platform"/>
+    <member type="node" ref="5116045644" role="platform"/>
+    <member type="node" ref="2059750331" role="platform"/>
+    <member type="node" ref="2059750410" role="platform"/>
+    <member type="node" ref="4658245524" role="platform"/>
+    <member type="node" ref="5866599807" role="platform"/>
+    <member type="node" ref="4658230790" role="platform"/>
+    <member type="node" ref="4663729037" role="platform"/>
+    <member type="node" ref="4663729036" role="platform"/>
+    <member type="node" ref="3851652387" role="platform"/>
+    <member type="way" ref="525993052" role=""/>
+    <member type="way" ref="477595901" role=""/>
+    <member type="way" ref="293034098" role=""/>
+    <member type="way" ref="196715578" role=""/>
+    <member type="way" ref="24228612" role=""/>
+    <member type="way" ref="24228669" role=""/>
+    <member type="way" ref="677759566" role=""/>
+    <member type="way" ref="677759567" role=""/>
+    <member type="way" ref="478326506" role=""/>
+    <member type="way" ref="466652649" role=""/>
+    <member type="way" ref="677761649" role=""/>
+    <member type="way" ref="466648503" role=""/>
+    <member type="way" ref="677761648" role=""/>
+    <member type="way" ref="677761647" role=""/>
+    <member type="way" ref="677761651" role=""/>
+    <member type="way" ref="478326665" role=""/>
+    <member type="way" ref="293019777" role=""/>
+    <member type="way" ref="405097139" role=""/>
+    <member type="way" ref="195551210" role=""/>
+    <member type="way" ref="195551209" role=""/>
+    <member type="way" ref="30721060" role=""/>
+    <member type="way" ref="30721124" role=""/>
+    <member type="way" ref="365395480" role=""/>
+    <member type="way" ref="677924451" role=""/>
+    <member type="way" ref="286535166" role=""/>
+    <member type="way" ref="30720910" role=""/>
+    <member type="way" ref="365395481" role=""/>
+    <member type="way" ref="196715562" role=""/>
+    <member type="way" ref="678206947" role=""/>
+    <member type="way" ref="678206948" role=""/>
+    <member type="way" ref="677122033" role=""/>
+    <member type="way" ref="196715564" role=""/>
+    <member type="way" ref="677120584" role=""/>
+    <member type="way" ref="677120583" role=""/>
+    <member type="way" ref="195551208" role=""/>
+    <member type="way" ref="702643984" role=""/>
+    <member type="way" ref="702643983" role=""/>
+    <member type="way" ref="702643903" role=""/>
+    <member type="way" ref="31799947" role=""/>
+    <member type="way" ref="677918496" role=""/>
+    <member type="way" ref="677918495" role=""/>
+    <member type="way" ref="390451882" role=""/>
+    <member type="way" ref="702643109" role=""/>
+    <member type="way" ref="702643025" role=""/>
+    <member type="way" ref="703835091" role=""/>
+    <member type="way" ref="702642456" role=""/>
+    <member type="way" ref="702642455" role=""/>
+    <member type="way" ref="473589574" role=""/>
+    <member type="way" ref="512275836" role=""/>
+    <member type="way" ref="365353304" role=""/>
+    <member type="way" ref="725274093" role=""/>
+    <member type="way" ref="677753067" role=""/>
+    <member type="way" ref="725274094" role=""/>
+    <member type="way" ref="725274095" role=""/>
+    <member type="way" ref="678736470" role=""/>
+    <member type="way" ref="725274092" role=""/>
+    <member type="way" ref="678736471" role=""/>
+    <member type="way" ref="678736469" role=""/>
+    <member type="way" ref="678736468" role=""/>
+    <member type="way" ref="678736466" role=""/>
+    <member type="way" ref="725274089" role=""/>
+    <member type="way" ref="38909275" role=""/>
+    <member type="way" ref="725274091" role=""/>
+    <member type="way" ref="678736465" role=""/>
+    <member type="way" ref="830466528" role=""/>
+    <member type="way" ref="31799780" role=""/>
+    <member type="way" ref="677925756" role=""/>
+    <member type="way" ref="692594453" role=""/>
+    <member type="way" ref="195551211" role=""/>
+    <member type="way" ref="677925755" role=""/>
+    <member type="way" ref="845427686" role=""/>
+    <member type="way" ref="36950716" role=""/>
+    <member type="way" ref="477929225" role=""/>
+    <member type="way" ref="195551203" role=""/>
+    <member type="way" ref="473641226" role=""/>
+    <member type="way" ref="917939159" role=""/>
+    <member type="way" ref="41171348" role=""/>
+    <member type="way" ref="593948562" role=""/>
+    <member type="way" ref="895174662" role=""/>
+    <member type="way" ref="41171349" role=""/>
+    <member type="way" ref="835225082" role=""/>
+    <member type="way" ref="677908731" role=""/>
+    <member type="way" ref="834023366" role=""/>
+    <member type="way" ref="677740989" role=""/>
+    <member type="way" ref="437072200" role=""/>
+    <member type="way" ref="834023365" role=""/>
+    <member type="way" ref="681396491" role=""/>
+    <member type="way" ref="677911257" role=""/>
+    <member type="way" ref="677912884" role=""/>
+    <member type="way" ref="23893355" role=""/>
+    <member type="way" ref="677912881" role=""/>
+    <member type="way" ref="677912886" role=""/>
+    <member type="way" ref="198723956" role=""/>
+    <member type="way" ref="23893387" role=""/>
+    <member type="way" ref="38922658" role=""/>
+    <member type="way" ref="41234379" role=""/>
+    <member type="way" ref="65399798" role=""/>
+    <member type="way" ref="200366255" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="472134922" role=""/>
+    <member type="way" ref="289953743" role=""/>
+    <member type="way" ref="289953739" role=""/>
+    <member type="way" ref="289953742" role=""/>
+    <member type="way" ref="472134926" role=""/>
+    <member type="way" ref="150899580" role=""/>
+    <member type="way" ref="291575508" role=""/>
+    <member type="way" ref="122976429" role=""/>
+    <member type="way" ref="768501209" role=""/>
+    <member type="way" ref="676885138" role=""/>
+    <member type="way" ref="721794451" role=""/>
+    <member type="way" ref="155396485" role=""/>
+    <member type="way" ref="289959026" role=""/>
+    <member type="way" ref="680974973" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="686663563" role=""/>
+    <member type="way" ref="476367774" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="82204229" role=""/>
+    <member type="way" ref="676318987" role=""/>
+    <member type="way" ref="676319004" role=""/>
+    <member type="way" ref="676318999" role=""/>
+    <member type="way" ref="676318995" role=""/>
+    <member type="way" ref="676318990" role=""/>
+    <member type="way" ref="478296729" role=""/>
+    <member type="way" ref="676323759" role=""/>
+    <member type="way" ref="676323760" role=""/>
+    <member type="way" ref="676323756" role=""/>
+    <member type="way" ref="676323757" role=""/>
+    <member type="way" ref="676130933" role=""/>
+    <member type="way" ref="676130929" role=""/>
+    <member type="way" ref="676130927" role=""/>
+    <member type="way" ref="23115346" role=""/>
+    <member type="way" ref="676130931" role=""/>
+    <member type="way" ref="525997333" role=""/>
+    <member type="way" ref="195576433" role=""/>
+    <member type="way" ref="487184929" role=""/>
+    <tag k="from" v="Петлово брдо"/>
+    <tag k="from:sr-Latn" v="Petlovo brdo"/>
+    <tag k="lineRef" v="325"/>
+    <tag k="name" v="Е2 Петлово брдо - Дунав станица"/>
+    <tag k="name:sr-Latn" v="E2 Petlovo brdo - Dunav stanica"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="E2"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Дунав станица"/>
+    <tag k="to:sr-Latn" v="Dunav stanica"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="7031647" version="73" timestamp="2021-01-16T01:02:39Z" changeset="97588001" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="3851652387" role="platform_entry_only"/>
+    <member type="node" ref="4663729035" role="platform"/>
+    <member type="node" ref="4663729038" role="platform"/>
+    <member type="node" ref="1618592187" role="platform"/>
+    <member type="node" ref="1119942190" role="platform"/>
+    <member type="node" ref="2059750330" role="platform"/>
+    <member type="node" ref="5116045641" role="platform"/>
+    <member type="node" ref="1858130486" role="platform"/>
+    <member type="node" ref="462529782" role="platform"/>
+    <member type="node" ref="5116005559" role="platform"/>
+    <member type="node" ref="7093538586" role="platform"/>
+    <member type="node" ref="1790035860" role="platform"/>
+    <member type="node" ref="2059750376" role="platform"/>
+    <member type="node" ref="2059750503" role="platform"/>
+    <member type="node" ref="1790354844" role="platform"/>
+    <member type="node" ref="2059750403" role="platform"/>
+    <member type="node" ref="5116045653" role="platform"/>
+    <member type="node" ref="5110436206" role="platform"/>
+    <member type="node" ref="5110436208" role="platform"/>
+    <member type="node" ref="2059750488" role="platform"/>
+    <member type="node" ref="2059750419" role="platform"/>
+    <member type="node" ref="5110436203" role="platform"/>
+    <member type="node" ref="5116005577" role="platform"/>
+    <member type="node" ref="2059750438" role="platform"/>
+    <member type="node" ref="2059750413" role="platform"/>
+    <member type="node" ref="2059750338" role="platform"/>
+    <member type="node" ref="5116005576" role="platform"/>
+    <member type="node" ref="4073191641" role="platform"/>
+    <member type="node" ref="4587701090" role="platform"/>
+    <member type="node" ref="3985532687" role="platform"/>
+    <member type="node" ref="3985532688" role="platform"/>
+    <member type="node" ref="4709157836" role="platform"/>
+    <member type="node" ref="4076726570" role="platform"/>
+    <member type="node" ref="4709166257" role="platform_exit_only"/>
+    <member type="way" ref="472147025" role=""/>
+    <member type="way" ref="23115358" role=""/>
+    <member type="way" ref="472116295" role=""/>
+    <member type="way" ref="195576430" role=""/>
+    <member type="way" ref="525997333" role=""/>
+    <member type="way" ref="676130931" role=""/>
+    <member type="way" ref="676130922" role=""/>
+    <member type="way" ref="23115335" role=""/>
+    <member type="way" ref="804412431" role=""/>
+    <member type="way" ref="676130923" role=""/>
+    <member type="way" ref="676323759" role=""/>
+    <member type="way" ref="478296729" role=""/>
+    <member type="way" ref="676318990" role=""/>
+    <member type="way" ref="676318995" role=""/>
+    <member type="way" ref="676318999" role=""/>
+    <member type="way" ref="676319004" role=""/>
+    <member type="way" ref="23115305" role=""/>
+    <member type="way" ref="676621711" role=""/>
+    <member type="way" ref="478296731" role=""/>
+    <member type="way" ref="556936699" role=""/>
+    <member type="way" ref="676621712" role=""/>
+    <member type="way" ref="392994844" role=""/>
+    <member type="way" ref="676630205" role=""/>
+    <member type="way" ref="676630201" role=""/>
+    <member type="way" ref="508373018" role=""/>
+    <member type="way" ref="676055075" role=""/>
+    <member type="way" ref="289959032" role=""/>
+    <member type="way" ref="23115219" role=""/>
+    <member type="way" ref="694060036" role=""/>
+    <member type="way" ref="619005693" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="23078542" role=""/>
+    <member type="way" ref="768501209" role=""/>
+    <member type="way" ref="122976429" role=""/>
+    <member type="way" ref="150899570" role=""/>
+    <member type="way" ref="195576480" role=""/>
+    <member type="way" ref="676671124" role=""/>
+    <member type="way" ref="676671123" role=""/>
+    <member type="way" ref="150899586" role=""/>
+    <member type="way" ref="196715565" role=""/>
+    <member type="way" ref="288824423" role=""/>
+    <member type="way" ref="289959023" role=""/>
+    <member type="way" ref="196715566" role=""/>
+    <member type="way" ref="382481633" role=""/>
+    <member type="way" ref="710795614" role=""/>
+    <member type="way" ref="365056745" role=""/>
+    <member type="way" ref="676056887" role=""/>
+    <member type="way" ref="365056744" role=""/>
+    <member type="way" ref="676068268" role=""/>
+    <member type="way" ref="382484546" role=""/>
+    <member type="way" ref="676107888" role=""/>
+    <member type="way" ref="676098576" role=""/>
+    <member type="way" ref="382484490" role=""/>
+    <member type="way" ref="676086311" role=""/>
+    <member type="way" ref="382483965" role=""/>
+    <member type="way" ref="817507922" role=""/>
+    <member type="way" ref="382484194" role=""/>
+    <member type="way" ref="676068269" role=""/>
+    <member type="way" ref="382484299" role=""/>
+    <member type="way" ref="507227630" role=""/>
+    <member type="way" ref="24282347" role=""/>
+    <member type="way" ref="22762705" role=""/>
+    <member type="way" ref="676097202" role=""/>
+    <member type="way" ref="23893460" role=""/>
+    <member type="way" ref="41234382" role=""/>
+    <member type="way" ref="198723955" role=""/>
+    <member type="way" ref="41234376" role=""/>
+    <member type="way" ref="677728908" role=""/>
+    <member type="way" ref="871350131" role=""/>
+    <member type="way" ref="895734447" role=""/>
+    <member type="way" ref="677728907" role=""/>
+    <member type="way" ref="677908729" role=""/>
+    <member type="way" ref="677908727" role=""/>
+    <member type="way" ref="179926017" role=""/>
+    <member type="way" ref="680976466" role=""/>
+    <member type="way" ref="593948561" role=""/>
+    <member type="way" ref="519156042" role=""/>
+    <member type="way" ref="41171641" role=""/>
+    <member type="way" ref="478708978" role=""/>
+    <member type="way" ref="677745293" role=""/>
+    <member type="way" ref="23298154" role=""/>
+    <member type="way" ref="41172314" role=""/>
+    <member type="way" ref="236287391" role=""/>
+    <member type="way" ref="38909276" role=""/>
+    <member type="way" ref="678736465" role=""/>
+    <member type="way" ref="725274091" role=""/>
+    <member type="way" ref="38909275" role=""/>
+    <member type="way" ref="725274089" role=""/>
+    <member type="way" ref="678736466" role=""/>
+    <member type="way" ref="678736468" role=""/>
+    <member type="way" ref="678736469" role=""/>
+    <member type="way" ref="678736471" role=""/>
+    <member type="way" ref="725274092" role=""/>
+    <member type="way" ref="678736470" role=""/>
+    <member type="way" ref="725274095" role=""/>
+    <member type="way" ref="725274094" role=""/>
+    <member type="way" ref="677753067" role=""/>
+    <member type="way" ref="725274093" role=""/>
+    <member type="way" ref="365353304" role=""/>
+    <member type="way" ref="678504380" role=""/>
+    <member type="way" ref="404314489" role=""/>
+    <member type="way" ref="702642455" role=""/>
+    <member type="way" ref="702642456" role=""/>
+    <member type="way" ref="703835091" role=""/>
+    <member type="way" ref="702643025" role=""/>
+    <member type="way" ref="702643109" role=""/>
+    <member type="way" ref="390451882" role=""/>
+    <member type="way" ref="677918495" role=""/>
+    <member type="way" ref="677918496" role=""/>
+    <member type="way" ref="31799947" role=""/>
+    <member type="way" ref="702643903" role=""/>
+    <member type="way" ref="702643983" role=""/>
+    <member type="way" ref="702643984" role=""/>
+    <member type="way" ref="195551208" role=""/>
+    <member type="way" ref="677120583" role=""/>
+    <member type="way" ref="677120584" role=""/>
+    <member type="way" ref="196715564" role=""/>
+    <member type="way" ref="677122033" role=""/>
+    <member type="way" ref="678206948" role=""/>
+    <member type="way" ref="678206947" role=""/>
+    <member type="way" ref="196715562" role=""/>
+    <member type="way" ref="365395481" role=""/>
+    <member type="way" ref="30720910" role=""/>
+    <member type="way" ref="286535166" role=""/>
+    <member type="way" ref="677924451" role=""/>
+    <member type="way" ref="365395480" role=""/>
+    <member type="way" ref="30721124" role=""/>
+    <member type="way" ref="30721060" role=""/>
+    <member type="way" ref="195551209" role=""/>
+    <member type="way" ref="195551210" role=""/>
+    <member type="way" ref="405097142" role=""/>
+    <member type="way" ref="196715530" role=""/>
+    <member type="way" ref="293019778" role=""/>
+    <member type="way" ref="478328038" role=""/>
+    <member type="way" ref="478326665" role=""/>
+    <member type="way" ref="677761652" role=""/>
+    <member type="way" ref="677761646" role=""/>
+    <member type="way" ref="677761645" role=""/>
+    <member type="way" ref="466648499" role=""/>
+    <member type="way" ref="677761650" role=""/>
+    <member type="way" ref="466652649" role=""/>
+    <member type="way" ref="196715529" role=""/>
+    <member type="way" ref="466652640" role=""/>
+    <member type="way" ref="24228669" role=""/>
+    <member type="way" ref="24228612" role=""/>
+    <member type="way" ref="196715578" role=""/>
+    <member type="way" ref="293034098" role=""/>
+    <member type="way" ref="196715580" role=""/>
+    <tag k="from" v="Дунав станица"/>
+    <tag k="from:sr-Latn" v="Dunav stanica"/>
+    <tag k="lineRef" v="325"/>
+    <tag k="name" v="Е2 Дунав станица - Петлово брдо"/>
+    <tag k="name:sr-Latn" v="E2 Dunav stanica - Petlovo brdo"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="E2"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Петлово брдо"/>
+    <tag k="to:sr-Latn" v="Petlovo brdo"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="7031702" version="77" timestamp="2020-12-19T22:29:00Z" changeset="96123765" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="2053079153" role="platform"/>
+    <member type="node" ref="2053079891" role="platform"/>
+    <member type="node" ref="2053079923" role="platform"/>
+    <member type="node" ref="2053079901" role="platform"/>
+    <member type="node" ref="2053079021" role="platform"/>
+    <member type="node" ref="2053079130" role="platform"/>
+    <member type="node" ref="2053079123" role="platform"/>
+    <member type="node" ref="2053079905" role="platform"/>
+    <member type="node" ref="2053079109" role="platform"/>
+    <member type="node" ref="2053079072" role="platform"/>
+    <member type="node" ref="2053080206" role="platform"/>
+    <member type="node" ref="2053080274" role="platform"/>
+    <member type="node" ref="2053080264" role="platform"/>
+    <member type="node" ref="2051798519" role="platform"/>
+    <member type="node" ref="2066297402" role="platform"/>
+    <member type="node" ref="2059956587" role="platform"/>
+    <member type="node" ref="1331577978" role="platform"/>
+    <member type="node" ref="1808382560" role="platform"/>
+    <member type="node" ref="2059956597" role="platform"/>
+    <member type="node" ref="2053079432" role="platform"/>
+    <member type="node" ref="1685509555" role="platform"/>
+    <member type="node" ref="1541542019" role="platform"/>
+    <member type="node" ref="4682176364" role="platform"/>
+    <member type="node" ref="4715251009" role="platform"/>
+    <member type="node" ref="4682176366" role="platform"/>
+    <member type="node" ref="1800868638" role="platform"/>
+    <member type="node" ref="1800868637" role="platform"/>
+    <member type="node" ref="2903558309" role="platform"/>
+    <member type="node" ref="2903558310" role="platform"/>
+    <member type="node" ref="4685617258" role="platform"/>
+    <member type="node" ref="4327547990" role="platform"/>
+    <member type="node" ref="4327534892" role="platform"/>
+    <member type="node" ref="4327534893" role="platform"/>
+    <member type="node" ref="4685649933" role="platform"/>
+    <member type="node" ref="1803344633" role="platform"/>
+    <member type="node" ref="4682191124" role="platform"/>
+    <member type="node" ref="4682191123" role="platform_exit_only"/>
+    <member type="way" ref="837394711" role=""/>
+    <member type="way" ref="724325318" role=""/>
+    <member type="way" ref="526212742" role=""/>
+    <member type="way" ref="886477465" role=""/>
+    <member type="way" ref="886557594" role=""/>
+    <member type="way" ref="886477461" role=""/>
+    <member type="way" ref="26500484" role=""/>
+    <member type="way" ref="196297256" role=""/>
+    <member type="way" ref="526212739" role=""/>
+    <member type="way" ref="526212735" role=""/>
+    <member type="way" ref="676609957" role=""/>
+    <member type="way" ref="526212731" role=""/>
+    <member type="way" ref="676609956" role=""/>
+    <member type="way" ref="526212727" role=""/>
+    <member type="way" ref="676609955" role=""/>
+    <member type="way" ref="680908044" role=""/>
+    <member type="way" ref="196297263" role=""/>
+    <member type="way" ref="676609954" role=""/>
+    <member type="way" ref="196297285" role=""/>
+    <member type="way" ref="759278518" role=""/>
+    <member type="way" ref="196297286" role=""/>
+    <member type="way" ref="26500476" role=""/>
+    <member type="way" ref="135266851" role=""/>
+    <member type="way" ref="676127239" role=""/>
+    <member type="way" ref="25182084" role=""/>
+    <member type="way" ref="505529645" role=""/>
+    <member type="way" ref="867755713" role=""/>
+    <member type="way" ref="25182083" role=""/>
+    <member type="way" ref="505529804" role=""/>
+    <member type="way" ref="675450849" role=""/>
+    <member type="way" ref="163316445" role=""/>
+    <member type="way" ref="675451975" role=""/>
+    <member type="way" ref="679600750" role=""/>
+    <member type="way" ref="196297289" role=""/>
+    <member type="way" ref="676538486" role=""/>
+    <member type="way" ref="676538485" role=""/>
+    <member type="way" ref="195144169" role=""/>
+    <member type="way" ref="195144173" role=""/>
+    <member type="way" ref="675260093" role=""/>
+    <member type="way" ref="685724188" role=""/>
+    <member type="way" ref="675260095" role=""/>
+    <member type="way" ref="195109737" role=""/>
+    <member type="way" ref="675260094" role=""/>
+    <member type="way" ref="24844511" role=""/>
+    <member type="way" ref="835639937" role=""/>
+    <member type="way" ref="675275513" role=""/>
+    <member type="way" ref="675275514" role=""/>
+    <member type="way" ref="675275515" role=""/>
+    <member type="way" ref="417006296" role=""/>
+    <member type="way" ref="196297234" role=""/>
+    <member type="way" ref="675320912" role=""/>
+    <member type="way" ref="740027655" role=""/>
+    <member type="way" ref="675320911" role=""/>
+    <member type="way" ref="679788255" role=""/>
+    <member type="way" ref="679788256" role=""/>
+    <member type="way" ref="622354859" role=""/>
+    <member type="way" ref="622354840" role=""/>
+    <member type="way" ref="740027654" role=""/>
+    <member type="way" ref="622354855" role=""/>
+    <member type="way" ref="676065810" role=""/>
+    <member type="way" ref="740027653" role=""/>
+    <member type="way" ref="740027652" role=""/>
+    <member type="way" ref="196297237" role=""/>
+    <member type="way" ref="675302536" role=""/>
+    <member type="way" ref="116482670" role=""/>
+    <member type="way" ref="116482674" role=""/>
+    <member type="way" ref="473795254" role=""/>
+    <member type="way" ref="680727271" role=""/>
+    <member type="way" ref="23720049" role=""/>
+    <member type="way" ref="471317420" role=""/>
+    <member type="way" ref="705363889" role=""/>
+    <member type="way" ref="23650408" role=""/>
+    <member type="way" ref="705363890" role=""/>
+    <member type="way" ref="822320892" role=""/>
+    <member type="way" ref="114682422" role=""/>
+    <member type="way" ref="41235874" role=""/>
+    <member type="way" ref="822320897" role=""/>
+    <member type="way" ref="41235877" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23672600" role=""/>
+    <member type="way" ref="23098073" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="676379849" role=""/>
+    <member type="way" ref="23098147" role=""/>
+    <member type="way" ref="289911805" role=""/>
+    <member type="way" ref="478706097" role=""/>
+    <member type="way" ref="839469579" role=""/>
+    <member type="way" ref="80581172" role=""/>
+    <member type="way" ref="839469610" role=""/>
+    <member type="way" ref="676414346" role=""/>
+    <member type="way" ref="839469609" role=""/>
+    <member type="way" ref="676414348" role=""/>
+    <member type="way" ref="676100120" role=""/>
+    <member type="way" ref="839469606" role=""/>
+    <member type="way" ref="839469578" role=""/>
+    <member type="way" ref="23098163" role=""/>
+    <member type="way" ref="839469599" role=""/>
+    <member type="way" ref="839469605" role=""/>
+    <member type="way" ref="839469586" role=""/>
+    <member type="way" ref="839469603" role=""/>
+    <member type="way" ref="676100121" role=""/>
+    <member type="way" ref="839469604" role=""/>
+    <member type="way" ref="697237760" role=""/>
+    <member type="way" ref="676585428" role=""/>
+    <member type="way" ref="178541649" role=""/>
+    <member type="way" ref="23098187" role=""/>
+    <member type="way" ref="56693670" role=""/>
+    <member type="way" ref="56693667" role=""/>
+    <member type="way" ref="289862448" role=""/>
+    <member type="way" ref="701308615" role=""/>
+    <member type="way" ref="701308616" role=""/>
+    <member type="way" ref="706028638" role=""/>
+    <member type="way" ref="706028637" role=""/>
+    <member type="way" ref="706028636" role=""/>
+    <member type="way" ref="706028635" role=""/>
+    <member type="way" ref="706028634" role=""/>
+    <member type="way" ref="289864691" role=""/>
+    <member type="way" ref="706028633" role=""/>
+    <member type="way" ref="677916038" role=""/>
+    <member type="way" ref="677916031" role=""/>
+    <member type="way" ref="677916047" role=""/>
+    <member type="way" ref="706028632" role=""/>
+    <member type="way" ref="706028631" role=""/>
+    <member type="way" ref="676837614" role=""/>
+    <member type="way" ref="676837612" role=""/>
+    <member type="way" ref="289925433" role=""/>
+    <member type="way" ref="676840274" role=""/>
+    <member type="way" ref="725310134" role=""/>
+    <member type="way" ref="677164527" role=""/>
+    <member type="way" ref="704671578" role=""/>
+    <member type="way" ref="677164526" role=""/>
+    <member type="way" ref="104877063" role=""/>
+    <member type="way" ref="198723977" role=""/>
+    <member type="way" ref="677710485" role=""/>
+    <member type="way" ref="676086575" role=""/>
+    <member type="way" ref="751903267" role=""/>
+    <member type="way" ref="104882683" role=""/>
+    <member type="way" ref="208249175" role=""/>
+    <member type="way" ref="677146837" role=""/>
+    <member type="way" ref="677146836" role=""/>
+    <member type="way" ref="25998823" role=""/>
+    <member type="way" ref="676299692" role=""/>
+    <member type="way" ref="679918259" role=""/>
+    <member type="way" ref="195144145" role=""/>
+    <member type="way" ref="406806080" role=""/>
+    <member type="way" ref="871188565" role=""/>
+    <member type="way" ref="727389723" role=""/>
+    <member type="way" ref="195576465" role=""/>
+    <member type="way" ref="169044351" role=""/>
+    <member type="way" ref="195144180" role=""/>
+    <member type="way" ref="489312202" role=""/>
+    <member type="way" ref="195144133" role=""/>
+    <member type="way" ref="45408946" role=""/>
+    <tag k="from" v="Бежанијска коса"/>
+    <tag k="from:sr-Latn" v="Bežanijska kosa"/>
+    <tag k="lineRef" v="327"/>
+    <tag k="name" v="Е4 Бежанијска коса - Миријево 3"/>
+    <tag k="name:sr-Latn" v="E4 Bežanijska kosa - Mirijevo 3"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="E4"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Миријево 3"/>
+    <tag k="to:sr-Latn" v="Mirijevo 3"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="7031794" version="88" timestamp="2021-01-03T20:20:45Z" changeset="96863111" uid="6225925" user="Aleksa Marinski">
+    <member type="node" ref="4682191122" role="platform_entry_only"/>
+    <member type="node" ref="4682191125" role="platform"/>
+    <member type="node" ref="4715415980" role="platform"/>
+    <member type="node" ref="4685649934" role="platform"/>
+    <member type="node" ref="4327534894" role="platform"/>
+    <member type="node" ref="4327547191" role="platform"/>
+    <member type="node" ref="4362537891" role="platform"/>
+    <member type="node" ref="4685617259" role="platform"/>
+    <member type="node" ref="2903558308" role="platform"/>
+    <member type="node" ref="1800868636" role="platform"/>
+    <member type="node" ref="1800868639" role="platform"/>
+    <member type="node" ref="4682176365" role="platform"/>
+    <member type="node" ref="702297257" role="platform"/>
+    <member type="node" ref="4676720720" role="platform"/>
+    <member type="node" ref="8278923906" role="platform"/>
+    <member type="node" ref="1541542031" role="platform"/>
+    <member type="node" ref="1685509556" role="platform"/>
+    <member type="node" ref="2053079440" role="platform"/>
+    <member type="node" ref="1808382562" role="platform"/>
+    <member type="node" ref="1808382559" role="platform"/>
+    <member type="node" ref="1331577993" role="platform"/>
+    <member type="node" ref="2059956590" role="platform"/>
+    <member type="node" ref="2051798518" role="platform"/>
+    <member type="node" ref="2051798520" role="platform"/>
+    <member type="node" ref="2053080257" role="platform"/>
+    <member type="node" ref="2053080279" role="platform"/>
+    <member type="node" ref="2053080196" role="platform"/>
+    <member type="node" ref="2053079087" role="platform"/>
+    <member type="node" ref="2053079102" role="platform"/>
+    <member type="node" ref="2053079117" role="platform"/>
+    <member type="node" ref="2053079136" role="platform"/>
+    <member type="node" ref="2053079013" role="platform"/>
+    <member type="node" ref="2053079896" role="platform"/>
+    <member type="node" ref="2053079918" role="platform"/>
+    <member type="node" ref="2053079870" role="platform"/>
+    <member type="node" ref="2053079153" role="platform_exit_only"/>
+    <member type="way" ref="195144134" role=""/>
+    <member type="way" ref="195144133" role=""/>
+    <member type="way" ref="489312202" role=""/>
+    <member type="way" ref="195144180" role=""/>
+    <member type="way" ref="169044351" role=""/>
+    <member type="way" ref="195576465" role=""/>
+    <member type="way" ref="727389723" role=""/>
+    <member type="way" ref="871188565" role=""/>
+    <member type="way" ref="406806080" role=""/>
+    <member type="way" ref="195144145" role=""/>
+    <member type="way" ref="679918259" role=""/>
+    <member type="way" ref="676299692" role=""/>
+    <member type="way" ref="25998823" role=""/>
+    <member type="way" ref="677146836" role=""/>
+    <member type="way" ref="677146837" role=""/>
+    <member type="way" ref="208249175" role=""/>
+    <member type="way" ref="104882683" role=""/>
+    <member type="way" ref="751903267" role=""/>
+    <member type="way" ref="676086575" role=""/>
+    <member type="way" ref="677710485" role=""/>
+    <member type="way" ref="29052193" role=""/>
+    <member type="way" ref="208249174" role=""/>
+    <member type="way" ref="677103979" role=""/>
+    <member type="way" ref="198723979" role=""/>
+    <member type="way" ref="676841628" role=""/>
+    <member type="way" ref="677103977" role=""/>
+    <member type="way" ref="289926027" role=""/>
+    <member type="way" ref="104877062" role=""/>
+    <member type="way" ref="289925437" role=""/>
+    <member type="way" ref="697240522" role=""/>
+    <member type="way" ref="289925436" role=""/>
+    <member type="way" ref="289866888" role=""/>
+    <member type="way" ref="701307411" role=""/>
+    <member type="way" ref="676602695" role=""/>
+    <member type="way" ref="289866887" role=""/>
+    <member type="way" ref="676602692" role=""/>
+    <member type="way" ref="676602693" role=""/>
+    <member type="way" ref="289866885" role=""/>
+    <member type="way" ref="289866882" role=""/>
+    <member type="way" ref="708515296" role=""/>
+    <member type="way" ref="676647747" role=""/>
+    <member type="way" ref="676602680" role=""/>
+    <member type="way" ref="155396480" role=""/>
+    <member type="way" ref="195576444" role=""/>
+    <member type="way" ref="676603730" role=""/>
+    <member type="way" ref="104879985" role=""/>
+    <member type="way" ref="841047451" role=""/>
+    <member type="way" ref="521052119" role=""/>
+    <member type="way" ref="841045563" role=""/>
+    <member type="way" ref="480092340" role=""/>
+    <member type="way" ref="685870727" role=""/>
+    <member type="way" ref="676656289" role=""/>
+    <member type="way" ref="676611832" role=""/>
+    <member type="way" ref="521052116" role=""/>
+    <member type="way" ref="676414348" role=""/>
+    <member type="way" ref="839469609" role=""/>
+    <member type="way" ref="839469611" role=""/>
+    <member type="way" ref="839469608" role=""/>
+    <member type="way" ref="80581172" role=""/>
+    <member type="way" ref="839469579" role=""/>
+    <member type="way" ref="80581173" role=""/>
+    <member type="way" ref="289911807" role=""/>
+    <member type="way" ref="23098147" role=""/>
+    <member type="way" ref="779973176" role=""/>
+    <member type="way" ref="437717139" role=""/>
+    <member type="way" ref="543848386" role=""/>
+    <member type="way" ref="543848385" role=""/>
+    <member type="way" ref="543846162" role=""/>
+    <member type="way" ref="543848922" role=""/>
+    <member type="way" ref="543848921" role=""/>
+    <member type="way" ref="803340723" role=""/>
+    <member type="way" ref="393522390" role=""/>
+    <member type="way" ref="543849355" role=""/>
+    <member type="way" ref="543849354" role=""/>
+    <member type="way" ref="23098075" role=""/>
+    <member type="way" ref="197158270" role=""/>
+    <member type="way" ref="751959844" role=""/>
+    <member type="way" ref="751959845" role=""/>
+    <member type="way" ref="195576461" role=""/>
+    <member type="way" ref="676637001" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23672662" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="290012969" role=""/>
+    <member type="way" ref="290012968" role=""/>
+    <member type="way" ref="675220726" role=""/>
+    <member type="way" ref="675220727" role=""/>
+    <member type="way" ref="41235876" role=""/>
+    <member type="way" ref="41235875" role=""/>
+    <member type="way" ref="205987189" role=""/>
+    <member type="way" ref="822320893" role=""/>
+    <member type="way" ref="676108741" role=""/>
+    <member type="way" ref="26826000" role=""/>
+    <member type="way" ref="131952994" role=""/>
+    <member type="way" ref="680727272" role=""/>
+    <member type="way" ref="92469728" role=""/>
+    <member type="way" ref="675478314" role=""/>
+    <member type="way" ref="116482680" role=""/>
+    <member type="way" ref="116482672" role=""/>
+    <member type="way" ref="675312233" role=""/>
+    <member type="way" ref="196297236" role=""/>
+    <member type="way" ref="675484789" role=""/>
+    <member type="way" ref="675484790" role=""/>
+    <member type="way" ref="622354847" role=""/>
+    <member type="way" ref="675485549" role=""/>
+    <member type="way" ref="675485546" role=""/>
+    <member type="way" ref="622354851" role=""/>
+    <member type="way" ref="675320913" role=""/>
+    <member type="way" ref="675320914" role=""/>
+    <member type="way" ref="417006301" role=""/>
+    <member type="way" ref="675486047" role=""/>
+    <member type="way" ref="675486046" role=""/>
+    <member type="way" ref="196297235" role=""/>
+    <member type="way" ref="473641212" role=""/>
+    <member type="way" ref="473641214" role=""/>
+    <member type="way" ref="23578167" role=""/>
+    <member type="way" ref="675488303" role=""/>
+    <member type="way" ref="476171277" role=""/>
+    <member type="way" ref="675489764" role=""/>
+    <member type="way" ref="675489761" role=""/>
+    <member type="way" ref="195144168" role=""/>
+    <member type="way" ref="675493531" role=""/>
+    <member type="way" ref="195144184" role=""/>
+    <member type="way" ref="196297289" role=""/>
+    <member type="way" ref="679600750" role=""/>
+    <member type="way" ref="675451975" role=""/>
+    <member type="way" ref="163316445" role=""/>
+    <member type="way" ref="675450849" role=""/>
+    <member type="way" ref="505529804" role=""/>
+    <member type="way" ref="25182083" role=""/>
+    <member type="way" ref="867755713" role=""/>
+    <member type="way" ref="505529645" role=""/>
+    <member type="way" ref="25182084" role=""/>
+    <member type="way" ref="676127239" role=""/>
+    <member type="way" ref="196297211" role=""/>
+    <member type="way" ref="26500474" role=""/>
+    <member type="way" ref="135266850" role=""/>
+    <member type="way" ref="759278519" role=""/>
+    <member type="way" ref="26500477" role=""/>
+    <member type="way" ref="675062364" role=""/>
+    <member type="way" ref="675062363" role=""/>
+    <member type="way" ref="676060302" role=""/>
+    <member type="way" ref="676060301" role=""/>
+    <member type="way" ref="196297284" role=""/>
+    <member type="way" ref="680908040" role=""/>
+    <member type="way" ref="680908054" role=""/>
+    <member type="way" ref="683764093" role=""/>
+    <member type="way" ref="526501645" role=""/>
+    <member type="way" ref="196297262" role=""/>
+    <member type="way" ref="676386556" role=""/>
+    <member type="way" ref="676386555" role=""/>
+    <member type="way" ref="526501647" role=""/>
+    <member type="way" ref="526501648" role=""/>
+    <member type="way" ref="676609958" role=""/>
+    <member type="way" ref="26500472" role=""/>
+    <member type="way" ref="196297256" role=""/>
+    <member type="way" ref="26500484" role=""/>
+    <member type="way" ref="886477461" role=""/>
+    <member type="way" ref="886557594" role=""/>
+    <member type="way" ref="886477465" role=""/>
+    <member type="way" ref="724325319" role=""/>
+    <member type="way" ref="731762309" role=""/>
+    <member type="way" ref="478698739" role=""/>
+    <member type="way" ref="731762308" role=""/>
+    <tag k="from" v="Миријево 3"/>
+    <tag k="from:sr-Latn" v="MIrijevo 3"/>
+    <tag k="lineRef" v="327"/>
+    <tag k="name" v="Е4 Миријево 3 - Бежанијска коса"/>
+    <tag k="name:sr-Latn" v="E4 Mirijevo 3 - Bežanijska kosa"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="E4"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Бежанијска коса"/>
+    <tag k="to:sr-Latn" v="Bežanijska kosa"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="7031937" version="70" timestamp="2021-01-17T01:04:27Z" changeset="97623853" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="1657430216" role="platform_entry_only"/>
+    <member type="node" ref="1657430265" role="platform"/>
+    <member type="node" ref="2053080457" role="platform"/>
+    <member type="node" ref="2053079802" role="platform"/>
+    <member type="node" ref="2053079857" role="platform"/>
+    <member type="node" ref="2053079840" role="platform"/>
+    <member type="node" ref="2053079830" role="platform"/>
+    <member type="node" ref="1974639078" role="platform"/>
+    <member type="node" ref="1974600402" role="platform"/>
+    <member type="node" ref="1974600410" role="platform"/>
+    <member type="node" ref="1974648824" role="platform"/>
+    <member type="node" ref="4715094001" role="platform"/>
+    <member type="node" ref="1583468879" role="platform"/>
+    <member type="node" ref="2053079936" role="platform"/>
+    <member type="node" ref="1937578107" role="platform"/>
+    <member type="node" ref="2066417343" role="platform"/>
+    <member type="node" ref="2053079432" role="platform"/>
+    <member type="node" ref="1685509555" role="platform"/>
+    <member type="node" ref="1618643087" role="platform"/>
+    <member type="node" ref="1618643091" role="platform"/>
+    <member type="node" ref="1618713347" role="platform"/>
+    <member type="node" ref="2055938848" role="platform"/>
+    <member type="node" ref="3849440161" role="platform"/>
+    <member type="node" ref="4687731801" role="platform"/>
+    <member type="node" ref="4687731795" role="platform"/>
+    <member type="node" ref="4687731793" role="platform"/>
+    <member type="node" ref="4687704657" role="platform"/>
+    <member type="node" ref="4327547990" role="platform"/>
+    <member type="node" ref="4327534892" role="platform"/>
+    <member type="node" ref="4327534893" role="platform"/>
+    <member type="node" ref="4685649933" role="platform"/>
+    <member type="node" ref="1803344633" role="platform"/>
+    <member type="node" ref="1803344641" role="platform"/>
+    <member type="node" ref="1803344634" role="platform"/>
+    <member type="node" ref="1802191549" role="platform_exit_only"/>
+    <member type="way" ref="729700731" role=""/>
+    <member type="way" ref="26490975" role=""/>
+    <member type="way" ref="675310346" role=""/>
+    <member type="way" ref="675310347" role=""/>
+    <member type="way" ref="675310348" role=""/>
+    <member type="way" ref="153018113" role=""/>
+    <member type="way" ref="675310343" role=""/>
+    <member type="way" ref="676259783" role=""/>
+    <member type="way" ref="390662124" role=""/>
+    <member type="way" ref="572710743" role=""/>
+    <member type="way" ref="390662218" role=""/>
+    <member type="way" ref="256988635" role=""/>
+    <member type="way" ref="572710746" role=""/>
+    <member type="way" ref="196297254" role=""/>
+    <member type="way" ref="676289832" role=""/>
+    <member type="way" ref="153006231" role=""/>
+    <member type="way" ref="197772495" role=""/>
+    <member type="way" ref="676272235" role=""/>
+    <member type="way" ref="676272234" role=""/>
+    <member type="way" ref="676272233" role=""/>
+    <member type="way" ref="676272231" role=""/>
+    <member type="way" ref="676272232" role=""/>
+    <member type="way" ref="676272230" role=""/>
+    <member type="way" ref="676272229" role=""/>
+    <member type="way" ref="676272227" role=""/>
+    <member type="way" ref="676272226" role=""/>
+    <member type="way" ref="676272225" role=""/>
+    <member type="way" ref="676272224" role=""/>
+    <member type="way" ref="676274842" role=""/>
+    <member type="way" ref="676274838" role=""/>
+    <member type="way" ref="676274835" role=""/>
+    <member type="way" ref="197772496" role=""/>
+    <member type="way" ref="675457758" role=""/>
+    <member type="way" ref="675457754" role=""/>
+    <member type="way" ref="675457768" role=""/>
+    <member type="way" ref="675457751" role=""/>
+    <member type="way" ref="675507991" role=""/>
+    <member type="way" ref="892752497" role=""/>
+    <member type="way" ref="46597342" role=""/>
+    <member type="way" ref="892752496" role=""/>
+    <member type="way" ref="675297513" role=""/>
+    <member type="way" ref="892752495" role=""/>
+    <member type="way" ref="675297512" role=""/>
+    <member type="way" ref="676076690" role=""/>
+    <member type="way" ref="676076686" role=""/>
+    <member type="way" ref="197772508" role=""/>
+    <member type="way" ref="277209204" role=""/>
+    <member type="way" ref="277209203" role=""/>
+    <member type="way" ref="196297219" role=""/>
+    <member type="way" ref="277209200" role=""/>
+    <member type="way" ref="676080627" role=""/>
+    <member type="way" ref="676080628" role=""/>
+    <member type="way" ref="207641661" role=""/>
+    <member type="way" ref="196297218" role=""/>
+    <member type="way" ref="677660165" role=""/>
+    <member type="way" ref="677660164" role=""/>
+    <member type="way" ref="207641662" role=""/>
+    <member type="way" ref="871164281" role=""/>
+    <member type="way" ref="871164280" role=""/>
+    <member type="way" ref="207641657" role=""/>
+    <member type="way" ref="677660680" role=""/>
+    <member type="way" ref="676385934" role=""/>
+    <member type="way" ref="676385935" role=""/>
+    <member type="way" ref="473641216" role=""/>
+    <member type="way" ref="677660928" role=""/>
+    <member type="way" ref="399333134" role=""/>
+    <member type="way" ref="41205061" role=""/>
+    <member type="way" ref="399328394" role=""/>
+    <member type="way" ref="399328399" role=""/>
+    <member type="way" ref="146421255" role=""/>
+    <member type="way" ref="893184449" role=""/>
+    <member type="way" ref="676048304" role=""/>
+    <member type="way" ref="676048303" role=""/>
+    <member type="way" ref="199914550" role=""/>
+    <member type="way" ref="676048302" role=""/>
+    <member type="way" ref="183385951" role=""/>
+    <member type="way" ref="197772505" role=""/>
+    <member type="way" ref="675508842" role=""/>
+    <member type="way" ref="679852335" role=""/>
+    <member type="way" ref="118917604" role=""/>
+    <member type="way" ref="593948548" role=""/>
+    <member type="way" ref="23578267" role=""/>
+    <member type="way" ref="676002071" role=""/>
+    <member type="way" ref="470739714" role=""/>
+    <member type="way" ref="52783876" role=""/>
+    <member type="way" ref="470739711" role=""/>
+    <member type="way" ref="675540194" role=""/>
+    <member type="way" ref="675540193" role=""/>
+    <member type="way" ref="725329129" role=""/>
+    <member type="way" ref="725329128" role=""/>
+    <member type="way" ref="725329127" role=""/>
+    <member type="way" ref="52783877" role=""/>
+    <member type="way" ref="725329126" role=""/>
+    <member type="way" ref="196297264" role=""/>
+    <member type="way" ref="675239061" role=""/>
+    <member type="way" ref="675302535" role=""/>
+    <member type="way" ref="478280129" role=""/>
+    <member type="way" ref="116482674" role=""/>
+    <member type="way" ref="473795254" role=""/>
+    <member type="way" ref="680727271" role=""/>
+    <member type="way" ref="23720049" role=""/>
+    <member type="way" ref="471317420" role=""/>
+    <member type="way" ref="705363889" role=""/>
+    <member type="way" ref="23650408" role=""/>
+    <member type="way" ref="705363890" role=""/>
+    <member type="way" ref="822320892" role=""/>
+    <member type="way" ref="114682422" role=""/>
+    <member type="way" ref="41235874" role=""/>
+    <member type="way" ref="822320897" role=""/>
+    <member type="way" ref="41235877" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="23672600" role=""/>
+    <member type="way" ref="23073170" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="23115379" role=""/>
+    <member type="way" ref="680496364" role=""/>
+    <member type="way" ref="23152150" role=""/>
+    <member type="way" ref="675265859" role=""/>
+    <member type="way" ref="398904906" role=""/>
+    <member type="way" ref="675246023" role=""/>
+    <member type="way" ref="574867476" role=""/>
+    <member type="way" ref="32039299" role=""/>
+    <member type="way" ref="474918017" role=""/>
+    <member type="way" ref="206318276" role=""/>
+    <member type="way" ref="474918016" role=""/>
+    <member type="way" ref="178541647" role=""/>
+    <member type="way" ref="122183518" role=""/>
+    <member type="way" ref="32035225" role=""/>
+    <member type="way" ref="526359483" role=""/>
+    <member type="way" ref="526359482" role=""/>
+    <member type="way" ref="526359481" role=""/>
+    <member type="way" ref="526359480" role=""/>
+    <member type="way" ref="32035247" role=""/>
+    <member type="way" ref="809972497" role=""/>
+    <member type="way" ref="23152737" role=""/>
+    <member type="way" ref="39625718" role=""/>
+    <member type="way" ref="675548491" role=""/>
+    <member type="way" ref="727389723" role=""/>
+    <member type="way" ref="195576465" role=""/>
+    <member type="way" ref="169044351" role=""/>
+    <member type="way" ref="195144180" role=""/>
+    <member type="way" ref="489312202" role=""/>
+    <member type="way" ref="489312203" role=""/>
+    <member type="way" ref="169044341" role=""/>
+    <member type="way" ref="169044353" role=""/>
+    <member type="way" ref="45408947" role=""/>
+    <tag k="from" v="Блок 45"/>
+    <tag k="from:sr-Latn" v="Blok 45"/>
+    <tag k="lineRef" v="331"/>
+    <tag k="name" v="Е6 Блок 45 - Миријево 4"/>
+    <tag k="name:sr-Latn" v="E6 Blok 45 - Mirijevo 4"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="E6"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Миријево 4"/>
+    <tag k="to:sr-Latn" v="MIrijevo 4"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="7031938" version="75" timestamp="2021-01-17T01:04:27Z" changeset="97623853" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="1803254399" role="platform_entry_only"/>
+    <member type="node" ref="1803344637" role="platform"/>
+    <member type="node" ref="1803344642" role="platform"/>
+    <member type="node" ref="4715415980" role="platform"/>
+    <member type="node" ref="4685649934" role="platform"/>
+    <member type="node" ref="4327534894" role="platform"/>
+    <member type="node" ref="4327547191" role="platform"/>
+    <member type="node" ref="4362537891" role="platform"/>
+    <member type="node" ref="4687704658" role="platform"/>
+    <member type="node" ref="4687731792" role="platform"/>
+    <member type="node" ref="4687731794" role="platform"/>
+    <member type="node" ref="4687731800" role="platform"/>
+    <member type="node" ref="3849440160" role="platform"/>
+    <member type="node" ref="2055938849" role="platform"/>
+    <member type="node" ref="2055938851" role="platform"/>
+    <member type="node" ref="1618717623" role="platform"/>
+    <member type="node" ref="1618643103" role="platform"/>
+    <member type="node" ref="1618643110" role="platform"/>
+    <member type="node" ref="1685509556" role="platform"/>
+    <member type="node" ref="2053079440" role="platform"/>
+    <member type="node" ref="2066417344" role="platform"/>
+    <member type="node" ref="2077480553" role="platform"/>
+    <member type="node" ref="1937578108" role="platform"/>
+    <member type="node" ref="2053079947" role="platform"/>
+    <member type="node" ref="2053079291" role="platform"/>
+    <member type="node" ref="4715415981" role="platform"/>
+    <member type="node" ref="1974648828" role="platform"/>
+    <member type="node" ref="1974600414" role="platform"/>
+    <member type="node" ref="1974600406" role="platform"/>
+    <member type="node" ref="2053079505" role="platform"/>
+    <member type="node" ref="2053079819" role="platform"/>
+    <member type="node" ref="2053079849" role="platform"/>
+    <member type="node" ref="2053079863" role="platform"/>
+    <member type="node" ref="2053079810" role="platform"/>
+    <member type="node" ref="2053079321" role="platform"/>
+    <member type="node" ref="1657430273" role="platform"/>
+    <member type="node" ref="1657430204" role="platform_exit_only"/>
+    <member type="way" ref="474215508" role=""/>
+    <member type="way" ref="169044352" role=""/>
+    <member type="way" ref="169044353" role=""/>
+    <member type="way" ref="169044341" role=""/>
+    <member type="way" ref="489312203" role=""/>
+    <member type="way" ref="489312202" role=""/>
+    <member type="way" ref="195144180" role=""/>
+    <member type="way" ref="169044351" role=""/>
+    <member type="way" ref="195576465" role=""/>
+    <member type="way" ref="727389723" role=""/>
+    <member type="way" ref="675548491" role=""/>
+    <member type="way" ref="39625718" role=""/>
+    <member type="way" ref="23152737" role=""/>
+    <member type="way" ref="809972497" role=""/>
+    <member type="way" ref="195576451" role=""/>
+    <member type="way" ref="526359485" role=""/>
+    <member type="way" ref="287873243" role=""/>
+    <member type="way" ref="526359484" role=""/>
+    <member type="way" ref="32035147" role=""/>
+    <member type="way" ref="122183518" role=""/>
+    <member type="way" ref="178541647" role=""/>
+    <member type="way" ref="474918016" role=""/>
+    <member type="way" ref="206318276" role=""/>
+    <member type="way" ref="474918017" role=""/>
+    <member type="way" ref="32039299" role=""/>
+    <member type="way" ref="574867476" role=""/>
+    <member type="way" ref="675246023" role=""/>
+    <member type="way" ref="398904906" role=""/>
+    <member type="way" ref="675265859" role=""/>
+    <member type="way" ref="23152150" role=""/>
+    <member type="way" ref="680496364" role=""/>
+    <member type="way" ref="23115379" role=""/>
+    <member type="way" ref="675234499" role=""/>
+    <member type="way" ref="470685109" role=""/>
+    <member type="way" ref="675546306" role=""/>
+    <member type="way" ref="675559843" role=""/>
+    <member type="way" ref="675559838" role=""/>
+    <member type="way" ref="675546307" role=""/>
+    <member type="way" ref="751971879" role=""/>
+    <member type="way" ref="751971878" role=""/>
+    <member type="way" ref="195576439" role=""/>
+    <member type="way" ref="676065274" role=""/>
+    <member type="way" ref="41202289" role=""/>
+    <member type="way" ref="676065273" role=""/>
+    <member type="way" ref="751970114" role=""/>
+    <member type="way" ref="248716883" role=""/>
+    <member type="way" ref="676333412" role=""/>
+    <member type="way" ref="321357182" role=""/>
+    <member type="way" ref="115801173" role=""/>
+    <member type="way" ref="252557759" role=""/>
+    <member type="way" ref="204028995" role=""/>
+    <member type="way" ref="629807506" role=""/>
+    <member type="way" ref="676333409" role=""/>
+    <member type="way" ref="752738738" role=""/>
+    <member type="way" ref="162614800" role=""/>
+    <member type="way" ref="676055085" role=""/>
+    <member type="way" ref="700249781" role=""/>
+    <member type="way" ref="700249783" role=""/>
+    <member type="way" ref="23428529" role=""/>
+    <member type="way" ref="676637004" role=""/>
+    <member type="way" ref="676637003" role=""/>
+    <member type="way" ref="676637002" role=""/>
+    <member type="way" ref="195576449" role=""/>
+    <member type="way" ref="768573346" role=""/>
+    <member type="way" ref="859599232" role=""/>
+    <member type="way" ref="41202284" role=""/>
+    <member type="way" ref="676068916" role=""/>
+    <member type="way" ref="23672662" role=""/>
+    <member type="way" ref="23672605" role=""/>
+    <member type="way" ref="448103775" role=""/>
+    <member type="way" ref="448103774" role=""/>
+    <member type="way" ref="154244381" role=""/>
+    <member type="way" ref="676843906" role=""/>
+    <member type="way" ref="23712777" role=""/>
+    <member type="way" ref="532823603" role=""/>
+    <member type="way" ref="290014336" role=""/>
+    <member type="way" ref="290012969" role=""/>
+    <member type="way" ref="290012968" role=""/>
+    <member type="way" ref="675220726" role=""/>
+    <member type="way" ref="675220727" role=""/>
+    <member type="way" ref="41235876" role=""/>
+    <member type="way" ref="41235875" role=""/>
+    <member type="way" ref="205987189" role=""/>
+    <member type="way" ref="822320893" role=""/>
+    <member type="way" ref="676108741" role=""/>
+    <member type="way" ref="26826000" role=""/>
+    <member type="way" ref="131952994" role=""/>
+    <member type="way" ref="680727272" role=""/>
+    <member type="way" ref="92469728" role=""/>
+    <member type="way" ref="675478314" role=""/>
+    <member type="way" ref="116482680" role=""/>
+    <member type="way" ref="116482676" role=""/>
+    <member type="way" ref="116482678" role=""/>
+    <member type="way" ref="478280109" role=""/>
+    <member type="way" ref="725329125" role=""/>
+    <member type="way" ref="196603667" role=""/>
+    <member type="way" ref="196297265" role=""/>
+    <member type="way" ref="399336315" role=""/>
+    <member type="way" ref="675540191" role=""/>
+    <member type="way" ref="675540192" role=""/>
+    <member type="way" ref="52783881" role=""/>
+    <member type="way" ref="676004114" role=""/>
+    <member type="way" ref="676004115" role=""/>
+    <member type="way" ref="52783882" role=""/>
+    <member type="way" ref="676000250" role=""/>
+    <member type="way" ref="39621926" role=""/>
+    <member type="way" ref="677670650" role=""/>
+    <member type="way" ref="677670649" role=""/>
+    <member type="way" ref="118917597" role=""/>
+    <member type="way" ref="677670647" role=""/>
+    <member type="way" ref="677670648" role=""/>
+    <member type="way" ref="199914552" role=""/>
+    <member type="way" ref="41205351" role=""/>
+    <member type="way" ref="399333138" role=""/>
+    <member type="way" ref="199914551" role=""/>
+    <member type="way" ref="399333136" role=""/>
+    <member type="way" ref="399333135" role=""/>
+    <member type="way" ref="33455163" role=""/>
+    <member type="way" ref="41205058" role=""/>
+    <member type="way" ref="676385936" role=""/>
+    <member type="way" ref="473641217" role=""/>
+    <member type="way" ref="188128384" role=""/>
+    <member type="way" ref="188128385" role=""/>
+    <member type="way" ref="679869918" role=""/>
+    <member type="way" ref="679500271" role=""/>
+    <member type="way" ref="207641659" role=""/>
+    <member type="way" ref="207641663" role=""/>
+    <member type="way" ref="679869916" role=""/>
+    <member type="way" ref="679869914" role=""/>
+    <member type="way" ref="679869917" role=""/>
+    <member type="way" ref="679869915" role=""/>
+    <member type="way" ref="207641660" role=""/>
+    <member type="way" ref="392951764" role=""/>
+    <member type="way" ref="196297217" role=""/>
+    <member type="way" ref="208996948" role=""/>
+    <member type="way" ref="676076681" role=""/>
+    <member type="way" ref="197772510" role=""/>
+    <member type="way" ref="675297504" role=""/>
+    <member type="way" ref="197772512" role=""/>
+    <member type="way" ref="675290125" role=""/>
+    <member type="way" ref="675290124" role=""/>
+    <member type="way" ref="197772514" role=""/>
+    <member type="way" ref="675285730" role=""/>
+    <member type="way" ref="631673594" role=""/>
+    <member type="way" ref="631673598" role=""/>
+    <member type="way" ref="525991722" role=""/>
+    <member type="way" ref="707887888" role=""/>
+    <member type="way" ref="707887890" role=""/>
+    <member type="way" ref="676134681" role=""/>
+    <member type="way" ref="707887892" role=""/>
+    <member type="way" ref="676134676" role=""/>
+    <member type="way" ref="676134678" role=""/>
+    <member type="way" ref="714750428" role=""/>
+    <member type="way" ref="676134674" role=""/>
+    <member type="way" ref="676134673" role=""/>
+    <member type="way" ref="676134672" role=""/>
+    <member type="way" ref="676134671" role=""/>
+    <member type="way" ref="676134670" role=""/>
+    <member type="way" ref="676134669" role=""/>
+    <member type="way" ref="197772499" role=""/>
+    <member type="way" ref="714750434" role=""/>
+    <member type="way" ref="714750435" role=""/>
+    <member type="way" ref="714750436" role=""/>
+    <member type="way" ref="714750437" role=""/>
+    <member type="way" ref="676134667" role=""/>
+    <member type="way" ref="676134664" role=""/>
+    <member type="way" ref="676134663" role=""/>
+    <member type="way" ref="676134666" role=""/>
+    <member type="way" ref="667928035" role=""/>
+    <member type="way" ref="676289835" role=""/>
+    <member type="way" ref="478712112" role=""/>
+    <member type="way" ref="667635364" role=""/>
+    <member type="way" ref="676289834" role=""/>
+    <member type="way" ref="676266641" role=""/>
+    <member type="way" ref="676266640" role=""/>
+    <member type="way" ref="667929048" role=""/>
+    <member type="way" ref="256988638" role=""/>
+    <member type="way" ref="676265675" role=""/>
+    <member type="way" ref="676562466" role=""/>
+    <member type="way" ref="197772515" role=""/>
+    <member type="way" ref="676259254" role=""/>
+    <member type="way" ref="572710735" role=""/>
+    <member type="way" ref="196297253" role=""/>
+    <member type="way" ref="676569043" role=""/>
+    <member type="way" ref="676569039" role=""/>
+    <member type="way" ref="676569034" role=""/>
+    <member type="way" ref="572710733" role=""/>
+    <member type="way" ref="675310348" role=""/>
+    <member type="way" ref="675310347" role=""/>
+    <member type="way" ref="675310346" role=""/>
+    <member type="way" ref="26490975" role=""/>
+    <member type="way" ref="729700731" role=""/>
+    <tag k="from" v="Миријево 4"/>
+    <tag k="from:sr-Latn" v="Mirijevo 4"/>
+    <tag k="lineRef" v="331"/>
+    <tag k="name" v="Е6 Миријево 4 - Блок 45"/>
+    <tag k="name:sr-Latn" v="E6 Mirijevo 4 - Blok 45"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="E6"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Блок 45"/>
+    <tag k="to:sr-Latn" v="Blok 45"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="8729345" version="3" timestamp="2021-03-05T18:58:37Z" changeset="100510379" uid="733709" user="dizajnmario">
+    <member type="way" ref="514312123" role="outer"/>
+    <member type="way" ref="535364037" role="inner"/>
+    <tag k="area" v="yes"/>
+    <tag k="highway" v="pedestrian"/>
+    <tag k="name" v="Плато Милана Младеновића"/>
+    <tag k="name:sr" v="Плато Милана Младеновића"/>
+    <tag k="name:sr-Latn" v="Plato Milana Mladenovića"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="type" v="multipolygon"/>
+  </relation>
+  <relation id="8811957" version="5" timestamp="2021-03-23T12:52:44Z" changeset="101575695" uid="733709" user="dizajnmario">
+    <member type="way" ref="633746633" role="outer"/>
+    <member type="way" ref="689342984" role="inner"/>
+    <member type="way" ref="633746637" role="inner"/>
+    <member type="way" ref="633746636" role="inner"/>
+    <member type="way" ref="614163757" role="inner"/>
+    <member type="way" ref="614163758" role="inner"/>
+    <member type="way" ref="608463184" role="inner"/>
+    <member type="way" ref="633746634" role="inner"/>
+    <member type="way" ref="633746638" role="inner"/>
+    <member type="way" ref="633746640" role="inner"/>
+    <member type="way" ref="633746639" role="inner"/>
+    <member type="way" ref="633746641" role="inner"/>
+    <member type="way" ref="633746642" role="inner"/>
+    <member type="way" ref="633746644" role="inner"/>
+    <member type="way" ref="633746643" role="inner"/>
+    <member type="way" ref="589643042" role="inner"/>
+    <member type="way" ref="633957046" role="inner"/>
+    <tag k="highway" v="pedestrian"/>
+    <tag k="layer" v="4"/>
+    <tag k="surface" v="paving_stones"/>
+    <tag k="type" v="multipolygon"/>
+  </relation>
+  <relation id="9100144" version="3" timestamp="2021-03-03T19:12:28Z" changeset="100371090" uid="12771584" user="pPetrovic">
+    <member type="way" ref="23067386" role="from"/>
+    <member type="node" ref="6051259898" role="via"/>
+    <member type="way" ref="619005686" role="to"/>
+    <tag k="restriction" v="only_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="9484617" version="1" timestamp="2019-04-14T13:02:12Z" changeset="69201798" uid="6225925" user="Aleksa Marinski">
+    <member type="way" ref="683693009" role="from"/>
+    <member type="node" ref="2934914881" role="via"/>
+    <member type="way" ref="289959028" role="to"/>
+    <tag k="restriction" v="only_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="9494003" version="1" timestamp="2019-04-17T10:59:02Z" changeset="69304639" uid="6225925" user="Aleksa Marinski">
+    <member type="way" ref="619005684" role="from"/>
+    <member type="node" ref="5850035179" role="via"/>
+    <member type="way" ref="619005682" role="to"/>
+    <tag k="restriction" v="only_right_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="9730273" version="1" timestamp="2019-06-28T04:10:54Z" changeset="71692751" uid="893229" user="pule">
+    <member type="way" ref="676637003" role="from"/>
+    <member type="node" ref="249026854" role="via"/>
+    <member type="way" ref="676637003" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="9730274" version="1" timestamp="2019-06-28T04:10:54Z" changeset="71692751" uid="893229" user="pule">
+    <member type="way" ref="676637003" role="from"/>
+    <member type="node" ref="249026854" role="via"/>
+    <member type="way" ref="23073225" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10372710" version="4" timestamp="2020-06-10T15:27:50Z" changeset="86471098" uid="5569366" user="TXBG">
+    <member type="way" ref="768573346" role="from"/>
+    <member type="node" ref="249024039" role="via"/>
+    <member type="way" ref="195576449" role="to"/>
+    <tag k="restriction" v="only_straight_on"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10372799" version="1" timestamp="2019-12-04T20:18:47Z" changeset="77959192" uid="893229" user="pule">
+    <member type="way" ref="619005695" role="from"/>
+    <member type="node" ref="5850036516" role="via"/>
+    <member type="way" ref="684356845" role="to"/>
+    <tag k="restriction" v="only_right_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10372800" version="1" timestamp="2019-12-04T20:18:47Z" changeset="77959192" uid="893229" user="pule">
+    <member type="way" ref="619005688" role="from"/>
+    <member type="way" ref="752824506" role="via"/>
+    <member type="way" ref="752824507" role="to"/>
+    <tag k="restriction" v="only_straight_on"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10372801" version="1" timestamp="2019-12-04T20:18:47Z" changeset="77959192" uid="893229" user="pule">
+    <member type="way" ref="752824507" role="from"/>
+    <member type="node" ref="6522159889" role="via"/>
+    <member type="way" ref="752824507" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10372802" version="1" timestamp="2019-12-04T20:18:47Z" changeset="77959192" uid="893229" user="pule">
+    <member type="way" ref="752824507" role="from"/>
+    <member type="node" ref="6761575689" role="via"/>
+    <member type="way" ref="722621619" role="to"/>
+    <tag k="restriction" v="only_straight_on"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10372805" version="1" timestamp="2019-12-04T20:22:05Z" changeset="77959284" uid="893229" user="pule">
+    <member type="way" ref="720489084" role="from"/>
+    <member type="node" ref="6761575689" role="via"/>
+    <member type="way" ref="752824507" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10372806" version="1" timestamp="2019-12-04T20:22:05Z" changeset="77959284" uid="893229" user="pule">
+    <member type="way" ref="722621619" role="from"/>
+    <member type="node" ref="6761575689" role="via"/>
+    <member type="way" ref="752824507" role="to"/>
+    <tag k="restriction" v="only_straight_on"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10380119" version="2" timestamp="2020-12-29T15:16:28Z" changeset="96611003" uid="6342215" user="strahsek">
+    <member type="way" ref="619005682" role="from"/>
+    <member type="node" ref="5850035179" role="via"/>
+    <member type="way" ref="619005688" role="to"/>
+    <tag k="except" v="psv;taxi"/>
+    <tag k="restriction" v="only_straight_on"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10659070" version="2" timestamp="2020-10-16T08:27:37Z" changeset="92568621" uid="9026132" user="PulisakZ">
+    <member type="node" ref="503894445" role="via"/>
+    <member type="way" ref="41235240" role="to"/>
+    <member type="way" ref="859599232" role="from"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10659071" version="2" timestamp="2020-10-16T08:27:37Z" changeset="92568621" uid="9026132" user="PulisakZ">
+    <member type="node" ref="503894445" role="via"/>
+    <member type="way" ref="859599232" role="from"/>
+    <member type="way" ref="859599232" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10659072" version="1" timestamp="2020-01-31T15:13:04Z" changeset="80381120" uid="893229" user="pule">
+    <member type="way" ref="768573346" role="from"/>
+    <member type="node" ref="503894445" role="via"/>
+    <member type="way" ref="768573346" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="10659073" version="1" timestamp="2020-01-31T15:13:04Z" changeset="80381120" uid="893229" user="pule">
+    <member type="way" ref="41235240" role="from"/>
+    <member type="node" ref="503894445" role="via"/>
+    <member type="way" ref="768573346" role="to"/>
+    <tag k="restriction" v="no_left_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="11286111" version="1" timestamp="2020-07-09T07:32:51Z" changeset="87748342" uid="893229" user="pule">
+    <member type="way" ref="195576449" role="from"/>
+    <member type="node" ref="249024039" role="via"/>
+    <member type="way" ref="768573346" role="to"/>
+    <tag k="restriction" v="only_straight_on"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="11294570" version="1" timestamp="2020-07-12T09:04:42Z" changeset="87871754" uid="893229" user="pule">
+    <member type="way" ref="752824506" role="from"/>
+    <member type="node" ref="6735403188" role="via"/>
+    <member type="way" ref="752824506" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="11336010" version="1" timestamp="2020-07-22T18:46:00Z" changeset="88364283" uid="5569366" user="TXBG">
+    <member type="way" ref="619005688" role="from"/>
+    <member type="node" ref="5850035179" role="via"/>
+    <member type="way" ref="619005684" role="to"/>
+    <tag k="restriction" v="no_right_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="11551338" version="1" timestamp="2020-08-27T14:45:10Z" changeset="90033478" uid="893229" user="pule">
+    <member type="way" ref="41241567" role="from"/>
+    <member type="node" ref="2934914881" role="via"/>
+    <member type="way" ref="41397458" role="to"/>
+    <tag k="restriction" v="no_right_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="11936039" version="1" timestamp="2020-11-24T09:51:26Z" changeset="94695946" uid="893229" user="pule">
+    <member type="way" ref="289959026" role="from"/>
+    <member type="node" ref="6357050689" role="via"/>
+    <member type="way" ref="680974973" role="to"/>
+    <tag k="restriction" v="only_straight_on"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="11936057" version="1" timestamp="2020-11-24T09:53:23Z" changeset="94696092" uid="893229" user="pule">
+    <member type="way" ref="289959030" role="from"/>
+    <member type="node" ref="257726631" role="via"/>
+    <member type="way" ref="289959030" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="11936058" version="1" timestamp="2020-11-24T09:53:23Z" changeset="94696092" uid="893229" user="pule">
+    <member type="way" ref="680974973" role="from"/>
+    <member type="node" ref="257726631" role="via"/>
+    <member type="way" ref="41241567" role="to"/>
+    <tag k="restriction" v="no_u_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="11987662" version="2" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2631228" role=""/>
+    <member type="relation" ref="2631227" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00026"/>
+    <tag k="name" v="26"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="26"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="12003267" version="1" timestamp="2020-12-11T10:43:57Z" changeset="95675352" uid="893229" user="pule">
+    <member type="way" ref="676637001" role="from"/>
+    <member type="node" ref="249024039" role="via"/>
+    <member type="way" ref="195576449" role="to"/>
+    <tag k="restriction" v="only_right_turn"/>
+    <tag k="type" v="restriction"/>
+  </relation>
+  <relation id="12009891" version="2" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2667741" role=""/>
+    <member type="relation" ref="2667742" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00037"/>
+    <tag k="name" v="37"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="37"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="12014198" version="2" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2668874" role=""/>
+    <member type="relation" ref="2668875" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00044"/>
+    <tag k="name" v="44"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="44"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="12037475" version="2" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2643183" role=""/>
+    <member type="relation" ref="2643182" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00058"/>
+    <tag k="name" v="58"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="58"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="12120914" version="2" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2627547" role=""/>
+    <member type="relation" ref="2627546" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="00041"/>
+    <tag k="name" v="41"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="41"/>
+    <tag k="route_master" v="trolleybus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="12120955" version="2" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="2626210" role=""/>
+    <member type="relation" ref="270138" role=""/>
+    <tag k="colour" v="#FF8106"/>
+    <tag k="disused:route_master" v="trolleybus"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="name" v="19"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="19"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="12186833" version="3" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="2165543291" role="platform_entry_only"/>
+    <member type="node" ref="4658236196" role="platform"/>
+    <member type="node" ref="4658245524" role="platform"/>
+    <member type="node" ref="1124739236" role="platform"/>
+    <member type="node" ref="957069819" role="platform_exit_only"/>
+    <member type="way" ref="391815707" role=""/>
+    <member type="way" ref="541623551" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="23786175" role=""/>
+    <member type="way" ref="676885138" role=""/>
+    <member type="way" ref="721794451" role=""/>
+    <member type="way" ref="155396485" role=""/>
+    <member type="way" ref="289959026" role=""/>
+    <member type="way" ref="680974973" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="135929794" role=""/>
+    <member type="way" ref="82203841" role=""/>
+    <member type="way" ref="474193588" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="14:00"/>
+    <tag k="from" v="Трг Славија"/>
+    <tag k="from:sr-Latn" v="Trg Slavija"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="10022"/>
+    <tag k="gtfs:shape_id" v="10022_shape_1"/>
+    <tag k="gtfs:trip_id:sample" v="705222"/>
+    <tag k="interval" v="07:00"/>
+    <tag k="name" v="22A: Трг Славија =&gt; Студентски Трг"/>
+    <tag k="name:sr-Latn" v="22A: Trg Slavija =&gt; Studentski Trg"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="22A"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Студентски Трг"/>
+    <tag k="to:sr-Latn" v="Studentski Trg"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="12186834" version="3" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="node" ref="957069821" role="platform_entry_only"/>
+    <member type="node" ref="4359066192" role="platform"/>
+    <member type="node" ref="4658245523" role="platform"/>
+    <member type="node" ref="2077480521" role="platform"/>
+    <member type="node" ref="2165543108" role="platform_exit_only"/>
+    <member type="way" ref="474193587" role=""/>
+    <member type="way" ref="475958777" role=""/>
+    <member type="way" ref="720375798" role=""/>
+    <member type="way" ref="135929796" role=""/>
+    <member type="way" ref="504436867" role=""/>
+    <member type="way" ref="478112833" role=""/>
+    <member type="way" ref="289959033" role=""/>
+    <member type="way" ref="619005686" role=""/>
+    <member type="way" ref="619005680" role=""/>
+    <member type="way" ref="714776106" role=""/>
+    <member type="way" ref="619005682" role=""/>
+    <member type="way" ref="619005688" role=""/>
+    <member type="way" ref="752824506" role=""/>
+    <member type="way" ref="752824507" role=""/>
+    <member type="way" ref="722621619" role=""/>
+    <member type="way" ref="289959030" role=""/>
+    <member type="way" ref="41241567" role=""/>
+    <member type="way" ref="289959028" role=""/>
+    <member type="way" ref="567949328" role=""/>
+    <member type="way" ref="676859264" role=""/>
+    <member type="way" ref="453603986" role=""/>
+    <member type="way" ref="122976428" role=""/>
+    <member type="way" ref="393250538" role=""/>
+    <member type="way" ref="279935652" role=""/>
+    <member type="way" ref="355758659" role=""/>
+    <member type="way" ref="355758661" role=""/>
+    <member type="way" ref="355758663" role=""/>
+    <member type="way" ref="9473985" role=""/>
+    <member type="way" ref="391815708" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="duration" v="14:00"/>
+    <tag k="from" v="Студентски Трг"/>
+    <tag k="from:sr-Latn" v="Studentski Trg"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="10022"/>
+    <tag k="gtfs:shape_id" v="10022_shape_0"/>
+    <tag k="gtfs:trip_id:sample" v="705226"/>
+    <tag k="interval" v="07:00"/>
+    <tag k="name" v="22A: Студентски Трг =&gt; Трг Славија"/>
+    <tag k="name:sr-Latn" v="22A: Studentski Trg =&gt; Trg Slavija"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="public_transport:version" v="2"/>
+    <tag k="ref" v="22A"/>
+    <tag k="route" v="bus"/>
+    <tag k="to" v="Трг Славија"/>
+    <tag k="to:sr-Latn" v="Trg Slavija"/>
+    <tag k="type" v="route"/>
+  </relation>
+  <relation id="12186835" version="2" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="12186834" role=""/>
+    <member type="relation" ref="12186833" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="10022"/>
+    <tag k="name" v="22A"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="22A"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+  <relation id="12188455" version="2" timestamp="2021-01-26T21:33:19Z" changeset="98184888" uid="95504" user="Branko Kokanovic">
+    <member type="relation" ref="7028697" role=""/>
+    <member type="relation" ref="7028698" role=""/>
+    <tag k="colour" v="#0000FF"/>
+    <tag k="gtfs:agency_id" v="1"/>
+    <tag k="gtfs:agency_name" v="Gradska uprava grada Beograda Sekretarijat za javni prevoz"/>
+    <tag k="gtfs:agency_url" v="http://www.bgprevoz.rs"/>
+    <tag k="gtfs:route_id" v="40101"/>
+    <tag k="name" v="EKO1"/>
+    <tag k="network" v="БГ Превоз"/>
+    <tag k="operator" v="ГСП Београд"/>
+    <tag k="ref" v="EKO1"/>
+    <tag k="route_master" v="bus"/>
+    <tag k="type" v="route_master"/>
+  </relation>
+
+</osm>


### PR DESCRIPTION
Should fix #135

MATSim should depend on a newer geotools version as well (#87, #130) but there's no way to immediately force a version bump.