### PR TITLE
fix(deps): add junit-jupiter-engine for running with test engines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>5.12.0</version>


### PR DESCRIPTION
This seems to be required for running JUnit 6 tests with test engines.