### PR TITLE
Enable parsing of turn restrictions by default

### DIFF
--- a/doc/defaultOsmConfig.xml
+++ b/doc/defaultOsmConfig.xml
@@ -25,7 +25,7 @@
 		<param name="outputDetailedLinkGeometryFile" value="null" />
 		<param name="outputNetworkFile" value="null" />
 		<!-- If true: OSM turn restrictions are parsed and written as disallowedNextLinks attribute to the first link. -->
-		<param name="parseTurnRestrictions" value="false" />
+		<param name="parseTurnRestrictions" value="true" />
 		<!-- In case the speed limit allowed does not represent the speed a vehicle can actually realize, 
 		e.g. by constrains of traffic lights not explicitly modeled, a kind of "average simulated speed" can be used.
 		Defaults to false. Set true to scale the speed limit down by the value specified by the wayDefaultParams) -->

--- a/src/main/java/org/matsim/pt2matsim/config/OsmConverterConfigGroup.java
+++ b/src/main/java/org/matsim/pt2matsim/config/OsmConverterConfigGroup.java
@@ -69,7 +69,7 @@ public class OsmConverterConfigGroup extends ReflectiveConfigGroup {
 
 	@Parameter
 	@Comment("If true: OSM turn restrictions are parsed and written as disallowedNextLinks attribute to the first link.")
-	public boolean parseTurnRestrictions = false;
+	public boolean parseTurnRestrictions = true;
 
 	public OsmConverterConfigGroup() {
 		super(GROUP_NAME);

--- a/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
+++ b/src/test/java/org/matsim/pt2matsim/osm/OsmMultimodalNetworkConverterTest.java
@@ -34,7 +34,6 @@ public class OsmMultimodalNetworkConverterTest {
 		osmConfig.setOsmFile("test/osm/GerasdorfArtificialLanesAndMaxspeed.osm");
 		osmConfig.setOutputNetworkFile("test/osm/GerasdorfArtificialLanesAndMaxspeed.xml.gz");
 		osmConfig.setMaxLinkLength(1000);
-		osmConfig.parseTurnRestrictions = true; // turn restrictions not explicitly tested in this class
 
 		// read OSM file
 		OsmData osm = new OsmDataImpl();


### PR DESCRIPTION
As routing, network cleaning/simplifying, and more with turn restrictions is now fully supported by MATSim (see https://github.com/matsim-org/matsim-libs/issues/2829), we can enable parsing them by default. 🎉 