### PR TITLE
Update to MATSim 13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.matsim</groupId>
             <artifactId>matsim</artifactId>
-            <version>12.0</version>
+            <version>13.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/ArtificialLinkImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/ArtificialLinkImpl.java
@@ -209,4 +209,9 @@ public class ArtificialLinkImpl implements ArtificialLink {
 	public Coord getCoord() {
 		throw new IllegalAccessError();
 	}
+
+	@Override
+	public double getCapacityPeriod()  {
+		throw new IllegalAccessError();
+	}
 }


### PR DESCRIPTION
I'm not quite sure how [versioning is handled](https://github.com/matsim-org/matsim-libs/issues/1813) but I guess it's safe to bump MATSim to 13.0