### PR TITLE
Allow for OSM relation members to have multiple roles

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverter.java
@@ -776,7 +776,7 @@ public class OsmMultimodalNetworkConverter {
 			// - it is a turn restriction relation and
 			// - this way is the "from" link
 			if (!(Osm.Key.RESTRICTION.equals(relationTags.get(Osm.Key.TYPE))
-					&& Osm.Value.FROM.equals(relation.getMemberRole(way)))) {
+					&& relation.getMemberRoles(way).contains(Osm.Value.FROM))) {
 				continue;
 			}
 
@@ -832,9 +832,10 @@ public class OsmMultimodalNetworkConverter {
 			Id<Osm.Way> toWayId = null;
 			for (Osm.Element element : relation.getMembers()) {
 				if (element instanceof Osm.Way wayElement) {
-					if (Osm.Value.TO.equals(relation.getMemberRole(wayElement))) {
+					List<String> memberRoles = relation.getMemberRoles(wayElement);
+					if (memberRoles.contains(Osm.Value.TO)) {
 						toWayId = wayElement.getId();
-					} else if (Osm.Value.VIA.equals(relation.getMemberRole(wayElement))) {
+					} else if (memberRoles.contains(Osm.Value.VIA)) {
 						nextWayIds.add(wayElement.getId());
 					}
 				}

--- a/src/main/java/org/matsim/pt2matsim/osm/OsmTransitScheduleConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/OsmTransitScheduleConverter.java
@@ -108,7 +108,7 @@ public class OsmTransitScheduleConverter {
 
 				// create a facility for each member
 				for(Osm.Element member : relation.getMembers()) {
-					if(relation.getMemberRole(member).equals(Osm.Value.STOP) && member.getType().equals(Osm.ElementType.NODE)) {
+					if(relation.getMemberRoles(member).contains(Osm.Value.STOP) && member.getType().equals(Osm.ElementType.NODE)) {
 						Osm.Node n = (Osm.Node) member;
 						TransitStopFacility newStopFacility = createStopFacilityFromOsmNode(n, stopPostAreaId);
 
@@ -219,7 +219,8 @@ public class OsmTransitScheduleConverter {
 			Osm.Element member = relation.getMembers().get(i);
 
 			// route Stops
-			if(member.getType().equals(Osm.ElementType.NODE) && (Osm.Value.STOP.equals(relation.getMemberRole(member)) || Osm.Value.STOP_FORWARD.equals(relation.getMemberRole(member)))) {
+			List<String> memberRoles = relation.getMemberRoles(member);
+			if(member.getType().equals(Osm.ElementType.NODE) && (memberRoles.contains(Osm.Value.STOP) || memberRoles.contains(Osm.Value.STOP_FORWARD))) {
 				Id<TransitStopFacility> id = Id.create(((Osm.Node) member).getId(), TransitStopFacility.class);
 				TransitStopFacility transitStopFacility = transitSchedule.getFacilities().get(id);
 				if(transitStopFacility != null) {

--- a/src/main/java/org/matsim/pt2matsim/osm/lib/Osm.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/lib/Osm.java
@@ -107,10 +107,10 @@ public final class Osm {
 		List<Element> getMembers();
 
 		/**
-		 * @return the role the given member has. <tt>null</tt> if element is not
-		 * a member or no role is assigned
+		 * @return the role(s) the given member has. Empty list, if element is
+		 *         not a member or list with null value(s) if no role(s) are assigned.
 		 */
-		String getMemberRole(Element member);
+		List<String> getMemberRoles(Element member);
 
 		/**
 		 * @return the relations of which this relation is a member

--- a/src/main/java/org/matsim/pt2matsim/osm/lib/OsmDataImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/lib/OsmDataImpl.java
@@ -108,7 +108,7 @@ public class OsmDataImpl implements OsmData {
 
 			Osm.Relation currentRel = relations.get(Id.create(pr.id, Osm.Relation.class));
 
-			Map<Osm.Element, String> memberRoles = new HashMap<>();
+			Map<Osm.Element, List<String>> memberRoles = new HashMap<>();
 			List<Osm.Element> memberList = new ArrayList<>();
 			for(OsmFileReader.ParsedRelationMember pMember : pr.members) {
 				Osm.Element member = null;
@@ -125,8 +125,8 @@ public class OsmDataImpl implements OsmData {
 				}
 				// relation member might be outside of map area
 				if(member != null) {
-					memberList.add(member);
-					memberRoles.put(member, pMember.role);
+					memberList.add(member); // this will add members with multiple roles multiple times
+					memberRoles.computeIfAbsent(member, m -> new ArrayList<>()).add(pMember.role);
 				}
 
 				// add relations to nodes/ways/relations

--- a/src/main/java/org/matsim/pt2matsim/osm/lib/OsmElement.java
+++ b/src/main/java/org/matsim/pt2matsim/osm/lib/OsmElement.java
@@ -21,6 +21,7 @@ package org.matsim.pt2matsim.osm.lib;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -192,7 +193,7 @@ public class OsmElement {
 		private final Map<String, String> tags;
 		private final Map<Id<Osm.Relation>, Osm.Relation> relations = new HashMap<>();
 		private List<Osm.Element> members;
-		private Map<Osm.Element, String> memberRoles;
+		private Map<Osm.Element, List<String>> memberRoles;
 
 		public Relation(long id, Map<String, String> tags) {
 			this.id = Id.create(id, Osm.Relation.class);
@@ -233,11 +234,11 @@ public class OsmElement {
 			return relations;
 		}
 
-		public String getMemberRole(Osm.Element member) {
-			return memberRoles.get(member);
+		public List<String> getMemberRoles(Osm.Element member) {
+			return memberRoles.getOrDefault(member, Collections.emptyList());
 		}
 
-		/*pckg*/ void setMembers(List<Osm.Element> memberList, Map<Osm.Element, String> memberRoles) {
+		/*pckg*/ void setMembers(List<Osm.Element> memberList, Map<Osm.Element, List<String>> memberRoles) {
 			if(members != null) {
 				throw new IllegalArgumentException("Relation members have already been set");
 			}

--- a/src/test/java/org/matsim/pt2matsim/osm/RelationWithMultipleRolesTest.java
+++ b/src/test/java/org/matsim/pt2matsim/osm/RelationWithMultipleRolesTest.java
@@ -1,0 +1,33 @@
+package org.matsim.pt2matsim.osm;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.pt2matsim.osm.lib.Osm;
+import org.matsim.pt2matsim.osm.lib.Osm.Relation;
+import org.matsim.pt2matsim.osm.lib.OsmData;
+import org.matsim.pt2matsim.osm.lib.OsmDataImpl;
+import org.matsim.pt2matsim.osm.lib.OsmFileReader;
+
+class RelationWithMultipleRolesTest {
+
+	@Test
+	void testMultipleRoles() {
+		OsmData osmData = new OsmDataImpl();
+		new OsmFileReader(osmData).readFile("test/osm/relation_multiple_roles.osm");
+
+		Id<Osm.Relation> relationId = Id.create("-79", Osm.Relation.class);
+		Id<Osm.Way> wayId = Id.create("-1279", Osm.Way.class);
+
+		Osm.Way way = osmData.getWays().get(wayId);
+		Relation relation = osmData.getRelations().get(relationId);
+
+		Assertions.assertEquals(2, relation.getMemberRoles(way).size());
+		Assertions.assertEquals(List.of("from", "to"), relation.getMemberRoles(way));
+		// members with multiple roles will be added multiple times
+		Assertions.assertEquals(3, relation.getMembers().size());
+	}
+
+}

--- a/test/osm/relation_multiple_roles.osm
+++ b/test/osm/relation_multiple_roles.osm
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-25903' action='modify' visible='true' lat='52.2728319512' lon='10.4728888607' />
+  <node id='-25904' action='modify' visible='true' lat='52.27288447115' lon='10.48413268089' />
+  <way id='-1279' action='modify' visible='true'>
+    <nd ref='-25903' />
+    <nd ref='-25904' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='from &amp; to' />
+  </way>
+  <relation id='-79' action='modify' visible='true'>
+    <member type='way' ref='-1279' role='from' />
+    <member type='node' ref='-25904' role='via' />
+    <member type='way' ref='-1279' role='to' />
+    <tag k='restriction' v='no_u_turn' />
+    <tag k='type' v='restriction' />
+  </relation>
+</osm>


### PR DESCRIPTION
This is required for u-turns, where the from and to way can be the same.