### PR TITLE
Explicitly specify Maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,15 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.5.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,9 @@
 
     <properties>
         <geotools.version>24.2</geotools.version>
+        <jackson.version>2.10.3</jackson.version>
+        <jts.version>1.17.1</jts.version>
+        <log4j.version>2.17.1</log4j.version>
     </properties>
 
     <dependencies>
@@ -63,6 +66,26 @@
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
             <version>2.11.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>30.0-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <version>${jts.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,7 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-referencing</artifactId>
-            <version>${geotools.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <artifactId>gt-opengis</artifactId>
             <version>${geotools.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This pr explicitly defines the used dependencies in the pom.xml.

Currently, running `mvn dependency:analyze` shows the following warnings, which can cause issues when using pt2matsim as a dependency.

```log
[WARNING] Used undeclared dependencies found:
[WARNING]    org.geotools:gt-opengis:jar:24.2:compile
[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.10.3:compile
[WARNING]    com.google.guava:guava:jar:30.0-jre:compile
[WARNING]    org.locationtech.jts:jts-core:jar:1.17.1:compile
[WARNING]    org.apache.logging.log4j:log4j-1.2-api:jar:2.17.1:compile
[WARNING] Unused declared dependencies found:
[WARNING]    org.geotools:gt-referencing:jar:24.2:compile
[WARNING]    org.geotools:gt-epsg-hsql:jar:24.2:compile
```