### PR TITLE
Include integration tests in GitHub workflow

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         java-version: 1.17
     - name: Build with Maven
-      run: mvn test -B -Dmatsim.preferLocalDtds=true
+      run: mvn verify -B -Dmatsim.preferLocalDtds=true


### PR DESCRIPTION
Integration tests are now executed by the GitHub workflow.

#252 added the first integration test, but only `mvn test` was executed so test failures were not recognized.