### PR TITLE
Add network mode to vehicleType

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
@@ -208,6 +208,7 @@ public final class ScheduleTools {
 		vehicleType.setEgressTime(defaultValues.egressTime);
 		vehicleType.setDoorOperationMode(defaultValues.doorOperation);
 		vehicleType.setPcuEquivalents(defaultValues.pcuEquivalents);
+		vehicleType.setNetworkMode(defaultValues.transportMode.name);
 
 		VehicleCapacity capacity = vehicleType.getCapacity();
 		capacity.setSeats(defaultValues.capacitySeats);


### PR DESCRIPTION
I noticed, that the created vehicles missed the networkMode from `VehicleTypeDefaults`.