### PR TITLE
Improve parsing of turn restrictions as DisallowedNextLinks

### DIFF
--- a/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTurnRestrictionsTest.java
+++ b/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTurnRestrictionsTest.java
@@ -4,8 +4,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
@@ -18,18 +20,216 @@ import org.matsim.pt2matsim.config.OsmConverterConfigGroup;
 import org.matsim.pt2matsim.osm.lib.OsmData;
 import org.matsim.pt2matsim.osm.lib.OsmDataImpl;
 import org.matsim.pt2matsim.osm.lib.OsmFileReader;
+import org.matsim.pt2matsim.tools.NetworkTools;
 
 class OsmMultimodalNetworkConverterTurnRestrictionsTest {
 
-	private static Network network;
+	private static final boolean DEBUG = true;
 
-	@BeforeAll
-	static void convertRudolfplatz() {
+	@BeforeEach
+	void setLogLevel() {
+		if (DEBUG) {
+			Configurator.setLevel(LogManager.getLogger(OsmMultimodalNetworkConverter.class),
+					org.apache.logging.log4j.Level.DEBUG);
+		}
+	}
+
+	@Test
+	void test0Valid() {
+
+		Network network = convert("tr0_valid.osm");
+
+		// --------------------------------------------------------------------
+
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+		long noOfDnl = network.getLinks().values().stream()
+				.map(NetworkUtils::getDisallowedNextLinks)
+				.filter(Objects::nonNull)
+				.count();
+		Assertions.assertEquals(1L, noOfDnl);
+
+		DisallowedNextLinks dnl = NetworkUtils.getDisallowedNextLinks(network.getLinks().get(Id.createLinkId("1")));
+		Assertions.assertNotNull(dnl);
+
+		Assertions.assertEquals(List.of(List.of(Id.createLinkId("7"), Id.createLinkId("9"))),
+				dnl.getDisallowedLinkSequences("car"));
+	}
+
+	@Test
+	void test1Invalid() {
+
+		// This OSM network has an invalid turn restriction relation. The to-way does
+		// not start or end at the via-node.
+		Network network = convert("tr1_invalid.osm");
+
+		// --------------------------------------------------------------------
+
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+		long noOfDnl = network.getLinks().values().stream()
+				.map(NetworkUtils::getDisallowedNextLinks)
+				.filter(Objects::nonNull)
+				.count();
+		Assertions.assertEquals(0L, noOfDnl);
+	}
+
+	@Test
+	void test2Valid() {
+
+		// This is a uturn, where from & to is the same way
+		// It needs to be ensured, that only one Turn restriction is created at the via
+		// node.
+		Network network = convert("tr2_valid.osm");
+
+		// --------------------------------------------------------------------
+
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+		long noOfDnl = network.getLinks().values().stream()
+				.map(NetworkUtils::getDisallowedNextLinks)
+				.filter(Objects::nonNull)
+				.count();
+		Assertions.assertEquals(1L, noOfDnl);
+
+		DisallowedNextLinks dnl1 = NetworkUtils.getDisallowedNextLinks(network.getLinks().get(Id.createLinkId("1")));
+		Assertions.assertNotNull(dnl1);
+		DisallowedNextLinks dnl2 = NetworkUtils.getDisallowedNextLinks(network.getLinks().get(Id.createLinkId("2")));
+		Assertions.assertNull(dnl2);
+
+		Assertions.assertEquals(List.of(List.of(Id.createLinkId("2"))), dnl1.getDisallowedLinkSequences("car"));
+	}
+
+	@Test
+	void test3Valid() {
+
+		// This is a uturn, where from & to is the same way and the way is long so two
+		// links are created
+		Network network = convert("tr3_valid.osm");
+
+		// --------------------------------------------------------------------
+
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+		long noOfDnl = network.getLinks().values().stream()
+				.map(NetworkUtils::getDisallowedNextLinks)
+				.filter(Objects::nonNull)
+				.count();
+		Assertions.assertEquals(1L, noOfDnl);
+
+		DisallowedNextLinks dnl = NetworkUtils.getDisallowedNextLinks(network.getLinks().get(Id.createLinkId("9")));
+		Assertions.assertNotNull(dnl);
+
+		Assertions.assertEquals(List.of(List.of(Id.createLinkId("10"), Id.createLinkId("8"))),
+				dnl.getDisallowedLinkSequences("car"));
+	}
+
+	@Test
+	void test4Valid() {
+
+		// This is a uturn, where from & to are different ways and via is also a way,
+		// all one-way
+		Network network = convert("tr4_valid.osm");
+
+		// --------------------------------------------------------------------
+
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+		long noOfDnl = network.getLinks().values().stream()
+				.map(NetworkUtils::getDisallowedNextLinks)
+				.filter(Objects::nonNull)
+				.count();
+		Assertions.assertEquals(1L, noOfDnl);
+
+		DisallowedNextLinks dnl = NetworkUtils.getDisallowedNextLinks(network.getLinks().get(Id.createLinkId("8")));
+		Assertions.assertNotNull(dnl);
+
+		Assertions.assertEquals(List.of(List.of(Id.createLinkId("10"), Id.createLinkId("7"))),
+				dnl.getDisallowedLinkSequences("car"));
+	}
+
+	@Test
+	void test5Valid() {
+
+		// This is a uturn, where from & to are different ways and via is also a way,
+		// all one-way and long links
+		Network network = convert("tr5_valid.osm");
+
+		// --------------------------------------------------------------------
+
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+		long noOfDnl = network.getLinks().values().stream()
+				.map(NetworkUtils::getDisallowedNextLinks)
+				.filter(Objects::nonNull)
+				.count();
+		Assertions.assertEquals(1L, noOfDnl);
+
+		DisallowedNextLinks dnl = NetworkUtils.getDisallowedNextLinks(network.getLinks().get(Id.createLinkId("9")));
+		Assertions.assertNotNull(dnl);
+
+		Assertions.assertEquals(List.of(List.of(Id.createLinkId("11"), Id.createLinkId("7"))),
+				dnl.getDisallowedLinkSequences("car"));
+	}
+
+	@Test
+	void test6Valid() {
+
+		// only straight is allowed
+		Network network = convert("tr6_valid.osm");
+
+		// --------------------------------------------------------------------
+
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+		long noOfDnl = network.getLinks().values().stream()
+				.map(NetworkUtils::getDisallowedNextLinks)
+				.filter(Objects::nonNull)
+				.count();
+		Assertions.assertEquals(1L, noOfDnl);
+
+		DisallowedNextLinks dnl = NetworkUtils.getDisallowedNextLinks(network.getLinks().get(Id.createLinkId("3")));
+		Assertions.assertNotNull(dnl);
+
+		Assertions.assertEquals(List.of(
+				List.of(Id.createLinkId("4")), List.of(Id.createLinkId("6")), List.of(Id.createLinkId("8"))),
+				dnl.getDisallowedLinkSequences("car"));
+	}
+
+	@Test
+	void testRudolfplatz() {
+
+		Network network = convert("Rudolfplatz.osm");
+
+		// --------------------------------------------------------------------
+
+		Id<Link> lId124 = Id.createLinkId("124");
+		Link l124 = network.getLinks().get(lId124);
+		DisallowedNextLinks dnl = NetworkUtils.getDisallowedNextLinks(l124);
+
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+		long noOfDnl = network.getLinks().values().stream()
+				.map(NetworkUtils::getDisallowedNextLinks)
+				.filter(Objects::nonNull)
+				.count();
+		Assertions.assertEquals(11L, noOfDnl);
+
+		Assertions.assertEquals(Map.of(
+				"bus", List.of(List.of(Id.createLinkId("68"), Id.createLinkId("414"))),
+				TransportMode.car, List.of(List.of(Id.createLinkId("68"), Id.createLinkId("414"))),
+				TransportMode.pt, List.of(List.of(Id.createLinkId("68"), Id.createLinkId("414")))), dnl.getAsMap());
+	}
+
+	// Helpers
+
+	static Network convert(String filename) {
+
 		// setup config
 		OsmConverterConfigGroup osmConfig = OsmConverterConfigGroup.createDefaultConfig();
 		osmConfig.setOutputCoordinateSystem("EPSG:25832");
-		osmConfig.setOsmFile("test/osm/Rudolfplatz.osm");
-		osmConfig.setOutputNetworkFile("test/osm/Rudolfplatz.xml.gz");
+		osmConfig.setOsmFile("test/osm/" + filename);
+		osmConfig.setOutputNetworkFile("test/osm/" + filename.replace(".osm", "") + ".xml");
 		osmConfig.setMaxLinkLength(1000);
 		osmConfig.parseTurnRestrictions = true;
 
@@ -41,35 +241,14 @@ class OsmMultimodalNetworkConverterTurnRestrictionsTest {
 		OsmMultimodalNetworkConverter converter = new OsmMultimodalNetworkConverter(osm);
 		converter.convert(osmConfig);
 
-		network = converter.getNetwork();
+		Network network = converter.getNetwork();
 
 		// write file
-		// NetworkTools.writeNetwork(network, osmConfig.getOutputNetworkFile());
-	}
+		if (DEBUG) {
+			NetworkTools.writeNetwork(network, osmConfig.getOutputNetworkFile());
+		}
 
-	@Test
-	void testisValid() {
-
-		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
-
-	}
-
-	@Test
-	void testDisallowedNextLinks() {
-
-		Id<Link> lId124 = Id.createLinkId("124");
-		Link l124 = network.getLinks().get(lId124);
-		DisallowedNextLinks dnl = NetworkUtils.getDisallowedNextLinks(l124);
-		long noOfDnl = network.getLinks().values().stream()
-				.map(NetworkUtils::getDisallowedNextLinks)
-				.filter(Objects::nonNull)
-				.count();
-
-		Assertions.assertEquals(Map.of(
-				"bus", List.of(List.of(Id.createLinkId("68"), Id.createLinkId("414"))),
-				TransportMode.car, List.of(List.of(Id.createLinkId("68"), Id.createLinkId("414"))),
-				TransportMode.pt, List.of(List.of(Id.createLinkId("68"), Id.createLinkId("414")))), dnl.getAsMap());
-		Assertions.assertEquals(11L, noOfDnl);
+		return network;
 	}
 
 }

--- a/test/osm/tr0_valid.osm
+++ b/test/osm/tr0_valid.osm
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-25468' action='modify' visible='true' lat='52.27555212699' lon='10.48961916162' />
+  <node id='-25469' action='modify' visible='true' lat='52.27540125106' lon='10.50074851706' />
+  <node id='-25470' action='modify' visible='true' lat='52.27839664183' lon='10.49532549442' />
+  <node id='-25471' action='modify' visible='true' lat='52.26065798802' lon='10.49425261081' />
+  <node id='-25472' action='modify' visible='true' lat='52.27556124957' lon='10.49517783808' />
+  <node id='-25473' action='modify' visible='true' lat='52.26038471718' lon='10.52768860166' />
+  <way id='-763' action='modify' visible='true'>
+    <nd ref='-25468' />
+    <nd ref='-25472' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='from (west)' />
+  </way>
+  <way id='-764' action='modify' visible='true'>
+    <nd ref='-25472' />
+    <nd ref='-25471' />
+    <nd ref='-25473' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='south' />
+  </way>
+  <way id='-765' action='modify' visible='true'>
+    <nd ref='-25472' />
+    <nd ref='-25469' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='east' />
+  </way>
+  <way id='-808' action='modify' visible='true'>
+    <nd ref='-25470' />
+    <nd ref='-25472' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='north' />
+  </way>
+  <relation id='-64' action='modify' visible='true'>
+    <member type='node' ref='-25472' role='via' />
+    <member type='way' ref='-763' role='from' />
+    <member type='way' ref='-764' role='to' />
+    <tag k='restriction' v='no_right_turn' />
+    <tag k='type' v='restriction' />
+  </relation>
+</osm>

--- a/test/osm/tr1_invalid.osm
+++ b/test/osm/tr1_invalid.osm
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-25468' action='modify' visible='true' lat='52.27555212699' lon='10.48961916162' />
+  <node id='-25469' action='modify' visible='true' lat='52.27540125106' lon='10.50074851706' />
+  <node id='-25470' action='modify' visible='true' lat='52.27839664183' lon='10.49532549442' />
+  <node id='-25471' action='modify' visible='true' lat='52.27294933513' lon='10.49502508701' />
+  <node id='-25472' action='modify' visible='true' lat='52.27556124957' lon='10.49517783808' />
+  <node id='-25473' action='modify' visible='true' lat='52.27057528358' lon='10.49876365964' />
+  <way id='-763' action='modify' visible='true'>
+    <nd ref='-25468' />
+    <nd ref='-25472' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='from' />
+  </way>
+  <way id='-764' action='modify' visible='true'>
+    <nd ref='-25470' />
+    <nd ref='-25472' />
+    <nd ref='-25471' />
+    <nd ref='-25473' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='to' />
+  </way>
+  <way id='-765' action='modify' visible='true'>
+    <nd ref='-25472' />
+    <nd ref='-25469' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='leaving intersection' />
+  </way>
+  <relation id='-64' action='modify' visible='true'>
+    <member type='node' ref='-25472' role='via' />
+    <member type='way' ref='-763' role='from' />
+    <member type='way' ref='-764' role='to' />
+    <tag k='restriction' v='no_right_turn' />
+    <tag k='type' v='restriction' />
+  </relation>
+</osm>

--- a/test/osm/tr2_valid.osm
+++ b/test/osm/tr2_valid.osm
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-25468' action='modify' visible='true' lat='52.27555212699' lon='10.48961916162' />
+  <node id='-25469' action='modify' visible='true' lat='52.27540125106' lon='10.50074851706' />
+  <node id='-25470' action='modify' visible='true' lat='52.27839664183' lon='10.49532549442' />
+  <node id='-25471' action='modify' visible='true' lat='52.27179388351' lon='10.49493925632' />
+  <node id='-25472' action='modify' visible='true' lat='52.27556124957' lon='10.49517783808' />
+  <way id='-763' action='modify' visible='true'>
+    <nd ref='-25468' />
+    <nd ref='-25472' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='from (west)' />
+  </way>
+  <way id='-764' action='modify' visible='true'>
+    <nd ref='-25472' />
+    <nd ref='-25471' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='south' />
+  </way>
+  <way id='-765' action='modify' visible='true'>
+    <nd ref='-25472' />
+    <nd ref='-25469' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='east' />
+  </way>
+  <way id='-808' action='modify' visible='true'>
+    <nd ref='-25470' />
+    <nd ref='-25472' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='north' />
+  </way>
+  <relation id='-64' action='modify' visible='true'>
+    <member type='node' ref='-25472' role='via' />
+    <member type='way' ref='-763' role='from' />
+    <member type='way' ref='-763' role='to' />
+    <tag k='restriction' v='no_u_turn' />
+    <tag k='type' v='restriction' />
+  </relation>
+</osm>

--- a/test/osm/tr3_valid.osm
+++ b/test/osm/tr3_valid.osm
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-25877' action='modify' visible='true' lat='52.2754996102' lon='10.46644487573' />
+  <node id='-25878' action='modify' visible='true' lat='52.27540125106' lon='10.50074851706' />
+  <node id='-25879' action='modify' visible='true' lat='52.27839664183' lon='10.49532549442' />
+  <node id='-25880' action='modify' visible='true' lat='52.27179388351' lon='10.49493925632' />
+  <node id='-25881' action='modify' visible='true' lat='52.27556124957' lon='10.49517783808' />
+  <node id='-25882' action='modify' visible='true' lat='52.25775615326' lon='10.46610823631' />
+  <way id='-1255' action='modify' visible='true'>
+    <nd ref='-25882' />
+    <nd ref='-25877' />
+    <nd ref='-25881' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='from (west)' />
+  </way>
+  <way id='-1256' action='modify' visible='true'>
+    <nd ref='-25881' />
+    <nd ref='-25880' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='south' />
+  </way>
+  <way id='-1257' action='modify' visible='true'>
+    <nd ref='-25881' />
+    <nd ref='-25878' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='east' />
+  </way>
+  <way id='-1258' action='modify' visible='true'>
+    <nd ref='-25879' />
+    <nd ref='-25881' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='north' />
+  </way>
+  <relation id='-72' action='modify' visible='true'>
+    <member type='way' ref='-1255' role='from' />
+    <member type='node' ref='-25881' role='via' />
+    <member type='way' ref='-1255' role='to' />
+    <tag k='restriction' v='no_u_turn' />
+    <tag k='type' v='restriction' />
+  </relation>
+</osm>

--- a/test/osm/tr4_valid.osm
+++ b/test/osm/tr4_valid.osm
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-25631' action='modify' visible='true' lat='52.27539457643' lon='10.48923292352' />
+  <node id='-25632' action='modify' visible='true' lat='52.27529621706' lon='10.50083434774' />
+  <node id='-25633' action='modify' visible='true' lat='52.2851178459' lon='10.49532549442' />
+  <node id='-25634' action='modify' visible='true' lat='52.26097319333' lon='10.49459593357' />
+  <node id='-25635' action='modify' visible='true' lat='52.27540369904' lon='10.4950061767' />
+  <node id='-25636' action='modify' visible='true' lat='52.27256935051' lon='10.49486151695' />
+  <node id='-25637' action='modify' visible='true' lat='52.27264813088' lon='10.48923960686' />
+  <node id='-25762' action='modify' visible='true' lat='52.2725430641' lon='10.50091262341' />
+  <way id='-996' action='modify' visible='true'>
+    <nd ref='-25635' />
+    <nd ref='-25631' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='to (west)' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-997' action='modify' visible='true'>
+    <nd ref='-25636' />
+    <nd ref='-25634' />
+    <nd ref='-25637' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='south' />
+  </way>
+  <way id='-998' action='modify' visible='true'>
+    <nd ref='-25635' />
+    <nd ref='-25632' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='east' />
+  </way>
+  <way id='-999' action='modify' visible='true'>
+    <nd ref='-25631' />
+    <nd ref='-25633' />
+    <nd ref='-25635' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='north' />
+  </way>
+  <way id='-1000' action='modify' visible='true'>
+    <nd ref='-25635' />
+    <nd ref='-25636' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='via (north-south)' />
+  </way>
+  <way id='-1001' action='modify' visible='true'>
+    <nd ref='-25637' />
+    <nd ref='-25636' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='from (west)' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-1068' action='modify' visible='true'>
+    <nd ref='-25631' />
+    <nd ref='-25637' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='south (west)' />
+  </way>
+  <way id='-1129' action='modify' visible='true'>
+    <nd ref='-25636' />
+    <nd ref='-25762' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='east' />
+  </way>
+  <relation id='-69' action='modify' visible='true'>
+    <member type='way' ref='-996' role='to' />
+    <member type='way' ref='-1000' role='via' />
+    <member type='way' ref='-1001' role='from' />
+    <tag k='restriction' v='no_u_turn' />
+    <tag k='type' v='restriction' />
+  </relation>
+</osm>

--- a/test/osm/tr5_valid.osm
+++ b/test/osm/tr5_valid.osm
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-25631' action='modify' visible='true' lat='52.27523702531' lon='10.46979227258' />
+  <node id='-25632' action='modify' visible='true' lat='52.27529621706' lon='10.50083434774' />
+  <node id='-25633' action='modify' visible='true' lat='52.2851178459' lon='10.49532549442' />
+  <node id='-25634' action='modify' visible='true' lat='52.26097319333' lon='10.49459593357' />
+  <node id='-25635' action='modify' visible='true' lat='52.27540369904' lon='10.4950061767' />
+  <node id='-25636' action='modify' visible='true' lat='52.27256935051' lon='10.49486151695' />
+  <node id='-25637' action='modify' visible='true' lat='52.27249057' lon='10.46979895592' />
+  <node id='-25762' action='modify' visible='true' lat='52.2725430641' lon='10.50091262341' />
+  <node id='-25848' action='modify' visible='true' lat='52.26613512135' lon='10.49065585613' />
+  <node id='-25866' action='modify' visible='true' lat='52.28018413894' lon='10.48842421532' />
+  <way id='-996' action='modify' visible='true'>
+    <nd ref='-25635' />
+    <nd ref='-25866' />
+    <nd ref='-25631' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='to (west)' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-997' action='modify' visible='true'>
+    <nd ref='-25636' />
+    <nd ref='-25634' />
+    <nd ref='-25637' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='south' />
+  </way>
+  <way id='-998' action='modify' visible='true'>
+    <nd ref='-25635' />
+    <nd ref='-25632' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='east' />
+  </way>
+  <way id='-999' action='modify' visible='true'>
+    <nd ref='-25631' />
+    <nd ref='-25633' />
+    <nd ref='-25635' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='north' />
+  </way>
+  <way id='-1000' action='modify' visible='true'>
+    <nd ref='-25635' />
+    <nd ref='-25636' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='via (north-south)' />
+  </way>
+  <way id='-1001' action='modify' visible='true'>
+    <nd ref='-25637' />
+    <nd ref='-25848' />
+    <nd ref='-25636' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='from (west)' />
+    <tag k='oneway' v='yes' />
+  </way>
+  <way id='-1068' action='modify' visible='true'>
+    <nd ref='-25631' />
+    <nd ref='-25637' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='south (west)' />
+  </way>
+  <way id='-1129' action='modify' visible='true'>
+    <nd ref='-25636' />
+    <nd ref='-25762' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='east' />
+  </way>
+  <relation id='-69' action='modify' visible='true'>
+    <member type='way' ref='-996' role='to' />
+    <member type='way' ref='-1000' role='via' />
+    <member type='way' ref='-1001' role='from' />
+    <tag k='restriction' v='no_u_turn' />
+    <tag k='type' v='restriction' />
+  </relation>
+</osm>

--- a/test/osm/tr6_valid.osm
+++ b/test/osm/tr6_valid.osm
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-25927' action='modify' visible='true' lat='52.2741866167' lon='10.47263669729' />
+  <node id='-25930' action='modify' visible='true' lat='52.27412572376' lon='10.48602175298' />
+  <node id='-25931' action='modify' visible='true' lat='52.27409527727' lon='10.49806332724' />
+  <node id='-25934' action='modify' visible='true' lat='52.28024504539' lon='10.48592223583' />
+  <node id='-25935' action='modify' visible='true' lat='52.26919311828' lon='10.48607151155' />
+  <way id='-1301' action='modify' visible='true'>
+    <nd ref='-25927' />
+    <nd ref='-25930' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='west' />
+  </way>
+  <way id='-1302' action='modify' visible='true'>
+    <nd ref='-25931' />
+    <nd ref='-25930' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='east' />
+  </way>
+  <way id='-1305' action='modify' visible='true'>
+    <nd ref='-25934' />
+    <nd ref='-25930' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='north' />
+  </way>
+  <way id='-1306' action='modify' visible='true'>
+    <nd ref='-25935' />
+    <nd ref='-25930' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='south' />
+  </way>
+  <relation id='-84' action='modify' visible='true'>
+    <member type='way' ref='-1301' role='from' />
+    <member type='node' ref='-25930' role='via' />
+    <member type='way' ref='-1302' role='to' />
+    <tag k='restriction' v='only_straight_on' />
+    <tag k='type' v='restriction' />
+  </relation>
+</osm>


### PR DESCRIPTION
This change revamps the parsing of turn restrictions and adds some tests for edge cases like `to` and `from` being the same way for u-turns and `via` being links and not nodes.