### PR TITLE
Fix packaging with shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,16 @@
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Either new Java versions check more strictly if signature files fit to the provided jar, or now some dependencies of pt2matsim become signed jars. In any case, the shaded jar was not useable anymore due to signature issues. The provided fix makes sure that the shaded jar can still be used as before.