### PR TITLE
Bump GeoJson-Jackson from 1.5 to 1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.locationtech.jts</groupId>
@@ -98,6 +97,18 @@
             <version>${geotools.version}</version>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.fasterxml.jackson</groupId>
+            <artifactId>jackson-bom</artifactId>
+            <version>${jackson.version}</version>
+            <scope>import</scope>
+            <type>pom</type>
+          </dependency>   
+        </dependencies>
+      </dependencyManagement>
 
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>de.grundid.opendatalab</groupId>
             <artifactId>geojson-jackson</artifactId>
-            <version>1.5</version>
+            <version>1.8</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>de.grundid.opendatalab</groupId>
             <artifactId>geojson-jackson</artifactId>
-            <version>1.8</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
@@ -85,6 +85,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <!-- required for tests with geojson-jackson -->
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.locationtech.jts</groupId>


### PR DESCRIPTION
From `geojson-jackson` version 1.8.1 on, it was necessary to add `com.fasterxml.jackson.core:jackson-annotations` as dependency.