### PR TITLE
Bump actions/cache from v2 to v4

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
As of https://github.com/actions/cache/discussions/1510, there are no changes to the parameters of the action despite bumping the version. This should close https://github.com/matsim-org/pt2matsim/issues/268.