### PR TITLE
Fix usage of deprecated methods and classes

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/hafas/HafasConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/HafasConverter.java
@@ -33,6 +33,7 @@ import org.matsim.pt2matsim.tools.VehicleTypeDefaults;
 import org.matsim.pt2matsim.tools.debug.ScheduleCleaner;
 import org.matsim.vehicles.VehicleCapacity;
 import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.Vehicles;
 import org.matsim.vehicles.VehiclesFactory;
 
@@ -182,9 +183,9 @@ public class HafasConverter {
 					// using default values for vehicle type
 					vehicleType.setLength(defaultVehicleType.length);
 					vehicleType.setWidth(defaultVehicleType.width);
-					vehicleType.setAccessTime(defaultVehicleType.accessTime);
-					vehicleType.setEgressTime(defaultVehicleType.egressTime);
-					vehicleType.setDoorOperationMode(defaultVehicleType.doorOperation);
+					VehicleUtils.setAccessTime(vehicleType, defaultVehicleType.accessTime);
+					VehicleUtils.setEgressTime(vehicleType, defaultVehicleType.egressTime);
+					VehicleUtils.setDoorOperationMode(vehicleType, defaultVehicleType.doorOperation);
 					vehicleType.setPcuEquivalents(defaultVehicleType.pcuEquivalents);
 
 					VehicleCapacity vehicleCapacity = vehicleType.getCapacity();

--- a/src/main/java/org/matsim/pt2matsim/osm/OsmTransitScheduleConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/OsmTransitScheduleConverter.java
@@ -236,7 +236,7 @@ public class OsmTransitScheduleConverter {
 			}
 		}
 
-		NetworkRoute networkRoute = (linkSequenceForward.size() == 0 ? null : RouteUtils.createNetworkRoute(linkSequenceForward, null));
+		NetworkRoute networkRoute = (linkSequenceForward.size() == 0 ? null : RouteUtils.createNetworkRoute(linkSequenceForward));
 
 		if(stopSequenceForward.size() == 0) {
 			return null;

--- a/src/main/java/org/matsim/pt2matsim/run/gis/Network2ShapeFile.java
+++ b/src/main/java/org/matsim/pt2matsim/run/gis/Network2ShapeFile.java
@@ -24,9 +24,9 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.utils.collections.CollectionUtils;
 import org.matsim.core.utils.geometry.geotools.MGC;
+import org.matsim.core.utils.gis.GeoFileWriter;
 import org.matsim.core.utils.gis.PointFeatureFactory;
 import org.matsim.core.utils.gis.PolylineFeatureFactory;
-import org.matsim.core.utils.gis.ShapeFileWriter;
 import org.matsim.pt2matsim.tools.NetworkTools;
 import org.opengis.feature.simple.SimpleFeature;
 
@@ -94,7 +94,7 @@ public class Network2ShapeFile {
 			nodeFeatures.add(f);
 		}
 
-		ShapeFileWriter.writeGeometries(nodeFeatures, nodesOutputFile);
+		GeoFileWriter.writeGeometries(nodeFeatures, nodesOutputFile);
 	}
 
 	public void convertLinks(String linksOutputFile) {
@@ -125,7 +125,7 @@ public class Network2ShapeFile {
 			linkFeatures.add(f);
 		}
 
-		ShapeFileWriter.writeGeometries(linkFeatures, linksOutputFile);
+		GeoFileWriter.writeGeometries(linkFeatures, linksOutputFile);
 	}
 
 	private Coordinate[] getCoordinates(Link link) {

--- a/src/main/java/org/matsim/pt2matsim/run/gis/Schedule2ShapeFile.java
+++ b/src/main/java/org/matsim/pt2matsim/run/gis/Schedule2ShapeFile.java
@@ -27,9 +27,9 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.utils.collections.CollectionUtils;
 import org.matsim.core.utils.collections.MapUtils;
 import org.matsim.core.utils.geometry.geotools.MGC;
+import org.matsim.core.utils.gis.GeoFileWriter;
 import org.matsim.core.utils.gis.PointFeatureFactory;
 import org.matsim.core.utils.gis.PolylineFeatureFactory;
-import org.matsim.core.utils.gis.ShapeFileWriter;
 import org.matsim.pt.transitSchedule.api.*;
 import org.matsim.pt2matsim.tools.NetworkTools;
 import org.matsim.pt2matsim.tools.ScheduleTools;
@@ -144,7 +144,7 @@ public class Schedule2ShapeFile {
 			}
 		}
 
-		ShapeFileWriter.writeGeometries(lineFeatures, outputFile);
+		GeoFileWriter.writeGeometries(lineFeatures, outputFile);
 	}
 
 
@@ -181,7 +181,7 @@ public class Schedule2ShapeFile {
 			pointFeatures.add(pf);
 		}
 
-		ShapeFileWriter.writeGeometries(pointFeatures, pointOutputFile);
+		GeoFileWriter.writeGeometries(pointFeatures, pointOutputFile);
 	}
 
 	/**
@@ -229,7 +229,7 @@ public class Schedule2ShapeFile {
 			}
 		}
 
-		ShapeFileWriter.writeGeometries(features, outputFile);
+		GeoFileWriter.writeGeometries(features, outputFile);
 	}
 
 	/**

--- a/src/main/java/org/matsim/pt2matsim/tools/CoordTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/CoordTools.java
@@ -269,6 +269,7 @@ public final class CoordTools {
 	 *
 	 * @deprecated not used anywhere
 	 */
+	@Deprecated
 	public static int getBorderCrossType(Coord SWcut, Coord NEcut, Coord fromCoord, Coord toCoord) {
 		int fromSector = getAreaOfInterestSector(SWcut, NEcut, fromCoord);
 		int toSector = getAreaOfInterestSector(SWcut, NEcut, toCoord);

--- a/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
@@ -317,7 +317,7 @@ public final class ScheduleTools {
 
 					// add link sequence to schedule
 					if(linkIdSequence != null) {
-						transitRoute.setRoute(RouteUtils.createNetworkRoute(linkIdSequence, network));
+						transitRoute.setRoute(RouteUtils.createNetworkRoute(linkIdSequence));
 					}
 				} else {
 					log.warn("Route " + transitRoute.getId() + " on line " + transitLine.getId() + " has no stop sequence");

--- a/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
@@ -205,9 +205,9 @@ public final class ScheduleTools {
 		VehicleType vehicleType = vf.createVehicleType(vTypeId);
 		vehicleType.setLength(defaultValues.length);
 		vehicleType.setWidth(defaultValues.width);
-		vehicleType.setAccessTime(defaultValues.accessTime);
-		vehicleType.setEgressTime(defaultValues.egressTime);
-		vehicleType.setDoorOperationMode(defaultValues.doorOperation);
+		VehicleUtils.setAccessTime(vehicleType, defaultValues.accessTime);
+		VehicleUtils.setEgressTime(vehicleType, defaultValues.egressTime);
+		VehicleUtils.setDoorOperationMode(vehicleType, defaultValues.doorOperation);
 		vehicleType.setPcuEquivalents(defaultValues.pcuEquivalents);
 		vehicleType.setNetworkMode(defaultValues.transportMode.name);
 

--- a/src/main/java/org/matsim/pt2matsim/tools/ShapeTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/ShapeTools.java
@@ -32,8 +32,8 @@ import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
 import org.matsim.core.utils.geometry.geotools.MGC;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
+import org.matsim.core.utils.gis.GeoFileWriter;
 import org.matsim.core.utils.gis.PolylineFeatureFactory;
-import org.matsim.core.utils.gis.ShapeFileWriter;
 import org.matsim.pt2matsim.gtfs.GtfsFeed;
 import org.matsim.pt2matsim.gtfs.GtfsFeedImpl;
 import org.matsim.pt2matsim.gtfs.lib.GtfsDefinitions;
@@ -228,7 +228,7 @@ public final class ShapeTools {
 				}
 			}
 		}
-		ShapeFileWriter.writeGeometries(features, outFile);
+		GeoFileWriter.writeGeometries(features, outFile);
 	}
 
 	/**
@@ -257,7 +257,7 @@ public final class ShapeTools {
 				features.add(f);
 			}
 		}
-		ShapeFileWriter.writeGeometries(features, filename);
+		GeoFileWriter.writeGeometries(features, filename);
 
 	}
 


### PR DESCRIPTION
* Use `VehicleUtils` for `accessTime`, `egressTime`, `doorOperationMode`
* Add missing `@Deprecated` annotation to `CoordTools.getBorderCrossType()`
* Remove unused `network` argument from `RouteUtils.createNetworkRoute(..)`
* Replace deprecated `ShapeFileWriter` with `GeoFileWriter`