### PR TITLE
Use MatsimVehicleWriter instead of VehicleWriterV1

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
@@ -517,7 +517,7 @@ public final class ScheduleTools {
 	 */
 	public static void writeVehicles(Vehicles vehicles, String filePath) {
 		log.info("Writing vehicles to file " + filePath);
-		new VehicleWriterV1(vehicles).writeFile(filePath);
+		new MatsimVehicleWriter(vehicles).writeFile(filePath);
 	}
 
 	/**


### PR DESCRIPTION
Hi,

I'd like to use [vehicle definitions v2](http://www.matsim.org/files/dtd/vehicleDefinitions_v2.0.xsd) to specify networkMode in vehicle.xml. VehicleWriterV1 is now marked as deprecated, and it's [recommended](https://github.com/matsim-org/matsim-libs/blob/13.0/matsim/src/main/java/org/matsim/vehicles/VehicleWriterV1.java#L51-L56) to use MatsimVehicleWriter instead of using VehicleWriterV2 directly. 
If no special reason to keep vehicle writer to v1, how about updating it to the latest one?

Thanks.