### PR TITLE
fix exported WTK format

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/osm/LinkGeometryExporter.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/LinkGeometryExporter.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -76,7 +77,7 @@ public class LinkGeometryExporter {
 	private static String toWktLinestring(List<Osm.Node> nodes) {
 		List<String> coords = nodes.stream().map(node -> {
 			Coord coord = node.getCoord();
-			return String.format("%.5f %.5f", coord.getX(), coord.getY());
+			return String.format(Locale.ROOT, "%.5f %.5f", coord.getX(), coord.getY());
 		}).collect(Collectors.toList());
 		return "LINESTRING(" + Joiner.on(',').join(coords) + ")";
 	}


### PR DESCRIPTION
When setting `outputDetailedLinkGeometryFile` to true and using french (fr_FR) Locale, the exported WTK is wrong.
The problem should exist for other than the fr_FR locale that use `,` as their decimal separator in `String.format`

Before patch :
```
LinkId,Geometry
100,"LINESTRING(376532,13825 6682657,98988,376560,14865 6682668,79825,376573,79065 6682673,30999)"
```
After patch : 
```
LinkId,Geometry
100,"LINESTRING(376532.13825 6682657.98988,376560.14865 6682668.79825,376573.79065 6682673.30999)"
```
