### PR TITLE
Bump MATSim from 14.0 to 15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.matsim</groupId>
             <artifactId>matsim</artifactId>
-            <version>14.0</version>
+            <version>15.0-PR2500</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/ArtificialLinkImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/pseudoRouter/ArtificialLinkImpl.java
@@ -26,6 +26,7 @@ import org.matsim.pt2matsim.config.PublicTransitMappingStrings;
 import org.matsim.pt2matsim.mapping.linkCandidateCreation.LinkCandidate;
 import org.matsim.pt2matsim.tools.PTMapperTools;
 import org.matsim.utils.objectattributes.attributable.Attributes;
+import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 
 import java.util.Set;
 
@@ -46,7 +47,7 @@ public class ArtificialLinkImpl implements ArtificialLink {
 	private double capacity = 9999;
 
 	private Set<String> transportModes = PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE_AS_SET;
-	private Attributes attributes = new Attributes();
+	private Attributes attributes = new AttributesImpl();
 
 	public ArtificialLinkImpl(LinkCandidate fromLinkCandidate, LinkCandidate toLinkCandidate, double freespeed, double linkLength) {
 		this.id = PTMapperTools.createArtificialLinkId(fromLinkCandidate, toLinkCandidate);


### PR DESCRIPTION
For now, just 15.0-PR2500, but the 15.0 release is just around the corner.