### PR TITLE
Migrate from JUnit 4 to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <jackson.version>2.14.2</jackson.version>
         <jts.version>1.19.0</jts.version>
         <log4j.version>2.20.0</log4j.version>
+        <junit.version>5.10.2</junit.version>
     </properties>
 
     <dependencies>
@@ -42,9 +43,9 @@
             <version>2024.0</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/matsim/pt2matsim/editor/BasicScheduleEditorTest.java
+++ b/src/test/java/org/matsim/pt2matsim/editor/BasicScheduleEditorTest.java
@@ -1,7 +1,7 @@
 package org.matsim.pt2matsim.editor;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -17,7 +17,7 @@ import static org.matsim.pt2matsim.tools.ScheduleToolsTest.*;
 /**
  * @author polettif
  */
-public class BasicScheduleEditorTest {
+class BasicScheduleEditorTest {
 
 	/**
 	 * Possible Commands:
@@ -25,7 +25,7 @@ public class BasicScheduleEditorTest {
 	 * ["rerouteViaLink"] [TransitLineId] [TransitRouteId] [oldLinkId] [newLinkId]
 	 */
 	@Test
-	public void rerouteViaLink() {
+	void rerouteViaLink() {
 		TransitSchedule schedule = initSchedule();
 		Network network = NetworkToolsTest.initNetwork();
 
@@ -47,7 +47,7 @@ public class BasicScheduleEditorTest {
 		linkIdsExpected.add(Id.createLinkId("ZI"));
 		linkIdsExpected.add(Id.createLinkId("IB"));
 
-		Assert.assertEquals(linkIdsExpected, linkIds);
+		Assertions.assertEquals(linkIdsExpected, linkIds);
 	}
 
 	/**
@@ -57,7 +57,7 @@ public class BasicScheduleEditorTest {
 	 * ["changeRefLink"] ["allTransitRoutesOnLink"] [linkId] [ParentId] [newlinkId]
 	 */
 	@Test
-	public void changeRefLink() {
+	void changeRefLink() {
 		TransitSchedule schedule = initSchedule();
 		Network network = NetworkToolsTest.initNetwork();
 
@@ -79,7 +79,7 @@ public class BasicScheduleEditorTest {
 		linkIdsExpected.add(Id.createLinkId("ZI"));
 		linkIdsExpected.add(Id.createLinkId("IB"));
 
-		Assert.assertEquals(linkIdsExpected, linkIds);
+		Assertions.assertEquals(linkIdsExpected, linkIds);
 	}
 
 }

--- a/src/test/java/org/matsim/pt2matsim/gtfs/GtfsConverterTest.java
+++ b/src/test/java/org/matsim/pt2matsim/gtfs/GtfsConverterTest.java
@@ -1,8 +1,8 @@
 package org.matsim.pt2matsim.gtfs;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
@@ -16,14 +16,14 @@ import java.util.*;
 /**
  * @author polettif
  */
-public class GtfsConverterTest {
+class GtfsConverterTest {
 
 	private GtfsFeed gtfsFeed;
 	private GtfsConverter gtfsConverter;
 	private String coordSystem = TransformationFactory.CH1903_LV03_Plus;
 	private TransitSchedule convertedSchedule;
 
-	@Before
+	@BeforeEach
 	public void convert() {
 		gtfsFeed = new GtfsFeedImpl("test/gtfs-feed/");
 
@@ -32,25 +32,25 @@ public class GtfsConverterTest {
 	}
 
 	@Test
-	public void convertAll() {
+	void convertAll() {
 		TransitSchedule schedule = gtfsConverter.convert(GtfsConverter.ALL_SERVICE_IDS, coordSystem);
-		Assert.assertTrue(TransitScheduleValidator.validateAllStopsExist(schedule).isValid());
-		Assert.assertTrue(TransitScheduleValidator.validateOffsets(schedule).isValid());
+		Assertions.assertTrue(TransitScheduleValidator.validateAllStopsExist(schedule).isValid());
+		Assertions.assertTrue(TransitScheduleValidator.validateOffsets(schedule).isValid());
 	}
 
 	@Test
-	public void numberOfStopsAndRoutes() {
+	void numberOfStopsAndRoutes() {
 		int nTransitRoutes = 0;
 		for(TransitLine transitLine : convertedSchedule.getTransitLines().values()) {
 			nTransitRoutes += transitLine.getRoutes().size();
 		}
-		Assert.assertEquals(6, convertedSchedule.getFacilities().size());
-		Assert.assertEquals(3, convertedSchedule.getTransitLines().size());
-		Assert.assertEquals(3, nTransitRoutes);
+		Assertions.assertEquals(6, convertedSchedule.getFacilities().size());
+		Assertions.assertEquals(3, convertedSchedule.getTransitLines().size());
+		Assertions.assertEquals(3, nTransitRoutes);
 	}
 
 	@Test
-	public void departuresFromFrequencies() {
+	void departuresFromFrequencies() {
 		TransitSchedule baseSchedule = ScheduleToolsTest.initSchedule();
 		for(TransitLine transitLine : convertedSchedule.getTransitLines().values()) {
 			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {
@@ -67,25 +67,25 @@ public class GtfsConverterTest {
 					actualDepTimes.add(departure.getDepartureTime());
 				}
 
-				Assert.assertEquals(expectedDepTimes, actualDepTimes);
+				Assertions.assertEquals(expectedDepTimes, actualDepTimes);
 			}
 		}
 	}
 
 	@Test
-	public void offsets() {
+	void offsets() {
 		TransitSchedule baseSchedule = ScheduleToolsTest.initSchedule();
 		for(TransitLine transitLine : convertedSchedule.getTransitLines().values()) {
 			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {
 				TransitRoute expectedRoute = baseSchedule.getTransitLines().get(transitLine.getId()).getRoutes().get(transitRoute.getId());
-				Assert.assertEquals(expectedRoute.getStops().size(), transitRoute.getStops().size());
+				Assertions.assertEquals(expectedRoute.getStops().size(), transitRoute.getStops().size());
 				for(int i = 0; i < transitRoute.getStops().size() - 1; i++) {
 					if(i > 0) {
-						Assert.assertEquals(expectedRoute.getStops().get(i).getArrivalOffset().seconds(),
+						Assertions.assertEquals(expectedRoute.getStops().get(i).getArrivalOffset().seconds(),
 								transitRoute.getStops().get(i).getArrivalOffset().seconds(), 0.1);
 					}
 					if(i < transitRoute.getStops().size() - 2) {
-						Assert.assertEquals(expectedRoute.getStops().get(i).getDepartureOffset().seconds(),
+						Assertions.assertEquals(expectedRoute.getStops().get(i).getDepartureOffset().seconds(),
 								transitRoute.getStops().get(i).getDepartureOffset().seconds(), 0.1);
 					}
 				}
@@ -94,17 +94,17 @@ public class GtfsConverterTest {
 	}
 
 	@Test
-	public void stops() {
+	void stops() {
 		TransitSchedule baseSchedule = ScheduleToolsTest.initUnmappedSchedule();
 		for(TransitStopFacility actualStopFac : convertedSchedule.getFacilities().values()) {
 			TransitStopFacility expectedStopFac = baseSchedule.getFacilities().get(actualStopFac.getId());
-			Assert.assertEquals(expectedStopFac.getCoord(), actualStopFac.getCoord());
-			Assert.assertEquals(expectedStopFac.getName(), actualStopFac.getName());
+			Assertions.assertEquals(expectedStopFac.getCoord(), actualStopFac.getCoord());
+			Assertions.assertEquals(expectedStopFac.getName(), actualStopFac.getName());
 		}
 	}
 
 	@Test
-	public void combineRoutes() {
+	void combineRoutes() {
 		TransitSchedule test = ScheduleTools.createSchedule();
 		TransitScheduleFactory f = test.getFactory();
 		Id<TransitLine> lineId = Id.create("L", TransitLine.class);
@@ -137,14 +137,14 @@ public class GtfsConverterTest {
 		line.addRoute(route2);
 		line.addRoute(route3);
 
-		Assert.assertEquals(3, line.getRoutes().size());
+		Assertions.assertEquals(3, line.getRoutes().size());
 		// only routes with identical stop sequence (1, 2, 3) and departure sequence (2, 3) are combined.
 		gtfsConverter.combineTransitRoutes(test);
-		Assert.assertEquals(2, line.getRoutes().size());
+		Assertions.assertEquals(2, line.getRoutes().size());
 	}
 
 	@Test
-	public void testTransfers() {
+	void testTransfers() {
 		Set<String> expectedTransferTimes = new TreeSet<>();
 		MinimalTransferTimes.MinimalTransferTimesIterator iter1 = ScheduleToolsTest.initUnmappedSchedule().getMinimalTransferTimes().iterator();
 		while(iter1.hasNext()) {
@@ -159,7 +159,7 @@ public class GtfsConverterTest {
 			actualTransferTime.add(getTransferTimeTestString(iter2));
 		}
 
-		Assert.assertEquals(expectedTransferTimes, actualTransferTime);
+		Assertions.assertEquals(expectedTransferTimes, actualTransferTime);
 	}
 
 	private String getTransferTimeTestString(MinimalTransferTimes.MinimalTransferTimesIterator iterator) {

--- a/src/test/java/org/matsim/pt2matsim/gtfs/GtfsFeedImplTest.java
+++ b/src/test/java/org/matsim/pt2matsim/gtfs/GtfsFeedImplTest.java
@@ -1,8 +1,8 @@
 package org.matsim.pt2matsim.gtfs;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
@@ -23,39 +23,39 @@ import java.util.TreeSet;
 /**
  * @author polettif
  */
-public class GtfsFeedImplTest {
+class GtfsFeedImplTest {
 
 	private GtfsFeed feed;
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		feed = new GtfsFeedImpl("test/gtfs-feed/");
-		Assert.assertEquals(TransformationFactory.WGS84, feed.getCurrentCoordSystem());
+		Assertions.assertEquals(TransformationFactory.WGS84, feed.getCurrentCoordSystem());
 	}
 
 	@Test
-	public void compareShapes() {
+	void compareShapes() {
 		feed.transform(TransformationFactory.CH1903_LV03_Plus);
 		for(Map.Entry<Id<RouteShape>, RouteShape> entry : ShapeToolsTest.initShapes().entrySet()) {
 			RouteShape feedShape = feed.getShapes().get(entry.getKey());
 			for(Map.Entry<Integer, Coord> coordEntry : entry.getValue().getCoordsSorted().entrySet()) {
-				Assert.assertEquals(coordEntry.getValue(), feedShape.getCoordsSorted().get(coordEntry.getKey()));
+				Assertions.assertEquals(coordEntry.getValue(), feedShape.getCoordsSorted().get(coordEntry.getKey()));
 			}
 		}
 	}
 
 	@Test
-	public void statistics() {
-		Assert.assertEquals(6, feed.getStops().size());
-		Assert.assertEquals(3, feed.getRoutes().size());
-		Assert.assertEquals(4, feed.getServices().size());
-		Assert.assertEquals(3, feed.getShapes().size());
-		Assert.assertEquals(6, feed.getTrips().size());
-		Assert.assertEquals(6, feed.getTransfers().size());
+	void statistics() {
+		Assertions.assertEquals(6, feed.getStops().size());
+		Assertions.assertEquals(3, feed.getRoutes().size());
+		Assertions.assertEquals(4, feed.getServices().size());
+		Assertions.assertEquals(3, feed.getShapes().size());
+		Assertions.assertEquals(6, feed.getTrips().size());
+		Assertions.assertEquals(6, feed.getTransfers().size());
 	}
 
 	@Test
-	public void stopsAndCoordsEqualAfterRetransform() {
+	void stopsAndCoordsEqualAfterRetransform() {
 		Map<String, Coord> stopCoords1 = cloneFeedStopCoords(feed);
 
 		// transform
@@ -69,9 +69,9 @@ public class GtfsFeedImplTest {
 		Stop testStop = feed.getStops().values().stream().findFirst().
 				<Stop>map(s -> new StopImpl(s.getId(), s.getName(), s.getLon(), s.getLat(), s.getLocationType(), s.getParentStationId())).
 				orElse(null);
-		Assert.assertNotNull(testStop);
-		Assert.assertEquals(testStop, feed.getStops().get(testStop.getId()));
-		Assert.assertEquals(TransformationFactory.CH1903_LV03_Plus, feed.getCurrentCoordSystem());
+				Assertions.assertNotNull(testStop);
+				Assertions.assertEquals(testStop, feed.getStops().get(testStop.getId()));
+				Assertions.assertEquals(TransformationFactory.CH1903_LV03_Plus, feed.getCurrentCoordSystem());
 
 		// retransform
 		feed.transform(TransformationFactory.WGS84);
@@ -95,40 +95,40 @@ public class GtfsFeedImplTest {
 			Coord compare = entry.getValue();
 
 			if(expectedBool) {
-				Assert.assertEquals(orig.getX(), compare.getX(), delta);
-				Assert.assertEquals(orig.getY(), compare.getY(), delta);
+				Assertions.assertEquals(orig.getX(), compare.getX(), delta);
+				Assertions.assertEquals(orig.getY(), compare.getY(), delta);
 			} else {
-				Assert.assertNotEquals(orig.getX(), compare.getX(), delta);
-				Assert.assertNotEquals(orig.getY(), compare.getY(), delta);
+				Assertions.assertNotEquals(orig.getX(), compare.getX(), delta);
+				Assertions.assertNotEquals(orig.getY(), compare.getY(), delta);
 			}
 		}
 	}
 
 	@Test
-	public void testServices() {
+	void testServices() {
 		Service emptService = feed.getServices().get("EMPT");
-		Assert.assertEquals(1, emptService.getAdditions().size());
-		Assert.assertEquals(1, emptService.getExceptions().size());
-		Assert.assertEquals(LocalDate.of(2018, 10, 2), emptService.getAdditions().first());
-		Assert.assertEquals(LocalDate.of(2018, 10, 1), emptService.getExceptions().first());
-		Assert.assertEquals(LocalDate.of(2018, 10, 7), emptService.getEndDate());
+		Assertions.assertEquals(1, emptService.getAdditions().size());
+		Assertions.assertEquals(1, emptService.getExceptions().size());
+		Assertions.assertEquals(LocalDate.of(2018, 10, 2), emptService.getAdditions().first());
+		Assertions.assertEquals(LocalDate.of(2018, 10, 1), emptService.getExceptions().first());
+		Assertions.assertEquals(LocalDate.of(2018, 10, 7), emptService.getEndDate());
 
 		Set<LocalDate> covered = new TreeSet<>();
 		covered.add(LocalDate.of(2018, 10, 2));
 		covered.add(LocalDate.of(2018, 10, 3));
 		covered.add(LocalDate.of(2018, 10, 4));
 		covered.add(LocalDate.of(2018, 10, 6));
-		Assert.assertEquals(covered, emptService.getCoveredDays());
+		Assertions.assertEquals(covered, emptService.getCoveredDays());
 	}
 
 	@Test
-	public void gtfsShapesGeojson() {
+	void gtfsShapesGeojson() {
 		GtfsTools.writeShapesToGeojson(feed, "test/shapes.geojson");
 		new File("test/shapes.geojson").delete();
 	}
 
 	@Test
-	public void missingCalendar() {
+	void missingCalendar() {
 		new GtfsFeedImpl("test/gtfs-feed-cal/");
 	}
 

--- a/src/test/java/org/matsim/pt2matsim/gtfs/GtfsRealFeedTest.java
+++ b/src/test/java/org/matsim/pt2matsim/gtfs/GtfsRealFeedTest.java
@@ -1,33 +1,33 @@
 package org.matsim.pt2matsim.gtfs;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author polettif
  */
-public class GtfsRealFeedTest {
+class GtfsRealFeedTest {
 
 	private GtfsFeed feed;
 	private GtfsConverter converter;
 
-	@Before
+	@BeforeEach
 	public void loadAndConvert() {
 		feed = new GtfsFeedImpl("test/stib-mivb-gtfs.zip");
 		converter = new GtfsConverter(feed);
 	}
 
 	@Test
-	public void statistics() {
-		Assert.assertEquals(2514, feed.getStops().size());
-		Assert.assertEquals(92, feed.getRoutes().size());
-		Assert.assertEquals(139, feed.getServices().size());
-		Assert.assertEquals(806, feed.getShapes().size());
+	void statistics() {
+		Assertions.assertEquals(2514, feed.getStops().size());
+		Assertions.assertEquals(92, feed.getRoutes().size());
+		Assertions.assertEquals(139, feed.getServices().size());
+		Assertions.assertEquals(806, feed.getShapes().size());
 	}
 
 	@Test
-	public void convert() {
+	void convert() {
 		converter.convert(GtfsConverter.DAY_WITH_MOST_TRIPS, "EPSG:32631");
 	}
 

--- a/src/test/java/org/matsim/pt2matsim/gtfs/SpaceIdTest.java
+++ b/src/test/java/org/matsim/pt2matsim/gtfs/SpaceIdTest.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
@@ -25,8 +25,8 @@ import org.matsim.pt2matsim.tools.ScheduleTools;
 import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.Vehicles;
 
-public class SpaceIdTest {
-	@After
+class SpaceIdTest {
+	@AfterEach
 	public void cleanup() {
 		new File("test_output_schedule.xml").delete();
 	}
@@ -41,7 +41,7 @@ public class SpaceIdTest {
 	 * link IDs that do not have spaces included.
 	 */
 	@Test
-	public void testFeedWithSpacesInId() {
+	void testFeedWithSpacesInId() {
 		GtfsFeed feed = new GtfsFeedImpl("test/space-feed/");
 		GtfsConverter covnerter = new GtfsConverter(feed);
 

--- a/src/test/java/org/matsim/pt2matsim/hafas/HafasConverterTest.java
+++ b/src/test/java/org/matsim/pt2matsim/hafas/HafasConverterTest.java
@@ -1,8 +1,8 @@
 package org.matsim.pt2matsim.hafas;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
@@ -16,12 +16,12 @@ import java.io.IOException;
 /**
  * @author polettif
  */
-public class HafasConverterTest {
+class HafasConverterTest {
 
 	private TransitSchedule schedule;
 	private Vehicles vehicles;
 
-	@Before
+	@BeforeEach
 	public void convert() throws IOException {
 		this.schedule = ScheduleTools.createSchedule();
 		this.vehicles = VehicleUtils.createVehiclesContainer();
@@ -33,21 +33,21 @@ public class HafasConverterTest {
 	}
 
 	@Test
-	public void transitRoutes() {
-		Assert.assertEquals(1, schedule.getTransitLines().size());
+	void transitRoutes() {
+		Assertions.assertEquals(1, schedule.getTransitLines().size());
 
 		int nRoutes = 0;
 		for(TransitLine tl : schedule.getTransitLines().values()) {
-			Assert.assertEquals("BRB", tl.getId().toString());
+			Assertions.assertEquals("BRB", tl.getId().toString());
 			for(TransitRoute tr : tl.getRoutes().values()) {
 				nRoutes++;
 			}
 		}
-		Assert.assertEquals(2, nRoutes);
+		Assertions.assertEquals(2, nRoutes);
 	}
 
 	@Test
-	public void minimalTransferTimes() {
+	void minimalTransferTimes() {
 		int nbMinimalTransferTimes = 0;
 		MinimalTransferTimes transferTimes = schedule.getMinimalTransferTimes();
 		MinimalTransferTimes.MinimalTransferTimesIterator iterator = transferTimes.iterator();
@@ -55,24 +55,24 @@ public class HafasConverterTest {
 			iterator.next();
 			nbMinimalTransferTimes += 1;
 		}
-		Assert.assertEquals(3, nbMinimalTransferTimes);
+		Assertions.assertEquals(3, nbMinimalTransferTimes);
 
-		Assert.assertEquals(5*60.0, transferTimes.get(
+		Assertions.assertEquals(5 * 60.0, transferTimes.get(
 				Id.create("8508350", TransitStopFacility.class),
 				Id.create("8508350", TransitStopFacility.class)), 0.00001);
 
-		Assert.assertEquals(6*60.0, transferTimes.get(
+		Assertions.assertEquals(6 * 60.0, transferTimes.get(
 				Id.create("8508351", TransitStopFacility.class),
 				Id.create("8508351", TransitStopFacility.class)), 0.00001);
 
-		Assert.assertEquals(60*60.0, transferTimes.get(
+		Assertions.assertEquals(60 * 60.0, transferTimes.get(
 				Id.create("8508350", TransitStopFacility.class),
 				Id.create("8508351", TransitStopFacility.class)), 0.00001);
 	}
 
 	@Test
-	public void nStops() {
-		Assert.assertEquals(3, schedule.getFacilities().size());
+	void nStops() {
+		Assertions.assertEquals(3, schedule.getFacilities().size());
 	}
 
 }

--- a/src/test/java/org/matsim/pt2matsim/hafas/HafasFplanTest.java
+++ b/src/test/java/org/matsim/pt2matsim/hafas/HafasFplanTest.java
@@ -1,7 +1,7 @@
 package org.matsim.pt2matsim.hafas;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt2matsim.tools.ScheduleTools;
 import org.matsim.vehicles.VehicleUtils;
@@ -10,9 +10,9 @@ import org.matsim.vehicles.Vehicles;
 import java.io.IOException;
 import java.util.stream.Collectors;
 
-public class HafasFplanTest {
+class HafasFplanTest {
     @Test
-    public void simpleFplanTest() throws IOException {
+	void simpleFplanTest() throws IOException {
 
         String hafasFolder = "test/FPLAN_HAFAS/";
 
@@ -21,10 +21,10 @@ public class HafasFplanTest {
         HafasConverter.run(hafasFolder, schedule, null, vehicles);
 
         int nbRoutes = schedule.getTransitLines().values().stream().flatMap(l -> l.getRoutes().values().stream()).collect(Collectors.toList()).size();
-        Assert.assertEquals(2, nbRoutes);
+		Assertions.assertEquals(2, nbRoutes);
         int nbDeps = schedule.getTransitLines().values().stream().
                 flatMap(l -> l.getRoutes().values().stream().flatMap(r -> r.getDepartures().values().stream())).collect(Collectors.toList()).size();
-        Assert.assertEquals(3, nbDeps);
+		Assertions.assertEquals(3, nbDeps);
 
     }
 }

--- a/src/test/java/org/matsim/pt2matsim/mapping/PTMapperShapesTest.java
+++ b/src/test/java/org/matsim/pt2matsim/mapping/PTMapperShapesTest.java
@@ -1,8 +1,8 @@
 package org.matsim.pt2matsim.mapping;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -29,13 +29,13 @@ import static org.matsim.pt2matsim.mapping.PTMapperTest.initPTMConfig;
 /**
  * @author polettif
  */
-public class PTMapperShapesTest {
+class PTMapperShapesTest {
 
 	public Network network;
 	public TransitSchedule schedule;
 	public PublicTransitMappingConfigGroup ptmConfig;
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		ptmConfig = initPTMConfig();
 		network = NetworkToolsTest.initNetwork();
@@ -50,20 +50,20 @@ public class PTMapperShapesTest {
 	}
 
 	@Test
-	public void validateMappedSchedule() {
-		Assert.assertTrue(TransitScheduleValidator.validateAll(schedule, network).isValid());
+	void validateMappedSchedule() {
+		Assertions.assertTrue(TransitScheduleValidator.validateAll(schedule, network).isValid());
 	}
 
 
 	@Test
-	public void allowedModes() {
+	void allowedModes() {
 		for(Link l : network.getLinks().values()) {
-			Assert.assertFalse(l.getAllowedModes().contains(PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE));
+			Assertions.assertFalse(l.getAllowedModes().contains(PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE));
 		}
 	}
 
 	@Test
-	public void linkSequences() {
+	void linkSequences() {
 		TransitSchedule initSchedule = ScheduleToolsTest.initSchedule();
 
 		for(TransitLine l : schedule.getTransitLines().values()) {
@@ -71,7 +71,7 @@ public class PTMapperShapesTest {
 				TransitRoute initRoute = initSchedule.getTransitLines().get(l.getId()).getRoutes().get(r.getId());
 				List<Id<Link>> initLinkIds = ScheduleTools.getTransitRouteLinkIds(initRoute);
 				List<Id<Link>> linkIds = ScheduleTools.getTransitRouteLinkIds(r);
-				Assert.assertEquals(initLinkIds, linkIds);
+				Assertions.assertEquals(initLinkIds, linkIds);
 			}
 		}
 	}

--- a/src/test/java/org/matsim/pt2matsim/mapping/PTMapperTest.java
+++ b/src/test/java/org/matsim/pt2matsim/mapping/PTMapperTest.java
@@ -1,8 +1,8 @@
 package org.matsim.pt2matsim.mapping;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -46,7 +46,7 @@ public class PTMapperTest {
 		return config;
 	}
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		ptmConfig = initPTMConfig();
 		network = NetworkToolsTest.initNetwork();
@@ -56,25 +56,25 @@ public class PTMapperTest {
 	}
 
 	@Test
-	public void validateMappedSchedule() {
-		Assert.assertTrue(TransitScheduleValidator.validateAll(schedule, network).isValid());
+	void validateMappedSchedule() {
+		Assertions.assertTrue(TransitScheduleValidator.validateAll(schedule, network).isValid());
 	}
 
 
 	@Test
-	public void allowedModes() {
+	void allowedModes() {
 		for(Link l : network.getLinks().values()) {
-			Assert.assertFalse(l.getAllowedModes().contains(PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE));
+			Assertions.assertFalse(l.getAllowedModes().contains(PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE));
 		}
 	}
 
 	@Test
-	public void numberOfStopFacilities() {
-		Assert.assertEquals(10, schedule.getFacilities().size());
+	void numberOfStopFacilities() {
+		Assertions.assertEquals(10, schedule.getFacilities().size());
 	}
 
 	@Test
-	public void linkSequences() {
+	void linkSequences() {
 		TransitSchedule initSchedule = ScheduleToolsTest.initSchedule();
 
 		for(TransitLine l : schedule.getTransitLines().values()) {
@@ -83,14 +83,14 @@ public class PTMapperTest {
 				List<Id<Link>> initLinkIds = ScheduleTools.getTransitRouteLinkIds(initRoute);
 				List<Id<Link>> linkIds = ScheduleTools.getTransitRouteLinkIds(r);
 				if(!r.getId().equals(ROUTE_B)) { // route B cantt be guessed by the mapper because there's not enough information
-					Assert.assertEquals(initLinkIds, linkIds);
+					Assertions.assertEquals(initLinkIds, linkIds);
 				}
 			}
 		}
 	}
 
 	@Test
-	public void artificialLinks() {
+	void artificialLinks() {
 		PublicTransitMappingConfigGroup ptmConfig2 = initPTMConfig();
 		ptmConfig2.setMaxLinkCandidateDistance(3);
 
@@ -99,11 +99,11 @@ public class PTMapperTest {
 		new PTMapper(schedule2, network2).run(ptmConfig2);
 
 		// 1 loop link, 3 artificial links
-		Assert.assertEquals(NetworkToolsTest.initNetwork().getLinks().size()+4, network2.getLinks().size());
-		Assert.assertEquals(9, schedule2.getFacilities().size());
+		Assertions.assertEquals(NetworkToolsTest.initNetwork().getLinks().size() + 4, network2.getLinks().size());
+		Assertions.assertEquals(9, schedule2.getFacilities().size());
 	}
 	@Test
-	public void noTransportModeAssignment() {
+	void noTransportModeAssignment() {
 		PublicTransitMappingConfigGroup noTMAConfig = new PublicTransitMappingConfigGroup();
 		noTMAConfig.getModesToKeepOnCleanUp().add("car");
 		noTMAConfig.setNumOfThreads(2);
@@ -121,18 +121,18 @@ public class PTMapperTest {
 			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {
 				List<Id<Link>> linkIds = ScheduleTools.getTransitRouteLinkIds(transitRoute);
 				for(Id<Link> linkId : linkIds) {
-					Assert.assertTrue(linkId.toString().contains("pt_"));
+					Assertions.assertTrue(linkId.toString().contains("pt_"));
 				}
 			}
 		}
 		// only artificial stop links
 		for(TransitStopFacility transitStopFacility : schedule2.getFacilities().values()) {
-			Assert.assertTrue(transitStopFacility.getLinkId().toString().contains("pt_"));
+			Assertions.assertTrue(transitStopFacility.getLinkId().toString().contains("pt_"));
 		}
 	}
 
 	@Test
-	public void defaultConfig() {
+	void defaultConfig() {
 		CreateDefaultPTMapperConfig.main(new String[]{"doc/defaultPTMapperConfig.xml"});
 	}
 

--- a/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
+++ b/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
@@ -1,16 +1,14 @@
 package org.matsim.pt2matsim.osm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.pt2matsim.config.OsmConverterConfigGroup;
@@ -28,7 +26,7 @@ public class OsmMultimodalNetworkConverterTest {
 	private static Map<Long, Set<Link>> osmid2link;
 	private static final double DELTA = 0.001;
 	
-	@BeforeClass
+	@BeforeAll
 	public static void convertGerasdorfArtificialLanesAndMaxspeed() {
 		// setup config
 		OsmConverterConfigGroup osmConfig = OsmConverterConfigGroup.createDefaultConfig();
@@ -71,41 +69,41 @@ public class OsmMultimodalNetworkConverterTest {
 	}
 	
 	@Test
-	public void testDefaultResidential() {
+	void testDefaultResidential() {
 		Set<Link> links = osmid2link.get(7994891L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertLanes(links, 1);
 		assertMaxspeed("taken from OsmConverterConfigGroup.createDefaultConfig", links, 15);
 	}
 	
 	@Test
-	public void testDefaultPrimary() {
+	void testDefaultPrimary() {
 		Set<Link> links = osmid2link.get(7994890L);
-		assertEquals("bidirectional", 2, links.size()); 
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertLanes("taken from OsmConverterConfigGroup.createDefaultConfig", links, 1);
 		assertMaxspeed("taken from OsmConverterConfigGroup.createDefaultConfig", links, 80);
 	}
 	
 	@Test
-	public void testPrimaryWithLanesAndMaxspeed() {
+	void testPrimaryWithLanesAndMaxspeed() {
 		Set<Link> links = osmid2link.get(7994889L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertLanes(links, 3);
 		assertMaxspeed(links, 70);
 	}
 
 	@Test
-	public void testPrimaryWithOddLanesAndMaxspeed() {
+	void testPrimaryWithOddLanesAndMaxspeed() {
 		Set<Link> links = osmid2link.get(7994888L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertLanes(links, 3.5);
 		assertMaxspeed(links, 70);
 	}
 
 	@Test
-	public void testPrimaryWithForwardAndBackwardLanesAndMaxspeed() {
+	void testPrimaryWithForwardAndBackwardLanesAndMaxspeed() {
 		Set<Link> links = osmid2link.get(7994887L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 
 		Set<Link> linksToNorth = getLinksTowardsNode(links, 59836731L);
 		assertLanes(linksToNorth, 3);
@@ -117,9 +115,9 @@ public class OsmMultimodalNetworkConverterTest {
 	}
 	
 	@Test
-	public void testPrimaryWithForwardAndBackwardSpecialLanesAndMaxspeed() {
+	void testPrimaryWithForwardAndBackwardSpecialLanesAndMaxspeed() {
 		Set<Link> links = osmid2link.get(7994886L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 
 		Set<Link> linksToNorth = getLinksTowardsNode(links, 57443579L);
 		assertLanes("4 minus one bus lane", linksToNorth, 3);
@@ -131,128 +129,129 @@ public class OsmMultimodalNetworkConverterTest {
 	}
 
 	@Test
-	public void testPrimaryWithSpecialLanes() {
+	void testPrimaryWithSpecialLanes() {
 		Set<Link> links = osmid2link.get(7994912L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertLanes("4 per direction minus one taxi lane", links, 3);
 		assertMaxspeed(links, 70);
 	}
 
 	@Test
-	public void testDefaultResidentialOneway() {
+	void testDefaultResidentialOneway() {
 		Set<Link> links = osmid2link.get(7994914L);
-		assertEquals("oneway", 1, links.size());
-		assertEquals("oneway up north", 1, getLinksTowardsNode(links, 59836794L).size());
+		Assertions.assertEquals(1, links.size(), "oneway");
+		Assertions.assertEquals(1, getLinksTowardsNode(links, 59836794L).size(), "oneway up north");
 		assertLanes(links, 1);
 		assertMaxspeed("taken from OsmConverterConfigGroup.createDefaultConfig", links, 15);
 	}
 	
 	@Test
-	public void testResidentialInvalidLanesAndMaxspeed() {
+	void testResidentialInvalidLanesAndMaxspeed() {
 		Set<Link> links = osmid2link.get(7994891L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertLanes("taken from OsmConverterConfigGroup.createDefaultConfig", links, 1);
 		assertMaxspeed("taken from OsmConverterConfigGroup.createDefaultConfig", links, 15);
 	}
 	
 
 	@Test
-	public void testDefaultPrimaryOneway() {
+	void testDefaultPrimaryOneway() {
 		Set<Link> links = osmid2link.get(7994919L);
-		assertEquals("oneway", 1, links.size());
-		assertEquals("oneway up north", 1, getLinksTowardsNode(links, 59836804L).size());
+		Assertions.assertEquals(1, links.size(), "oneway");
+		Assertions.assertEquals(1, getLinksTowardsNode(links, 59836804L).size(), "oneway up north");
 		assertLanes("taken from OsmConverterConfigGroup.createDefaultConfig", links, 1);
 		assertMaxspeed("taken from OsmConverterConfigGroup.createDefaultConfig", links, 80);
 	}
 
 	@Test
-	public void testPrimaryOnewayWithLanesAndMaxspeed() {
+	void testPrimaryOnewayWithLanesAndMaxspeed() {
 		Set<Link> links = osmid2link.get(240536138L);
-		assertEquals("oneway", 1, links.size());
-		assertEquals("oneway up north", 1, getLinksTowardsNode(links, 2482638327L).size());
+		Assertions.assertEquals(1, links.size(), "oneway");
+		Assertions.assertEquals(1, getLinksTowardsNode(links, 2482638327L).size(), "oneway up north");
 		assertLanes(links, 3);
 		assertMaxspeed(links, 70);
 	}
 
 	@Test
-	public void testPrimaryOnewayWithForwardLanesAndMaxspeed() {
+	void testPrimaryOnewayWithForwardLanesAndMaxspeed() {
 		Set<Link> links = osmid2link.get(7994920L);
-		assertEquals("oneway", 1, links.size());
-		assertEquals("oneway up north", 1, getLinksTowardsNode(links, 59836807L).size());
+		Assertions.assertEquals(1, links.size(), "oneway");
+		Assertions.assertEquals(1, getLinksTowardsNode(links, 59836807L).size(), "oneway up north");
 		assertLanes(links, 3);
 		assertMaxspeed(links, 70);
 	}
 
 	@Test
-	public void testPrimaryOnewayWithForwardSpecialLanesAndMaxspeed() {
+	void testPrimaryOnewayWithForwardSpecialLanesAndMaxspeed() {
 		Set<Link> links = osmid2link.get(7994925L);
-		assertEquals("oneway", 1, links.size());
-		assertEquals("oneway up north", 1, getLinksTowardsNode(links, 59836816L).size());
+		Assertions.assertEquals(1, links.size(), "oneway");
+		Assertions.assertEquals(1, getLinksTowardsNode(links, 59836816L).size(), "oneway up north");
 		assertLanes("4 minus one bus lane", links, 3);
 		assertMaxspeed(links, 70);
 	}
 
 	@Test
-	public void testPrimaryOnewayWithSpecialLane() {
+	void testPrimaryOnewayWithSpecialLane() {
 		Set<Link> links = osmid2link.get(7994927L);
-		assertEquals("oneway", 1, links.size());
-		assertEquals("oneway up north", 1, getLinksTowardsNode(links, 59836820L).size());
+		Assertions.assertEquals(1, links.size(), "oneway");
+		Assertions.assertEquals(1, getLinksTowardsNode(links, 59836820L).size(), "oneway up north");
 		assertLanes("4 minus one bus lane", links, 3);
 		assertMaxspeed(links, 70);
 	}
 	
 	@Test
-	public void testPrimaryDefaultReversedOneway() {
+	void testPrimaryDefaultReversedOneway() {
 		Set<Link> links = osmid2link.get(7994930L);
-		assertEquals("oneway", 1, links.size());
-		assertEquals("oneway down south", 1, getLinksTowardsNode(links, 59836834L).size());
+		Assertions.assertEquals(1, links.size(), "oneway");
+		Assertions.assertEquals(1, getLinksTowardsNode(links, 59836834L).size(), "oneway down south");
 		assertLanes(links, 3);
 		assertMaxspeed(links, 70);
 	}
 	
 	@Test
-	public void testMotorwayWithoutMaxspeedAndOneway() {
+	void testMotorwayWithoutMaxspeedAndOneway() {
 		Set<Link> links = osmid2link.get(7994932L);
-		assertEquals("oneway by default - taken from OsmConverterConfigGroup.createDefaultConfig", 1, links.size());
-		assertEquals("oneway up north", 1, getLinksTowardsNode(links, 59836844L).size());
+		Assertions.assertEquals(1, links.size(),
+				"oneway by default - taken from OsmConverterConfigGroup.createDefaultConfig");
+		Assertions.assertEquals(1, getLinksTowardsNode(links, 59836844L).size(), "oneway up north");
 		assertLanes("taken from OsmConverterConfigGroup.createDefaultConfig", links, 2);
 		assertMaxspeed(links, OsmMultimodalNetworkConverter.SPEED_LIMIT_NONE_KPH);
 	}
 	
 	@Test
-	public void testResidentialWithMaxspeedWalk() {
+	void testResidentialWithMaxspeedWalk() {
 		Set<Link> links = osmid2link.get(7994934L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertMaxspeed(links, OsmMultimodalNetworkConverter.SPEED_LIMIT_WALK_KPH);
 	}
 	
 	@Test
-	public void testResidentialWithMaxspeedMiles() {
+	void testResidentialWithMaxspeedMiles() {
 		Set<Link> links = osmid2link.get(7994935L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertMaxspeed(links, 20 * 1.609344);
 	}
 	
 	@Test
-	public void testResidentialWithMaxspeedKnots() {
+	void testResidentialWithMaxspeedKnots() {
 		Set<Link> links = osmid2link.get(7994935L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertMaxspeed(links, 20 * 1.609344);
 	}
 	
 	@Test
-	public void testResidentialMultipleSpeedLimits() {
+	void testResidentialMultipleSpeedLimits() {
 		Set<Link> links = osmid2link.get(7999581L);
-		assertEquals("bidirectional", 2, links.size());
+		Assertions.assertEquals(2, links.size(), "bidirectional");
 		assertMaxspeed("second speed limit is ignored", links, 40);
 	}
 	
 	@Test
-	public void testDeadEndStreetsAreContainedInNetwork() {
-		assertEquals(2, osmid2link.get(22971704L).size());
-		assertEquals(2, osmid2link.get(153227314L).size());
-		assertEquals(2, osmid2link.get(95142433L).size());
-		assertEquals(2, osmid2link.get(95142441L).size());
+	void testDeadEndStreetsAreContainedInNetwork() {
+		Assertions.assertEquals(2, osmid2link.get(22971704L).size());
+		Assertions.assertEquals(2, osmid2link.get(153227314L).size());
+		Assertions.assertEquals(2, osmid2link.get(95142433L).size());
+		Assertions.assertEquals(2, osmid2link.get(95142441L).size());
 	}
 	
 	private static void assertLanes(Set<Link> links, double expectedLanes) {
@@ -260,9 +259,10 @@ public class OsmMultimodalNetworkConverterTest {
 	}
 
 	private static void assertLanes(String message, Set<Link> links, double expectedLanes) {
-		assertFalse("at least one link expected", links.isEmpty());
+		Assertions.assertFalse(links.isEmpty(), "at least one link expected");
 		for (Link link : links) {
-			assertEquals("lanes (in one direction): " + message, expectedLanes, link.getNumberOfLanes(), DELTA);
+			Assertions.assertEquals(expectedLanes, link.getNumberOfLanes(), DELTA,
+					"lanes (in one direction): " + message);
 		}
 	}
 	
@@ -271,14 +271,15 @@ public class OsmMultimodalNetworkConverterTest {
 	}
 
 	private static void assertMaxspeed(String message, Set<Link> links, double expectedFreespeedKph) {
-		assertFalse("at least one link expected", links.isEmpty());
+		Assertions.assertFalse(links.isEmpty(), "at least one link expected");
 		for (Link link : links) {
-			assertEquals("freespeed m/s: message", expectedFreespeedKph / 3.6, link.getFreespeed(), DELTA);
+			Assertions.assertEquals(expectedFreespeedKph / 3.6, link.getFreespeed(), DELTA,
+					"freespeed m/s: " + message);
 		}
 	}
 
 	@Test
-	public void convertWaterlooCityCentre() {
+	void convertWaterlooCityCentre() {
 		// setup config
 		OsmConverterConfigGroup osmConfig = OsmConverterConfigGroup.createDefaultConfig();
 		osmConfig.setOutputCoordinateSystem("WGS84");
@@ -299,7 +300,7 @@ public class OsmMultimodalNetworkConverterTest {
 	}
 
 	@Test
-	public void convertEPSG() {
+	void convertEPSG() {
 		OsmConverterConfigGroup osmConfig = OsmConverterConfigGroup.createDefaultConfig();
 		osmConfig.setOutputCoordinateSystem("EPSG:8682");
 		osmConfig.setOsmFile("test/osm/Belgrade.osm");
@@ -312,7 +313,7 @@ public class OsmMultimodalNetworkConverterTest {
 	}
 
 	@Test
-	public void defaultConfig() {
+	void defaultConfig() {
 		CreateDefaultOsmConfig.main(new String[]{"doc/defaultOsmConfig.xml"});
 	}
 

--- a/src/test/java/org/matsim/pt2matsim/osm/RoutableSubnetworkTest.java
+++ b/src/test/java/org/matsim/pt2matsim/osm/RoutableSubnetworkTest.java
@@ -1,6 +1,7 @@
 package org.matsim.pt2matsim.osm;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.config.ConfigGroup;
@@ -13,15 +14,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-
 /**
  * @author shoerl
  */
-public class RoutableSubnetworkTest {
+class RoutableSubnetworkTest {
 
 	@Test
-	public void customSubnetworks() {
+	void customSubnetworks() {
 		// setup config
 		OsmConverterConfigGroup osmConfig = OsmConverterConfigGroup.createDefaultConfig();
 		osmConfig.setOutputCoordinateSystem("WGS84");
@@ -52,7 +51,7 @@ public class RoutableSubnetworkTest {
 		int carPassengerLinks = countModeLinks(converter.getNetwork(), "car_passenger");
 		
 		// Since some car links are not connected, we expect that there are more (uncleaned) passenger links now
-		assertEquals(carLinks + 8, carPassengerLinks);
+		Assertions.assertEquals(carLinks + 8, carPassengerLinks);
 		
 		// II) Convert with a network layer for car_passenger
 		osmConfig.addParameterSet(new OsmConverterConfigGroup.RoutableSubnetworkParams("car_passenger", Collections.singleton("car")));
@@ -64,7 +63,7 @@ public class RoutableSubnetworkTest {
 		int carPassengerLinks2 = countModeLinks(converter2.getNetwork(), "car_passenger");
 		
 		// Now car_passenger should be cleaned just as car... Thus it should be the same number.
-		assertEquals(carLinks2, carPassengerLinks2);
+		Assertions.assertEquals(carLinks2, carPassengerLinks2);
 	}
 	
 	private static int countModeLinks(Network network, String mode) {

--- a/src/test/java/org/matsim/pt2matsim/osm/lib/AllowedTagsFilterTest.java
+++ b/src/test/java/org/matsim/pt2matsim/osm/lib/AllowedTagsFilterTest.java
@@ -1,8 +1,8 @@
 package org.matsim.pt2matsim.osm.lib;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,7 +10,7 @@ import java.util.Map;
 /**
  * @author polettif
  */
-public class AllowedTagsFilterTest {
+class AllowedTagsFilterTest {
 
 	private AllowedTagsFilter filter1;
 	private AllowedTagsFilter filter2;
@@ -21,7 +21,7 @@ public class AllowedTagsFilterTest {
 	private Osm.Element way22;
 	private Osm.Element node;
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		filter1 = new AllowedTagsFilter();
 		filter1.add(Osm.ElementType.WAY, "key", "value1");
@@ -63,43 +63,43 @@ public class AllowedTagsFilterTest {
 	}
 
 	@Test
-	public void matches() {
-		Assert.assertTrue(filter1.matches(way11));
-		Assert.assertTrue(filter1.matches(way12));
-		Assert.assertTrue(filter1.matches(way21));
-		Assert.assertFalse(filter1.matches(way22));
-		Assert.assertFalse(filter1.matches(node));
+	void matches() {
+		Assertions.assertTrue(filter1.matches(way11));
+		Assertions.assertTrue(filter1.matches(way12));
+		Assertions.assertTrue(filter1.matches(way21));
+		Assertions.assertFalse(filter1.matches(way22));
+		Assertions.assertFalse(filter1.matches(node));
 
-		Assert.assertFalse(filter2.matches(way11));
-		Assert.assertTrue(filter2.matches(way12));
-		Assert.assertTrue(filter2.matches(way21));
-		Assert.assertTrue(filter2.matches(way22));
-		Assert.assertTrue(filter2.matches(node));
+		Assertions.assertFalse(filter2.matches(way11));
+		Assertions.assertTrue(filter2.matches(way12));
+		Assertions.assertTrue(filter2.matches(way21));
+		Assertions.assertTrue(filter2.matches(way22));
+		Assertions.assertTrue(filter2.matches(node));
 
-		Assert.assertTrue(filter3.matches(way11));
-		Assert.assertTrue(filter3.matches(way12));
-		Assert.assertFalse(filter3.matches(way21));
-		Assert.assertFalse(filter3.matches(way22));
+		Assertions.assertTrue(filter3.matches(way11));
+		Assertions.assertTrue(filter3.matches(way12));
+		Assertions.assertFalse(filter3.matches(way21));
+		Assertions.assertFalse(filter3.matches(way22));
 	}
 
 	@Test
-	public void mergeFilter() {
+	void mergeFilter() {
 		AllowedTagsFilter merged12 = new AllowedTagsFilter();
 		merged12.mergeFilter(filter1);
 		merged12.mergeFilter(filter2);
-		Assert.assertTrue(merged12.matches(way11));
-		Assert.assertTrue(merged12.matches(way12));
-		Assert.assertTrue(merged12.matches(way21));
-		Assert.assertTrue(merged12.matches(way22));
+		Assertions.assertTrue(merged12.matches(way11));
+		Assertions.assertTrue(merged12.matches(way12));
+		Assertions.assertTrue(merged12.matches(way21));
+		Assertions.assertTrue(merged12.matches(way22));
 
 		AllowedTagsFilter merged123 = new AllowedTagsFilter();
 		merged123.mergeFilter(filter1);
 		merged123.mergeFilter(filter2);
 		merged123.mergeFilter(filter3);
-		Assert.assertTrue(merged123.matches(way11));
-		Assert.assertTrue(merged123.matches(way12));
-		Assert.assertFalse(merged123.matches(way21));
-		Assert.assertFalse(merged123.matches(way22));
+		Assertions.assertTrue(merged123.matches(way11));
+		Assertions.assertTrue(merged123.matches(way12));
+		Assertions.assertFalse(merged123.matches(way21));
+		Assertions.assertFalse(merged123.matches(way22));
 	}
 
 }

--- a/src/test/java/org/matsim/pt2matsim/plausibility/MappingAnalysisTest.java
+++ b/src/test/java/org/matsim/pt2matsim/plausibility/MappingAnalysisTest.java
@@ -1,8 +1,8 @@
 package org.matsim.pt2matsim.plausibility;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.pt.transitSchedule.api.TransitLine;
@@ -22,7 +22,7 @@ import java.util.TreeMap;
 /**
  * @author polettif
  */
-public class MappingAnalysisTest {
+class MappingAnalysisTest {
 
 	private MappingAnalysis analysis;
 	private Id<TransitLine> lineA = Id.create("lineA", TransitLine.class);
@@ -31,7 +31,7 @@ public class MappingAnalysisTest {
 	private Id<TransitRoute> routeA2 = Id.create("routeA2", TransitRoute.class);
 	private Id<TransitRoute> routeB = Id.create("routeB", TransitRoute.class);
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		PublicTransitMappingConfigGroup ptmConfig = PTMapperTest.initPTMConfig();
 		Network network = NetworkToolsTest.initNetwork();
@@ -45,21 +45,21 @@ public class MappingAnalysisTest {
 	}
 
 	@Test
-	public void quantiles() {
-		Assert.assertEquals(7, analysis.getQ8585(), 0.001);
+	void quantiles() {
+		Assertions.assertEquals(7, analysis.getQ8585(), 0.001);
 
 		TreeMap<Integer, Double> quantilesA1 = analysis.getQuantiles(lineA, routeA1);
-		Assert.assertEquals(0.0, quantilesA1.get(0), 0.001);
+		Assertions.assertEquals(0.0, quantilesA1.get(0), 0.001);
 
 		TreeMap<Integer, Double> quantilesA2 = analysis.getQuantiles(lineA, routeA2);
-		Assert.assertEquals(ShapeToolsTest.offset, quantilesA2.get(50), 0.001);
+		Assertions.assertEquals(ShapeToolsTest.offset, quantilesA2.get(50), 0.001);
 
 		TreeMap<Integer, Double> quantilesB = analysis.getQuantiles(lineB, routeB);
-		Assert.assertEquals(0.0, quantilesB.get(0), 0.001);
+		Assertions.assertEquals(0.0, quantilesB.get(0), 0.001);
 	}
 
 	@Test
-	public void lengthRatios() {
+	void lengthRatios() {
 		analysis.getLengthRatio(lineA, routeA1);
 	}
 }

--- a/src/test/java/org/matsim/pt2matsim/plausibility/PlausibilityCheckTest.java
+++ b/src/test/java/org/matsim/pt2matsim/plausibility/PlausibilityCheckTest.java
@@ -1,10 +1,9 @@
 package org.matsim.pt2matsim.plausibility;
 
-import org.locationtech.jts.util.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt2matsim.plausibility.log.PlausibilityWarning;
@@ -15,23 +14,24 @@ import org.matsim.pt2matsim.tools.ScheduleTools;
 import org.matsim.pt2matsim.tools.ScheduleToolsTest;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
 /**
  * @author polettif
  */
-public class PlausibilityCheckTest {
+class PlausibilityCheckTest {
 
-	@Rule
-	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@TempDir
+	public Path temporaryFolder;
 
 	private String testDir;
 	private PlausibilityCheck check;
 
-	@Before
+	@BeforeEach
 	public void prepare() {
-		testDir = temporaryFolder.getRoot().toString();
+		testDir = temporaryFolder.toString();
 
 		TransitSchedule s = ScheduleToolsTest.initSchedule();
 		Network n = NetworkToolsTest.initNetwork();
@@ -43,22 +43,22 @@ public class PlausibilityCheckTest {
 	}
 
 	@Test
-	public void checks() {
+	void checks() {
 		Map<PlausibilityWarning.Type, Set<PlausibilityWarning>> warnings = check.getWarnings();
-		Assert.equals(0, warnings.get(PlausibilityWarning.Type.ArtificialLinkWarning).size());
-		Assert.equals(0, warnings.get(PlausibilityWarning.Type.LoopWarning).size());
-		Assert.equals(4, warnings.get(PlausibilityWarning.Type.DirectionChangeWarning).size());
-		Assert.equals(0, warnings.get(PlausibilityWarning.Type.TravelTimeWarning).size());
+		Assertions.assertEquals(0, warnings.get(PlausibilityWarning.Type.ArtificialLinkWarning).size());
+		Assertions.assertEquals(0, warnings.get(PlausibilityWarning.Type.LoopWarning).size());
+		Assertions.assertEquals(4, warnings.get(PlausibilityWarning.Type.DirectionChangeWarning).size());
+		Assertions.assertEquals(0, warnings.get(PlausibilityWarning.Type.TravelTimeWarning).size());
 	}
 
 	@Test
-	public void writeGeojson() {
+	void writeGeojson() {
 		check.writeResultsGeojson(testDir + "plausibility.geojson");
 		new File(testDir + "plausibility.geojson").delete();
 	}
 
 	@Test
-	public void staticRun() {
+	void staticRun() {
 		String scheduleFile = testDir + "testSchedule.xml";
 		String networkFile = testDir + "testNetwork.xml";
 		String outputfolder = testDir + "plausibility/";

--- a/src/test/java/org/matsim/pt2matsim/run/gis/Network2GeojsonTest.java
+++ b/src/test/java/org/matsim/pt2matsim/run/gis/Network2GeojsonTest.java
@@ -1,7 +1,7 @@
 package org.matsim.pt2matsim.run.gis;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
 import org.matsim.pt2matsim.tools.NetworkToolsTest;
@@ -11,17 +11,17 @@ import java.io.File;
 /**
  * @author polettif
  */
-public class Network2GeojsonTest {
+class Network2GeojsonTest {
 
 	private Network network;
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		this.network = NetworkToolsTest.initNetwork();
 	}
 
 	@Test
-	public void run() {
+	void run() {
 		Network2Geojson.run(TransformationFactory.CH1903_LV03_Plus, network, "test/nodes.geojson", "test/links.geojson");
 		new File("test/nodes.geojson").delete();
 		new File("test/links.geojson").delete();

--- a/src/test/java/org/matsim/pt2matsim/run/gis/Schedule2GeojsonTest.java
+++ b/src/test/java/org/matsim/pt2matsim/run/gis/Schedule2GeojsonTest.java
@@ -1,7 +1,7 @@
 package org.matsim.pt2matsim.run.gis;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
@@ -13,19 +13,19 @@ import java.io.File;
 /**
  * @author polettif
  */
-public class Schedule2GeojsonTest {
+class Schedule2GeojsonTest {
 
 	private TransitSchedule schedule;
 	private Network network;
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		this.schedule = ScheduleToolsTest.initSchedule();
 		this.network = NetworkToolsTest.initNetwork();
 	}
 
 	@Test
-	public void run() {
+	void run() {
 		Schedule2Geojson.run(TransformationFactory.CH1903_LV03_Plus, this.schedule, this.network, "test/schedule.geojson");
 		new File("test/schedule.geojson").delete();
 	}

--- a/src/test/java/org/matsim/pt2matsim/tools/CoordToolsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/tools/CoordToolsTest.java
@@ -1,14 +1,12 @@
 package org.matsim.pt2matsim.tools;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.core.utils.geometry.CoordUtils;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author polettif
@@ -57,29 +55,29 @@ public class CoordToolsTest {
 	 */
 
 	@Test
-	public void getAzimuth() {
-		assertEquals(0,   200* CoordTools.getAzimuth(coordA,coordD)/Math.PI, testDelta);
-		assertEquals(50,  200* CoordTools.getAzimuth(coordA,coordC)/Math.PI, testDelta);
-		assertEquals(100, 200* CoordTools.getAzimuth(coordA,coordB)/Math.PI, testDelta);
-		assertEquals(150, 200* CoordTools.getAzimuth(coordA,coordI)/Math.PI, testDelta);
-		assertEquals(200, 200* CoordTools.getAzimuth(coordA,coordH)/Math.PI, testDelta);
-		assertEquals(250, 200* CoordTools.getAzimuth(coordA,coordG)/Math.PI, testDelta);
-		assertEquals(300, 200* CoordTools.getAzimuth(coordA,coordF)/Math.PI, testDelta);
-		assertEquals(350, 200* CoordTools.getAzimuth(coordA,coordE)/Math.PI, testDelta);
+	void getAzimuth() {
+		Assertions.assertEquals(0, 200 * CoordTools.getAzimuth(coordA, coordD) / Math.PI, testDelta);
+		Assertions.assertEquals(50, 200 * CoordTools.getAzimuth(coordA, coordC) / Math.PI, testDelta);
+		Assertions.assertEquals(100, 200 * CoordTools.getAzimuth(coordA, coordB) / Math.PI, testDelta);
+		Assertions.assertEquals(150, 200 * CoordTools.getAzimuth(coordA, coordI) / Math.PI, testDelta);
+		Assertions.assertEquals(200, 200 * CoordTools.getAzimuth(coordA, coordH) / Math.PI, testDelta);
+		Assertions.assertEquals(250, 200 * CoordTools.getAzimuth(coordA, coordG) / Math.PI, testDelta);
+		Assertions.assertEquals(300, 200 * CoordTools.getAzimuth(coordA, coordF) / Math.PI, testDelta);
+		Assertions.assertEquals(350, 200 * CoordTools.getAzimuth(coordA, coordE) / Math.PI, testDelta);
 	}
 
 	@Test
-	public void getAzimuthDiff() {
-		assertEquals(100, 200*CoordTools.getAngleDiff(coordA, coordD, coordC)/Math.PI, testDelta);
-		assertEquals(150, 200*CoordTools.getAngleDiff(coordA, coordD, coordB)/Math.PI, testDelta);
-		assertEquals(-100,  200*CoordTools.getAngleDiff(coordA, coordB, coordC)/Math.PI, testDelta);
-		assertEquals(-150,  200*CoordTools.getAngleDiff(coordA, coordB, coordD)/Math.PI, testDelta);
+	void getAzimuthDiff() {
+		Assertions.assertEquals(100, 200 * CoordTools.getAngleDiff(coordA, coordD, coordC) / Math.PI, testDelta);
+		Assertions.assertEquals(150, 200 * CoordTools.getAngleDiff(coordA, coordD, coordB) / Math.PI, testDelta);
+		Assertions.assertEquals(-100, 200 * CoordTools.getAngleDiff(coordA, coordB, coordC) / Math.PI, testDelta);
+		Assertions.assertEquals(-150, 200 * CoordTools.getAngleDiff(coordA, coordB, coordD) / Math.PI, testDelta);
 
-		assertEquals(50, 200*CoordTools.getAngleDiff(coordH, coordA, coordC)/Math.PI, testDelta);
-		assertEquals(-50, 200*CoordTools.getAngleDiff(coordH, coordA, coordE)/Math.PI, testDelta);
+		Assertions.assertEquals(50, 200 * CoordTools.getAngleDiff(coordH, coordA, coordC) / Math.PI, testDelta);
+		Assertions.assertEquals(-50, 200 * CoordTools.getAngleDiff(coordH, coordA, coordE) / Math.PI, testDelta);
 
-		assertEquals(0, 200*CoordTools.getAngleDiff(coordF, coordA, coordB)/Math.PI, testDelta);
-		assertEquals(200, 200*CoordTools.getAngleDiff(coordA, coordF, coordB)/Math.PI, testDelta);
+		Assertions.assertEquals(0, 200 * CoordTools.getAngleDiff(coordF, coordA, coordB) / Math.PI, testDelta);
+		Assertions.assertEquals(200, 200 * CoordTools.getAngleDiff(coordA, coordF, coordB) / Math.PI, testDelta);
 
 		Map<String, Coord> coords = new HashMap<>();
 		coords.put("A", coordA); coords.put("B", coordB); coords.put("C", coordC); coords.put("D", coordD);
@@ -91,8 +89,8 @@ public class CoordToolsTest {
 				for(Map.Entry<String, Coord> c2 : coords.entrySet()) {
 					if(!c1.equals(c0) && !c2.equals(c0) && !c1.equals(c2)) {
 						double diff = CoordTools.getAngleDiff(c0.getValue(), c1.getValue(), c2.getValue());
-						assertTrue(diff <= Math.PI);
-						assertTrue(diff >= -Math.PI);
+						Assertions.assertTrue(diff <= Math.PI);
+						Assertions.assertTrue(diff >= -Math.PI);
 					}
 				}
 			}
@@ -101,26 +99,26 @@ public class CoordToolsTest {
 	}
 
 	@Test
-	public void calcNewPoint() {
+	void calcNewPoint() {
 		Coord newPointD = CoordTools.calcNewPoint(coordA, 0.00 * Math.PI, CoordUtils.calcEuclideanDistance(coordA, coordD));
-		assertEquals(newPointD.getX(), coordD.getX(), testDelta);
-		assertEquals(newPointD.getY(), coordD.getY(), testDelta);
+		Assertions.assertEquals(newPointD.getX(), coordD.getX(), testDelta);
+		Assertions.assertEquals(newPointD.getY(), coordD.getY(), testDelta);
 
 		Coord newPointX = CoordTools.calcNewPoint(coordA, 0.25 * Math.PI, CoordUtils.calcEuclideanDistance(coordA, coordC));
-		assertEquals(newPointX.getX(), coordC.getX(), testDelta);
-		assertEquals(newPointX.getY(), coordC.getY(), testDelta);
+		Assertions.assertEquals(newPointX.getX(), coordC.getX(), testDelta);
+		Assertions.assertEquals(newPointX.getY(), coordC.getY(), testDelta);
 
 		Coord duplicateCoordZ = CoordTools.calcNewPoint(coordA, CoordTools.getAzimuth(coordA, coordZ), CoordUtils.calcEuclideanDistance(coordA, coordZ));
-		assertEquals(duplicateCoordZ.getX(), coordZ.getX(), testDelta);
-		assertEquals(duplicateCoordZ.getY(), coordZ.getY(), testDelta);
+		Assertions.assertEquals(duplicateCoordZ.getX(), coordZ.getX(), testDelta);
+		Assertions.assertEquals(duplicateCoordZ.getY(), coordZ.getY(), testDelta);
 
 		Coord newPointB = CoordTools.calcNewPoint(coordA, 0.50 * Math.PI, 20);
-		assertEquals(newPointB.getX(), coordB.getX(), testDelta);
-		assertEquals(newPointB.getY(), coordB.getY(), testDelta);
+		Assertions.assertEquals(newPointB.getX(), coordB.getX(), testDelta);
+		Assertions.assertEquals(newPointB.getY(), coordB.getY(), testDelta);
 
 		Coord newPointG = CoordTools.calcNewPoint(coordA, 1.25*Math.PI, CoordUtils.calcEuclideanDistance(coordA, coordG));
-		assertEquals(newPointG.getX(), coordG.getX(), testDelta);
-		assertEquals(newPointG.getY(), coordG.getY(), testDelta);
+		Assertions.assertEquals(newPointG.getX(), coordG.getX(), testDelta);
+		Assertions.assertEquals(newPointG.getY(), coordG.getY(), testDelta);
 	}
 
 }

--- a/src/test/java/org/matsim/pt2matsim/tools/CsvToolsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/tools/CsvToolsTest.java
@@ -1,7 +1,7 @@
 package org.matsim.pt2matsim.tools;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.matsim.core.utils.collections.MapUtils;
 
 import java.io.File;
@@ -12,10 +12,10 @@ import java.util.Map;
 /**
  * @author polettif
  */
-public class CsvToolsTest {
+class CsvToolsTest {
 
 	@Test
-	public void mapCsvTest() throws IOException {
+	void mapCsvTest() throws IOException {
 		String file = "test/testfile.csv";
 		Map<String, Map<String, String>> testMap = new HashMap<>();
 
@@ -30,7 +30,7 @@ public class CsvToolsTest {
 		CsvTools.writeNestedMapToFile(testMap, file);
 		Map<String, Map<String, String>> readMap = CsvTools.readNestedMapFromFile(file, false);
 
-		Assert.assertEquals(testMap, readMap);
+		Assertions.assertEquals(testMap, readMap);
 
 		File f = new File(file);
 		boolean del = f.delete();

--- a/src/test/java/org/matsim/pt2matsim/tools/GtfsToolsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/tools/GtfsToolsTest.java
@@ -1,9 +1,9 @@
 package org.matsim.pt2matsim.tools;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.pt2matsim.gtfs.GtfsFeed;
 import org.matsim.pt2matsim.gtfs.GtfsFeedImpl;
 
@@ -14,19 +14,19 @@ import java.time.LocalDate;
 /**
  * @author polettif
  */
-public class GtfsToolsTest {
+class GtfsToolsTest {
 
 	private GtfsFeed gtfsFeed;
 	private String output = "test/gtfs-feed-rewrite/";
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		gtfsFeed = new GtfsFeedImpl("test/gtfs-feed/");
 		new File(output).mkdir();
 	}
 
 	@Test
-	public void writeFiles() throws IOException {
+	void writeFiles() throws IOException {
 		GtfsTools.writeStopTimes(gtfsFeed.getTrips().values(), output);
 		GtfsTools.writeStops(gtfsFeed.getStops().values(), output);
 		GtfsTools.writeTrips(gtfsFeed.getTrips().values(), output);
@@ -34,16 +34,16 @@ public class GtfsToolsTest {
 	}
 
 	@Test
-	public void getDayWithMostServices() {
-		Assert.assertEquals(LocalDate.of(2018, 10, 2), GtfsTools.getDayWithMostServices(gtfsFeed));
+	void getDayWithMostServices() {
+		Assertions.assertEquals(LocalDate.of(2018, 10, 2), GtfsTools.getDayWithMostServices(gtfsFeed));
 	}
 
 	@Test
-	public void getDayWithMostTrips() {
-		Assert.assertEquals(LocalDate.of(2018, 10, 5), GtfsTools.getDayWithMostTrips(gtfsFeed));
+	void getDayWithMostTrips() {
+		Assertions.assertEquals(LocalDate.of(2018, 10, 5), GtfsTools.getDayWithMostTrips(gtfsFeed));
 	}
 
-	@After
+	@AfterEach
 	public void clean() {
 		new File(output).delete();
 	}

--- a/src/test/java/org/matsim/pt2matsim/tools/NetworkToolsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/tools/NetworkToolsTest.java
@@ -1,8 +1,8 @@
 package org.matsim.pt2matsim.tools;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -14,7 +14,6 @@ import org.matsim.core.utils.geometry.CoordUtils;
 
 import java.util.*;
 
-import static org.junit.Assert.assertTrue;
 import static org.matsim.pt2matsim.tools.CoordToolsTest.*;
 
 /**
@@ -148,7 +147,7 @@ public class NetworkToolsTest {
 		return net;
 	}
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		network = initNetwork();
 	}
@@ -158,39 +157,40 @@ public class NetworkToolsTest {
 	}
 
 	@Test
-	public void getNearestLink() {
+	void getNearestLink() {
 		Coord testR = new Coord(2600041.0, 1200050.0);
 		Coord testL = new Coord(2600039.0, 1200050.0);
 
 		Node nearestNode = NetworkUtils.getNearestNode(network, testR);
-		Assert.assertEquals("A", nearestNode.getId().toString());
+		Assertions.assertEquals("A", nearestNode.getId().toString());
 
-		Assert.assertEquals("AD", NetworkTools.getNearestLink(network, testR, 4).getId().toString());
-		Assert.assertEquals("DA", NetworkTools.getNearestLink(network, testL, 4).getId().toString());
+		Assertions.assertEquals("AD", NetworkTools.getNearestLink(network, testR, 4).getId().toString());
+		Assertions.assertEquals("DA", NetworkTools.getNearestLink(network, testL, 4).getId().toString());
 	}
 
 	@Test
-	public void getOppositeLink() {
+	void getOppositeLink() {
 		Network network = initNetwork();
 
-		Assert.assertEquals("AD", NetworkTools.getOppositeLink(network.getLinks().get(Id.createLinkId("DA"))).getId().toString());
+		Assertions.assertEquals("AD",
+				NetworkTools.getOppositeLink(network.getLinks().get(Id.createLinkId("DA"))).getId().toString());
 	}
 
 	@Test
-	public void coordIsOnRightSideOfLink() {
+	void coordIsOnRightSideOfLink() {
 		Coord c = new Coord(2600039.0, 1200041.0);
 
-		Assert.assertTrue(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("IG"))));
-		Assert.assertTrue(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("FE"))));
-		Assert.assertTrue(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("ED"))));
-		Assert.assertTrue(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("DA"))));
+		Assertions.assertTrue(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("IG"))));
+		Assertions.assertTrue(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("FE"))));
+		Assertions.assertTrue(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("ED"))));
+		Assertions.assertTrue(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("DA"))));
 
-		Assert.assertFalse(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("AD"))));
-		Assert.assertFalse(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("AX"))));
+		Assertions.assertFalse(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("AD"))));
+		Assertions.assertFalse(NetworkTools.coordIsOnRightSideOfLink(c, network.getLinks().get(Id.createLinkId("AX"))));
 	}
 
 	@Test
-	public void linkSequenceHasDuplicateLink() {
+	void linkSequenceHasDuplicateLink() {
 		List<Link> seq = new ArrayList<>();
 		seq.add(getLink("XA"));
 		seq.add(getLink("AB"));
@@ -201,64 +201,64 @@ public class NetworkToolsTest {
 		seq.add(getLink("BI"));
 		seq.add(getLink("IH"));
 
-		assertTrue(NetworkTools.linkSequenceHasDuplicateLink(seq));
+		Assertions.assertTrue(NetworkTools.linkSequenceHasDuplicateLink(seq));
 	}
 
 	@Test
-	public void linkSequenceHasUTurns() {
+	void linkSequenceHasUTurns() {
 		List<Link> seq = new ArrayList<>();
 		seq.add(getLink("AB"));
 		seq.add(getLink("BC"));
 		seq.add(getLink("CB"));
 		seq.add(getLink("BI"));
 
-		assertTrue(NetworkTools.linkSequenceHasUTurns(seq));
+		Assertions.assertTrue(NetworkTools.linkSequenceHasUTurns(seq));
 	}
 
 	@Test
-	public void getSingleFilePrecedingLink() {
-		Assert.assertEquals("AH", NetworkTools.getSingleFilePrecedingLink(getLink("HZ")).getId().toString());
-		Assert.assertEquals("ZI", NetworkTools.getSingleFileSucceedingLink(getLink("HZ")).getId().toString());
+	void getSingleFilePrecedingLink() {
+		Assertions.assertEquals("AH", NetworkTools.getSingleFilePrecedingLink(getLink("HZ")).getId().toString());
+		Assertions.assertEquals("ZI", NetworkTools.getSingleFileSucceedingLink(getLink("HZ")).getId().toString());
 	}
 
 	@Test
-	public void reduceSequencedLinks() {
+	void reduceSequencedLinks() {
 		List<Link> seq = new ArrayList<>();
 		seq.add(getLink("AH"));
 		seq.add(getLink("HZ"));
 		seq.add(getLink("ZI"));
 
 		NetworkTools.reduceSequencedLinks(seq, new Coord(2600050.0, 1200035.0));
-		Assert.assertEquals(1, seq.size());
-		Assert.assertEquals("AH", seq.get(0).getId().toString());
+		Assertions.assertEquals(1, seq.size());
+		Assertions.assertEquals("AH", seq.get(0).getId().toString());
 
 		Collection<? extends Link> seqAll = new HashSet<>(network.getLinks().values());
 		NetworkTools.reduceSequencedLinks(seqAll, new Coord(2600041.0, 1200042.0));
-		Assert.assertEquals(10, network.getLinks().size()-seqAll.size());
+		Assertions.assertEquals(10, network.getLinks().size() - seqAll.size());
 	}
 
 	@Test
-	public void calcRouteLength() {
+	void calcRouteLength() {
 		List<Link> seq = new ArrayList<>();
 		seq.add(getLink("AB"));
 		seq.add(getLink("BC"));
 		seq.add(getLink("CD"));
 		seq.add(getLink("DA"));
-		Assert.assertEquals(80.0, NetworkTools.calcRouteLength(seq, true), 0.0001);
+		Assertions.assertEquals(80.0, NetworkTools.calcRouteLength(seq, true), 0.0001);
 	}
 
 	@Test
-	public void findClosestLinks() {
+	void findClosestLinks() {
 		Node node = network.getNodes().get(Id.createNodeId("G"));
 		Coord coordToLookFrom = new Coord(node.getCoord().getX() + 2, node.getCoord().getY() + 2);
 
 		Map<Double, Set<Link>> cars = NetworkTools.findClosestLinks(network, coordToLookFrom, 3, Collections.singleton("car"));
-		Assert.assertEquals(1, cars.keySet().size());
-		Assert.assertEquals(4, cars.get(2.0).size());
+		Assertions.assertEquals(1, cars.keySet().size());
+		Assertions.assertEquals(4, cars.get(2.0).size());
 
 		Map<Double, Set<Link>> nullTransportModes = NetworkTools.findClosestLinks(network, coordToLookFrom, 3, null);
-		Assert.assertEquals(1, nullTransportModes.keySet().size());
-		Assert.assertEquals(4, nullTransportModes.get(2.0).size());
+		Assertions.assertEquals(1, nullTransportModes.keySet().size());
+		Assertions.assertEquals(4, nullTransportModes.get(2.0).size());
 
 	}
 

--- a/src/test/java/org/matsim/pt2matsim/tools/ScheduleToolsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/tools/ScheduleToolsTest.java
@@ -1,8 +1,8 @@
 
 package org.matsim.pt2matsim.tools;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -179,16 +179,16 @@ public class ScheduleToolsTest {
 	}
 
 	@Test
-	public void validateTestSchedule() {
+	void validateTestSchedule() {
 		ValidationResult result = TransitScheduleValidator.validateAll(ScheduleToolsTest.initSchedule(), NetworkToolsTest.initNetwork());
 		for(ValidationIssue<?> issue : result.getIssues()) {
 			System.err.println(issue.getSeverity() + ": " + issue.getMessage());
 		}
-		Assert.assertTrue(result.isValid());
+		Assertions.assertTrue(result.isValid());
 	}
 
 	@Test
-	public void mergeSchedules() {
+	void mergeSchedules() {
 		TransitSchedule testSchedule = initSchedule();
 		ScheduleTools.mergeSchedules(testSchedule, initSchedule());
 
@@ -201,13 +201,13 @@ public class ScheduleToolsTest {
 			nRoutesInit += l.getRoutes().size();
 		}
 
-		Assert.assertEquals(testSchedule.getTransitLines().size(), initSchedule().getTransitLines().size());
-		Assert.assertEquals(nRoutesInit, nRoutesTest);
-		Assert.assertEquals(testSchedule.getFacilities().size(), initSchedule().getFacilities().size());
+		Assertions.assertEquals(testSchedule.getTransitLines().size(), initSchedule().getTransitLines().size());
+		Assertions.assertEquals(nRoutesInit, nRoutesTest);
+		Assertions.assertEquals(testSchedule.getFacilities().size(), initSchedule().getFacilities().size());
 	}
 
 	@Test
-	public void mergeSchedulesOffset() {
+	void mergeSchedulesOffset() {
 		TransitSchedule baseSchedule = initSchedule();
 		TransitSchedule testSchedule = initSchedule();
 		ScheduleTools.mergeSchedules(testSchedule, baseSchedule, 24 * 3600, 60 * 3600);
@@ -226,14 +226,14 @@ public class ScheduleToolsTest {
 			}
 		}
 
-		Assert.assertEquals(testSchedule.getTransitLines().size(), initSchedule().getTransitLines().size());
-		Assert.assertEquals(nRoutesInit, nRoutesTest);
-		Assert.assertEquals(testSchedule.getFacilities().size(), initSchedule().getFacilities().size());
-		Assert.assertEquals(nDeparturesInit * 2, nDeparturesTest);
+		Assertions.assertEquals(testSchedule.getTransitLines().size(), initSchedule().getTransitLines().size());
+		Assertions.assertEquals(nRoutesInit, nRoutesTest);
+		Assertions.assertEquals(testSchedule.getFacilities().size(), initSchedule().getFacilities().size());
+		Assertions.assertEquals(nDeparturesInit * 2, nDeparturesTest);
 	}
 
 	@Test
-	public void mergeSchedulesOffsetTimeLimit() {
+	void mergeSchedulesOffsetTimeLimit() {
 		TransitSchedule baseSchedule = initSchedule();
 		TransitSchedule testSchedule = initSchedule();
 		ScheduleTools.mergeSchedules(testSchedule, baseSchedule, 24 * 3600, 24 * 3600 + 12.5 * 3600);
@@ -252,14 +252,14 @@ public class ScheduleToolsTest {
 			}
 		}
 
-		Assert.assertEquals(testSchedule.getTransitLines().size(), initSchedule().getTransitLines().size());
-		Assert.assertEquals(nRoutesInit, nRoutesTest);
-		Assert.assertEquals(testSchedule.getFacilities().size(), initSchedule().getFacilities().size());
-		Assert.assertEquals(nDeparturesInit + 6, nDeparturesTest);
+		Assertions.assertEquals(testSchedule.getTransitLines().size(), initSchedule().getTransitLines().size());
+		Assertions.assertEquals(nRoutesInit, nRoutesTest);
+		Assertions.assertEquals(testSchedule.getFacilities().size(), initSchedule().getFacilities().size());
+		Assertions.assertEquals(nDeparturesInit + 6, nDeparturesTest);
 	}
 
 	@Test
-	public void freespeedBasedOnSchedule() {
+	void freespeedBasedOnSchedule() {
 		TransitSchedule schedule = initSchedule();
 		Network network = NetworkToolsTest.initNetwork();
 		Network baseNetwork = NetworkToolsTest.initNetwork();
@@ -286,6 +286,6 @@ public class ScheduleToolsTest {
 				linksChanged.add(link.getId());
 			}
 		}
-		Assert.assertEquals(linksUsedBySchedule, linksChanged);
+		Assertions.assertEquals(linksUsedBySchedule, linksChanged);
 	}
 }

--- a/src/test/java/org/matsim/pt2matsim/tools/ShapeToolsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/tools/ShapeToolsTest.java
@@ -1,8 +1,8 @@
 package org.matsim.pt2matsim.tools;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Node;
@@ -67,7 +67,7 @@ public class ShapeToolsTest {
 		return new Coord(c.getX() + offset, c.getY() + offset);
 	}
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		Map<Id<RouteShape>, RouteShape> shapes = initShapes();
 		this.shapeA1 = shapes.get(Id.create("A1", RouteShape.class));
@@ -76,26 +76,26 @@ public class ShapeToolsTest {
 	}
 
 	@Test
-	public void calcMinDistanceToShape() {
-		Assert.assertEquals(0, ShapeTools.calcMinDistanceToShape(coordX, shapeB), d);
-		Assert.assertEquals(5, ShapeTools.calcMinDistanceToShape(new Coord(2600035, 1200035), shapeB), d);
+	void calcMinDistanceToShape() {
+		Assertions.assertEquals(0, ShapeTools.calcMinDistanceToShape(coordX, shapeB), d);
+		Assertions.assertEquals(5, ShapeTools.calcMinDistanceToShape(new Coord(2600035, 1200035), shapeB), d);
 
 		Coord bx = CoordTools.calcNewPoint(coordX, CoordTools.getAzimuth(coordX, coordB), CoordUtils.calcEuclideanDistance(coordX, coordB) / 2);
-		Assert.assertEquals(0, ShapeTools.calcMinDistanceToShape(bx, shapeA1), d);
+		Assertions.assertEquals(0, ShapeTools.calcMinDistanceToShape(bx, shapeA1), d);
 	}
 
 
 	@Test
-	public void getNodesWithinBuffer() {
+	void getNodesWithinBuffer() {
 		Collection<Node> nodes = ShapeTools.getNodesWithinBuffer(NetworkToolsTest.initNetwork(), shapeB, 1.0);
-		Assert.assertEquals(9, nodes.size());
+		Assertions.assertEquals(9, nodes.size());
 	}
 
 	@Test
-	public void getShapeLength() {
+	void getShapeLength() {
 		double lengthA1 = ShapeTools.getShapeLength(shapeA1);
 		double lengthA2 = ShapeTools.getShapeLength(shapeA2);
-		Assert.assertEquals(lengthA1, lengthA2, d);
+		Assertions.assertEquals(lengthA1, lengthA2, d);
 	}
 
 }


### PR DESCRIPTION
Some things I noticed and fixed:

- [`PlausibilityCheckTest`](https://github.com/matsim-org/pt2matsim/compare/junit5?expand=1#diff-0d57fda553c75ab9c6d70d067b6680ee9204dfc54ce812c9f220f6b930ea7f48) was accidentally using `org.locationtech.jts.util.Assert`.
- The `message` argument was not used in [`OsmMultimodalNetworkConverterTest.assertMaxspeed(..)`](https://github.com/matsim-org/pt2matsim/compare/junit5?expand=1#diff-94dfd45167f3de757530d91b940df0190d6c49d36185fb3d5d426bdbfc7e95fdL276)