### PR TITLE
Migrate to log4j2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/org/matsim/pt2matsim/editor/BasicScheduleEditor.java
+++ b/src/main/java/org/matsim/pt2matsim/editor/BasicScheduleEditor.java
@@ -23,7 +23,8 @@ import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.exceptions.CsvValidationException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -54,7 +55,7 @@ import java.util.stream.Collectors;
  */
 public class BasicScheduleEditor implements ScheduleEditor {
 
-	protected static Logger log = Logger.getLogger(RunScheduleEditor.class);
+	protected static Logger log = LogManager.getLogger(RunScheduleEditor.class);
 	// fields
 	private final Network network;
 	private final TransitSchedule schedule;

--- a/src/main/java/org/matsim/pt2matsim/editor/RunScheduleEditor.java
+++ b/src/main/java/org/matsim/pt2matsim/editor/RunScheduleEditor.java
@@ -18,8 +18,10 @@
 
 package org.matsim.pt2matsim.editor;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.network.io.NetworkWriter;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
@@ -37,7 +39,7 @@ import java.io.IOException;
  */
 public class RunScheduleEditor {
 
-	protected static Logger log = Logger.getLogger(RunScheduleEditor.class);
+	protected static Logger log = LogManager.getLogger(RunScheduleEditor.class);
 
 	/**
 	 * Loads the schedule and network, then executes all commands in the commands csv file.
@@ -99,17 +101,17 @@ public class RunScheduleEditor {
 	}
 
 	private static void setLogLevels() {
-		Logger.getLogger(org.matsim.core.router.Dijkstra.class).setLevel(Level.ERROR); // suppress no route found warnings
-		Logger.getLogger(Network.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.api.core.v01.network.Node.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.api.core.v01.network.Link.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.utils.io.MatsimXmlParser.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.utils.io.MatsimFileTypeGuesser.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.network.filter.NetworkFilterManager.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.router.util.PreProcessDijkstra.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.router.util.PreProcessDijkstra.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.router.util.PreProcessEuclidean.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.router.util.PreProcessLandmarks.class).setLevel(Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.Dijkstra.class).getName(), Level.ERROR); // suppress no route found warnings
+		Configurator.setLevel(LogManager.getLogger(Network.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.api.core.v01.network.Node.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.api.core.v01.network.Link.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.utils.io.MatsimXmlParser.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.utils.io.MatsimFileTypeGuesser.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.network.filter.NetworkFilterManager.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.util.PreProcessDijkstra.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.util.PreProcessDijkstra.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.util.PreProcessEuclidean.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.util.PreProcessLandmarks.class).getName(), Level.WARN);
 	}
 
 }

--- a/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.gtfs;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.*;
@@ -49,7 +50,7 @@ public class GtfsConverter {
 	public static final String DAY_WITH_MOST_TRIPS = "dayWithMostTrips";
 	public static final String DAY_WITH_MOST_SERVICES = "dayWithMostServices";
 
-	protected static Logger log = Logger.getLogger(GtfsConverter.class);
+	protected static Logger log = LogManager.getLogger(GtfsConverter.class);
 	protected final GtfsFeed feed;
 	protected final TransitScheduleFactory scheduleFactory = ScheduleTools.createSchedule().getFactory();
 

--- a/src/main/java/org/matsim/pt2matsim/gtfs/GtfsFeedImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/GtfsFeedImpl.java
@@ -24,7 +24,8 @@ import com.opencsv.exceptions.CsvValidationException;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 import org.apache.commons.io.input.BOMInputStream;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
@@ -49,7 +50,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class GtfsFeedImpl implements GtfsFeed {
 
-	protected static final Logger log = Logger.getLogger(GtfsFeedImpl.class);
+	protected static final Logger log = LogManager.getLogger(GtfsFeedImpl.class);
 
 	/**
 	 * Path to the folder where the gtfs files are located

--- a/src/main/java/org/matsim/pt2matsim/hafas/HafasConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/HafasConverter.java
@@ -21,7 +21,8 @@
 
 package org.matsim.pt2matsim.hafas;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.collections.MapUtils;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
@@ -51,7 +52,7 @@ import java.util.Set;
  */
 public class HafasConverter {
 
-	protected static Logger log = Logger.getLogger(HafasConverter.class);
+	protected static Logger log = LogManager.getLogger(HafasConverter.class);
 
 	public static void run(String hafasFolder, TransitSchedule schedule, CoordinateTransformation transformation, Vehicles vehicles) throws IOException {
 		run(hafasFolder, schedule, transformation, vehicles, -1);

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/BitfeldAnalyzer.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/BitfeldAnalyzer.java
@@ -21,7 +21,8 @@
 
 package org.matsim.pt2matsim.hafas.lib;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -40,7 +41,7 @@ import java.util.Set;
  * @author boescpa
  */
 public class BitfeldAnalyzer {
-	protected static Logger log = Logger.getLogger(BitfeldAnalyzer.class);
+	protected static Logger log = LogManager.getLogger(BitfeldAnalyzer.class);
 
 	public static Set<Integer> findBitfeldnumbersOfBusiestDay(String FPLAN, String BITFELD) throws IOException {
 		final Set<Integer> bitfeldNummern = new HashSet<>();

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/ECKDATENReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/ECKDATENReader.java
@@ -1,6 +1,7 @@
 package org.matsim.pt2matsim.hafas.lib;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.*;
 import java.time.LocalDate;
@@ -9,7 +10,7 @@ import java.time.format.DateTimeParseException;
 
 public class ECKDATENReader {
 
-    protected static Logger log = Logger.getLogger(ECKDATENReader.class);
+    protected static Logger log = LogManager.getLogger(ECKDATENReader.class);
     private static final String ECKDATEN = "ECKDATEN";
     /*
         1 1−10 CHAR Fahrplanstart im Format TT.MM.JJJJ

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANReader.java
@@ -21,7 +21,8 @@
 
 package org.matsim.pt2matsim.hafas.lib;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.misc.Counter;
 import org.matsim.vehicles.VehicleType;
@@ -41,7 +42,7 @@ import java.util.Set;
  * @author polettif
  */
 public class FPLANReader {
-	protected static Logger log = Logger.getLogger(FPLANReader.class);
+	protected static Logger log = LogManager.getLogger(FPLANReader.class);
 
 	/**
 	 * Only reads the PtRoutes and leaves line/route

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANRoute.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/FPLANRoute.java
@@ -21,7 +21,8 @@
 
 package org.matsim.pt2matsim.hafas.lib;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.pt.transitSchedule.api.*;
 import org.matsim.vehicles.Vehicle;
@@ -37,7 +38,7 @@ import java.util.List;
  */
 public class FPLANRoute {
 
-	private static Logger log = Logger.getLogger(FPLANRoute.class);
+	private static Logger log = LogManager.getLogger(FPLANRoute.class);
 
 	private static TransitSchedule schedule;
 	private static TransitScheduleFactory scheduleFactory;

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/MinimalTransferTimesReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/MinimalTransferTimesReader.java
@@ -1,6 +1,7 @@
 package org.matsim.pt2matsim.hafas.lib;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.pt.transitSchedule.api.MinimalTransferTimes;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
@@ -16,7 +17,7 @@ import java.io.*;
  */
 public class MinimalTransferTimesReader {
 
-    protected static Logger log = Logger.getLogger(MinimalTransferTimesReader.class);
+    protected static Logger log = LogManager.getLogger(MinimalTransferTimesReader.class);
 
     public static void run(TransitSchedule schedule, String pathToHafasFolder, String UMSTEIGB, String METABHF) throws IOException {
 

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/StopReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/StopReader.java
@@ -21,7 +21,8 @@
 
 package org.matsim.pt2matsim.hafas.lib;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
@@ -43,7 +44,7 @@ import java.util.Map;
  * @author boescpa
  */
 public class StopReader {
-	protected static Logger log = Logger.getLogger(StopReader.class);
+	protected static Logger log = LogManager.getLogger(StopReader.class);
 
 	private final CoordinateTransformation transformation;
 	private final TransitSchedule schedule;

--- a/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
@@ -21,7 +21,8 @@
 
 package org.matsim.pt2matsim.mapping;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -66,7 +67,7 @@ import java.util.Set;
  */
 public class PTMapper {
 
-	protected static Logger log = Logger.getLogger(PTMapper.class);
+	protected static Logger log = LogManager.getLogger(PTMapper.class);
 	private final PseudoSchedule pseudoSchedule = new PseudoScheduleImpl();
 	private Network network;
 	private TransitSchedule schedule;

--- a/src/main/java/org/matsim/pt2matsim/mapping/Progress.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/Progress.java
@@ -1,9 +1,10 @@
 package org.matsim.pt2matsim.mapping;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class Progress {
-	private Logger logger = Logger.getLogger(Progress.class);
+	private Logger logger = LogManager.getLogger(Progress.class);
 
 	private final long total;
 	private final String description;

--- a/src/main/java/org/matsim/pt2matsim/mapping/PseudoRoutingImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PseudoRoutingImpl.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.mapping;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.router.util.LeastCostPathCalculator;
@@ -46,7 +47,7 @@ import java.util.Set;
  */
 public class PseudoRoutingImpl implements PseudoRouting {
 
-	protected static Logger log = Logger.getLogger(PseudoRoutingImpl.class);
+	protected static Logger log = LogManager.getLogger(PseudoRoutingImpl.class);
 	private final Progress progress;
 
 	private static boolean warnMinTravelCost = true;

--- a/src/main/java/org/matsim/pt2matsim/mapping/linkCandidateCreation/LinkCandidateCreatorStandard.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/linkCandidateCreation/LinkCandidateCreatorStandard.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.mapping.linkCandidateCreation;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -45,7 +46,7 @@ import java.util.*;
 public class LinkCandidateCreatorStandard implements LinkCandidateCreator {
 
 	private static final Set<String> loopLinkModes = CollectionUtils.stringToSet(PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE + "," + PublicTransitMappingStrings.STOP_FACILITY_LOOP_LINK);
-	protected static Logger log = Logger.getLogger(LinkCandidateCreatorStandard.class);
+	protected static Logger log = LogManager.getLogger(LinkCandidateCreatorStandard.class);
 
 	private final TransitSchedule schedule;
 	private final Network network;

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersGtfsShapes.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersGtfsShapes.java
@@ -1,6 +1,7 @@
 package org.matsim.pt2matsim.mapping.networkRouter;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -38,7 +39,7 @@ import java.util.Set;
  */
 public class ScheduleRoutersGtfsShapes implements ScheduleRouters {
 
-	protected static Logger log = Logger.getLogger(ScheduleRoutersGtfsShapes.class);
+	protected static Logger log = LogManager.getLogger(ScheduleRoutersGtfsShapes.class);
 
 	// standard fields
 	private final TransitSchedule schedule;

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersOsmAttributes.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersOsmAttributes.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.mapping.networkRouter;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -52,7 +53,7 @@ import java.util.Set;
 public class ScheduleRoutersOsmAttributes implements ScheduleRouters {
 
 
-    protected static Logger log = Logger.getLogger(ScheduleRoutersGtfsShapes.class);
+    protected static Logger log = LogManager.getLogger(ScheduleRoutersGtfsShapes.class);
     /**
      * If a link has a route with the same transport mode as the transit route,
      * the link's travel cost is multiplied by this factor.

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
@@ -1,6 +1,7 @@
 package org.matsim.pt2matsim.mapping.networkRouter;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -35,7 +36,7 @@ import java.util.Set;
  */
 public class ScheduleRoutersStandard implements ScheduleRouters {
 
-	protected static Logger log = Logger.getLogger(ScheduleRoutersStandard.class);
+	protected static Logger log = LogManager.getLogger(ScheduleRoutersStandard.class);
 
 	// standard fields
 	private final TransitSchedule schedule;

--- a/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/PseudoGraphImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/PseudoGraphImpl.java
@@ -19,7 +19,8 @@
 
 package org.matsim.pt2matsim.mapping.pseudoRouter;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.utils.geometry.CoordUtils;
@@ -35,7 +36,7 @@ public class PseudoGraphImpl implements PseudoGraph {
 
 	/*package*/ static final String SOURCE = "SOURCE";
 	/*package*/ static final String DESTINATION = "DESTINATION";
-	protected static Logger log = Logger.getLogger(PseudoGraphImpl.class);
+	protected static Logger log = LogManager.getLogger(PseudoGraphImpl.class);
 	private final Id<PseudoRouteStop> SOURCE_ID = Id.create(SOURCE, PseudoRouteStop.class);
 	private final PseudoRouteStop SOURCE_PSEUDO_STOP = new PseudoRouteStopImpl(SOURCE);
 	private final Id<PseudoRouteStop> DESTINATION_ID = Id.create(DESTINATION, PseudoRouteStop.class);

--- a/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/PseudoScheduleImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/PseudoScheduleImpl.java
@@ -25,7 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.pt.transitSchedule.api.MinimalTransferTimes.MinimalTransferTimesIterator;
@@ -66,7 +67,7 @@ public class PseudoScheduleImpl implements PseudoSchedule {
 
 		Map<Id<TransitStopFacility>, Set<Id<TransitStopFacility>>> parentsToChildren = new HashMap<>();
 
-		Logger logger = Logger.getLogger(PseudoScheduleImpl.class);
+		Logger logger = LogManager.getLogger(PseudoScheduleImpl.class);
 
 		int totalNumber = pseudoSchedule.size();
 		int currentNumber = 0;

--- a/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
@@ -21,7 +21,8 @@
 
 package org.matsim.pt2matsim.osm;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
@@ -64,7 +65,7 @@ import java.util.*;
  */
 public class OsmMultimodalNetworkConverter {
 
-	private final static Logger log = Logger.getLogger(OsmMultimodalNetworkConverter.class);
+	private final static Logger log = LogManager.getLogger(OsmMultimodalNetworkConverter.class);
 	
 	static final int SPEED_LIMIT_WALK_KPH = 10;
 	// // no speed limit (Germany) .. assume 200kph

--- a/src/main/java/org/matsim/pt2matsim/osm/OsmTransitScheduleConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/OsmTransitScheduleConverter.java
@@ -19,7 +19,8 @@
 
 package org.matsim.pt2matsim.osm;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -44,7 +45,7 @@ import java.util.*;
  */
 public class OsmTransitScheduleConverter {
 
-	protected static final Logger log = Logger.getLogger(OsmTransitScheduleConverter.class);
+	protected static final Logger log = LogManager.getLogger(OsmTransitScheduleConverter.class);
 
 	protected final OsmData osmData;
 

--- a/src/main/java/org/matsim/pt2matsim/osm/lib/OsmDataImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/lib/OsmDataImpl.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.osm.lib;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.misc.Counter;
 
@@ -29,7 +30,7 @@ import java.util.*;
  */
 public class OsmDataImpl implements OsmData {
 
-	private final static Logger log = Logger.getLogger(OsmData.class);
+	private final static Logger log = LogManager.getLogger(OsmData.class);
 
 	protected final Map<Id<Osm.Node>, Osm.Node> nodes = new HashMap<>();
 	protected final Map<Id<Osm.Way>, Osm.Way> ways = new HashMap<>();

--- a/src/main/java/org/matsim/pt2matsim/plausibility/MappingAnalysis.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/MappingAnalysis.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.plausibility;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -49,7 +50,7 @@ public class MappingAnalysis {
 
 	private static final double MEASURE_INTERVAL = 1;
 
-	private static final Logger log = Logger.getLogger(MappingAnalysis.class);
+	private static final Logger log = LogManager.getLogger(MappingAnalysis.class);
 	private final TransitSchedule schedule;
 	private final Map<Id<RouteShape>, RouteShape> shapes;
 	private final Network network;

--- a/src/main/java/org/matsim/pt2matsim/plausibility/PlausibilityCheck.java
+++ b/src/main/java/org/matsim/pt2matsim/plausibility/PlausibilityCheck.java
@@ -18,8 +18,10 @@
 
 package org.matsim.pt2matsim.plausibility;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.LogManager;
 import org.geojson.Feature;
 import org.geojson.FeatureCollection;
 import org.matsim.api.core.v01.Id;
@@ -63,7 +65,7 @@ import static org.matsim.pt2matsim.tools.ScheduleTools.getTransitRouteLinkIds;
  */
 public class PlausibilityCheck {
 
-	protected static final Logger log = Logger.getLogger(PlausibilityCheck.class);
+	protected static final Logger log = LogManager.getLogger(PlausibilityCheck.class);
 
 	public static final String CsvSeparator = ",";
 
@@ -509,12 +511,12 @@ public class PlausibilityCheck {
 	}
 
 	public static void setLogLevels() {
-		Logger.getLogger(MGC.class).setLevel(Level.ERROR);
-		Logger.getLogger(MatsimFileTypeGuesser.class).setLevel(Level.ERROR);
-		Logger.getLogger(Network.class).setLevel(Level.ERROR);
-		Logger.getLogger(Node.class).setLevel(Level.ERROR);
-		Logger.getLogger(Link.class).setLevel(Level.ERROR);
-		Logger.getLogger(MatsimXmlParser.class).setLevel(Level.ERROR);
+		Configurator.setLevel(LogManager.getLogger(MGC.class).getName(), Level.ERROR);
+		Configurator.setLevel(LogManager.getLogger(MatsimFileTypeGuesser.class).getName(), Level.ERROR);
+		Configurator.setLevel(LogManager.getLogger(Network.class).getName(), Level.ERROR);
+		Configurator.setLevel(LogManager.getLogger(Node.class).getName(), Level.ERROR);
+		Configurator.setLevel(LogManager.getLogger(Link.class).getName(), Level.ERROR);
+		Configurator.setLevel(LogManager.getLogger(MatsimXmlParser.class).getName(), Level.ERROR);
 	}
 
 	public Map<PlausibilityWarning.Type, Set<PlausibilityWarning>> getWarnings() {

--- a/src/main/java/org/matsim/pt2matsim/run/CheckMappedSchedulePlausibility.java
+++ b/src/main/java/org/matsim/pt2matsim/run/CheckMappedSchedulePlausibility.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.run;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.utils.geometry.geotools.MGC;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
@@ -37,7 +38,7 @@ import java.io.File;
  */
 public final class CheckMappedSchedulePlausibility {
 
-	protected static final Logger log = Logger.getLogger(PlausibilityCheck.class);
+	protected static final Logger log = LogManager.getLogger(PlausibilityCheck.class);
 
 	/**
 	 * Performs a plausibility check on the given schedule and network files

--- a/src/main/java/org/matsim/pt2matsim/run/Gtfs2TransitSchedule.java
+++ b/src/main/java/org/matsim/pt2matsim/run/Gtfs2TransitSchedule.java
@@ -18,8 +18,10 @@
 
 package org.matsim.pt2matsim.run;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.core.utils.geometry.geotools.MGC;
 import org.matsim.pt2matsim.gtfs.GtfsConverter;
 import org.matsim.pt2matsim.gtfs.GtfsFeed;
@@ -37,7 +39,7 @@ import static org.matsim.pt2matsim.gtfs.GtfsConverter.*;
  */
 public final class Gtfs2TransitSchedule {
 
-	protected static Logger log = Logger.getLogger(Gtfs2TransitSchedule.class);
+	protected static Logger log = LogManager.getLogger(Gtfs2TransitSchedule.class);
 
 	private Gtfs2TransitSchedule() {
 	}
@@ -92,7 +94,7 @@ public final class Gtfs2TransitSchedule {
 	 * @param vehicleFile               output default vehicles file (optional)
 	 */
 	public static void run(String gtfsFolder, String sampleDayParam, String outputCoordinateSystem, String scheduleFile, String vehicleFile) {
-		Logger.getLogger(MGC.class).setLevel(Level.ERROR);
+		Configurator.setLevel(LogManager.getLogger(MGC.class).getName(), Level.ERROR);
 
 		// check sample day parameter
 		if(!isValidSampleDayParam(sampleDayParam)) {

--- a/src/main/java/org/matsim/pt2matsim/run/PublicTransitMapper.java
+++ b/src/main/java/org/matsim/pt2matsim/run/PublicTransitMapper.java
@@ -21,7 +21,8 @@
 
 package org.matsim.pt2matsim.run;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
@@ -43,7 +44,7 @@ import java.util.Collections;
  */
 public final class PublicTransitMapper {
 
-	protected static Logger log = Logger.getLogger(PublicTransitMapper.class);
+	protected static Logger log = LogManager.getLogger(PublicTransitMapper.class);
 
 	private PublicTransitMapper() {
 	}

--- a/src/main/java/org/matsim/pt2matsim/run/gis/Network2Geojson.java
+++ b/src/main/java/org/matsim/pt2matsim/run/gis/Network2Geojson.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.run.gis;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.geojson.Feature;
 import org.geojson.FeatureCollection;
 import org.matsim.api.core.v01.Coord;
@@ -80,7 +81,7 @@ public class Network2Geojson {
 	}
 
 
-	protected static Logger log = Logger.getLogger(Network2Geojson.class);
+	protected static Logger log = LogManager.getLogger(Network2Geojson.class);
 	private final CoordinateTransformation ct;
 	private Network network;
 	private FeatureCollection linkFeatures = new FeatureCollection();

--- a/src/main/java/org/matsim/pt2matsim/run/gis/Schedule2Geojson.java
+++ b/src/main/java/org/matsim/pt2matsim/run/gis/Schedule2Geojson.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.run.gis;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.geojson.Feature;
 import org.geojson.FeatureCollection;
 import org.matsim.api.core.v01.Coord;
@@ -92,7 +93,7 @@ public class Schedule2Geojson {
 		s2s.writeSchedule(outputFile);
 	}
 
-	private static final Logger log = Logger.getLogger(Schedule2Geojson.class);
+	private static final Logger log = LogManager.getLogger(Schedule2Geojson.class);
 	private final TransitSchedule schedule;
 	private final Network network;
 	private final CoordinateTransformation ct;

--- a/src/main/java/org/matsim/pt2matsim/run/gis/Schedule2ShapeFile.java
+++ b/src/main/java/org/matsim/pt2matsim/run/gis/Schedule2ShapeFile.java
@@ -19,7 +19,8 @@
 package org.matsim.pt2matsim.run.gis;
 
 import org.locationtech.jts.geom.Coordinate;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -43,7 +44,7 @@ import java.util.*;
  */
 public class Schedule2ShapeFile {
 
-	private static final Logger log = Logger.getLogger(Schedule2ShapeFile.class);
+	private static final Logger log = LogManager.getLogger(Schedule2ShapeFile.class);
 	private final TransitSchedule schedule;
 	private final Network network;
 	private final String crs;

--- a/src/main/java/org/matsim/pt2matsim/tools/NetworkTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/NetworkTools.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.tools;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
@@ -54,7 +55,7 @@ import static org.matsim.pt2matsim.tools.ScheduleTools.getTransitRouteLinkIds;
  */
 public final class NetworkTools {
 
-	protected static Logger log = Logger.getLogger(NetworkTools.class);
+	protected static Logger log = LogManager.getLogger(NetworkTools.class);
 
 	private NetworkTools() {}
 

--- a/src/main/java/org/matsim/pt2matsim/tools/PTMapperTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/PTMapperTools.java
@@ -18,8 +18,10 @@
 
 package org.matsim.pt2matsim.tools;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -45,7 +47,7 @@ import java.util.stream.Collectors;
  */
 public final class PTMapperTools {
 
-	protected static Logger log = Logger.getLogger(PTMapperTools.class);
+	protected static Logger log = LogManager.getLogger(PTMapperTools.class);
 
 	private PTMapperTools() {
 	}
@@ -208,13 +210,13 @@ public final class PTMapperTools {
 	}
 
 	public static void setLogLevels() {
-		Logger.getLogger(org.matsim.core.router.Dijkstra.class).setLevel(Level.ERROR); // suppress no route found warnings
-		Logger.getLogger(Network.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.network.filter.NetworkFilterManager.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.router.util.PreProcessDijkstra.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.router.util.PreProcessDijkstra.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.router.util.PreProcessEuclidean.class).setLevel(Level.WARN);
-		Logger.getLogger(org.matsim.core.router.util.PreProcessLandmarks.class).setLevel(Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.Dijkstra.class).getName(), Level.ERROR); // suppress no route found warnings
+		Configurator.setLevel(LogManager.getLogger(Network.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.network.filter.NetworkFilterManager.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.util.PreProcessDijkstra.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.util.PreProcessDijkstra.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.util.PreProcessEuclidean.class).getName(), Level.WARN);
+		Configurator.setLevel(LogManager.getLogger(org.matsim.core.router.util.PreProcessLandmarks.class).getName(), Level.WARN);
 	}
 
 	/**

--- a/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.tools;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
@@ -49,7 +50,7 @@ import static org.matsim.vehicles.VehicleUtils.createVehiclesContainer;
  */
 public final class ScheduleTools {
 
-	protected static Logger log = Logger.getLogger(ScheduleTools.class);
+	protected static Logger log = LogManager.getLogger(ScheduleTools.class);
 
 	private ScheduleTools() {}
 

--- a/src/main/java/org/matsim/pt2matsim/tools/debug/ScheduleCleaner.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/debug/ScheduleCleaner.java
@@ -18,7 +18,8 @@
 
 package org.matsim.pt2matsim.tools.debug;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -47,7 +48,7 @@ import java.util.*;
  */
 public final class ScheduleCleaner {
 
-	protected static Logger log = Logger.getLogger(ScheduleTools.class);
+	protected static Logger log = LogManager.getLogger(ScheduleTools.class);
 
 	private ScheduleCleaner() {}
 


### PR DESCRIPTION
This change migrates pt2matsim from `log4j-1.2-api` to `log4j-api`/`log4j-core`.