### PR TITLE
Implement vehicle type resolution based on GTFS route short names

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/gtfs/GtfsConverter.java
@@ -26,6 +26,7 @@ import org.matsim.pt.transitSchedule.api.*;
 import org.matsim.pt2matsim.gtfs.lib.*;
 import org.matsim.pt2matsim.tools.GtfsTools;
 import org.matsim.pt2matsim.tools.ScheduleTools;
+import org.matsim.pt2matsim.tools.VehicleTypeDefaults;
 import org.matsim.pt2matsim.tools.debug.ScheduleCleaner;
 import org.matsim.pt2matsim.tools.lib.RouteShape;
 import org.matsim.vehicles.*;
@@ -354,22 +355,21 @@ public class GtfsConverter {
 
 	protected void createVehicles(TransitSchedule schedule, Vehicles vehicles) {
 		VehiclesFactory vf = vehicles.getFactory();
-		Map<GtfsDefinitions.ExtendedRouteType, VehicleType> vehicleTypes = new HashMap<>();
+		Map<VehicleTypeDefaults.Type, VehicleType> vehicleTypes = new HashMap<>();
 
 		long vehId = 0;
 		for(TransitLine line : schedule.getTransitLines().values()) {
-			// get extended route type
 			Route gtfsRoute = feed.getRoutes().get(line.getId().toString());
-			GtfsDefinitions.ExtendedRouteType extType = gtfsRoute.getExtendedRouteType();
+			VehicleTypeDefaults.Type resolvedType = resolveVehicleType(gtfsRoute);
 
-			// create vehicle type for each extended route type
-			if(!vehicleTypes.containsKey(extType)) {
-				VehicleType defaultVehicleType = ScheduleTools.createDefaultVehicleType(extType.name, extType.routeType.name);
+			// create vehicle type for each resolved type
+			if(!vehicleTypes.containsKey(resolvedType)) {
+				VehicleType defaultVehicleType = ScheduleTools.createDefaultVehicleType(resolvedType.name, resolvedType);
 				vehicles.addVehicleType(defaultVehicleType);
-				vehicleTypes.put(extType, defaultVehicleType);
+				vehicleTypes.put(resolvedType, defaultVehicleType);
 			}
 
-			VehicleType vehicleType = vehicleTypes.get(extType);
+			VehicleType vehicleType = vehicleTypes.get(resolvedType);
 			for(TransitRoute route : line.getRoutes().values()) {
 				// create a vehicle for each departure
 				for(Departure departure : route.getDepartures().values()) {
@@ -386,6 +386,61 @@ public class GtfsConverter {
 				vehicleType.getCapacity().setStandingRoom(0);
 			}
 		}
+	}
+
+	/**
+	 * Resolves the {@link VehicleTypeDefaults.Type} for a GTFS route.
+	 * Tries to match the alphabetic prefix of {@code route_short_name} against
+	 * the {@link VehicleTypeDefaults.Type} enum, guarded by route type compatibility.
+	 * Falls back to the base route type (e.g. RAIL, BUS, TRAM).
+	 *
+	 * <p>Note: The current prefix-matching logic and vehicle type defaults are heavily
+	 * based on German/DACH transit naming conventions (e.g. ICE, RE, RB, S-Bahn).
+	 * A more generic, country-agnostic approach is desirable - issues and/or PRs to
+	 * improve support for other countries' conventions are very welcome.</p>
+	 *
+	 * <p>Can be overridden to implement custom vehicle type resolution logic.</p>
+	 */
+	protected VehicleTypeDefaults.Type resolveVehicleType(Route gtfsRoute) {
+		String shortName = gtfsRoute.getShortName();
+		GtfsDefinitions.RouteType baseType = gtfsRoute.getRouteType();
+
+		if(shortName != null && !shortName.isEmpty()) {
+			// Extract alphabetic prefix: "ICE 28" -> "ICE", "S1" -> "S", "RE5" -> "RE"
+			String prefix = shortName.replaceAll("[^A-Za-z].*", "").toUpperCase();
+			if(!prefix.isEmpty()) {
+				try {
+					VehicleTypeDefaults.Type candidate = VehicleTypeDefaults.Type.valueOf(prefix);
+					if(isCompatible(candidate.transportMode, baseType)) {
+						return candidate;
+					}
+				} catch(IllegalArgumentException ignored) {
+					// No matching entry in VehicleTypeDefaults
+				}
+			}
+		}
+
+		// Fall back to base route type
+		String defVehType = gtfsRoute.getExtendedRouteType().routeType.name
+				.toUpperCase().replace(" ", "_");
+		try {
+			return VehicleTypeDefaults.Type.valueOf(defVehType);
+		} catch(IllegalArgumentException e) {
+			return VehicleTypeDefaults.Type.OTHER;
+		}
+	}
+
+	private static boolean isCompatible(GtfsDefinitions.RouteType vehicleMode,
+			GtfsDefinitions.RouteType routeType) {
+		if(vehicleMode == routeType) {
+			return true;
+		}
+		// U-Bahn (SUBWAY) often coded as RAIL in German GTFS
+		if(vehicleMode == GtfsDefinitions.RouteType.SUBWAY
+				&& routeType == GtfsDefinitions.RouteType.RAIL) {
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/ScheduleTools.java
@@ -191,16 +191,23 @@ public final class ScheduleTools {
 	 */
 	public static VehicleType createDefaultVehicleType(String id, String defaultVehicleType) {
 		String defVehType = defaultVehicleType.toUpperCase().replace(" ", "_");
-		VehiclesFactory vf = VehicleUtils.createVehiclesContainer().getFactory();
-		Id<VehicleType> vTypeId = Id.create(id, VehicleType.class);
 
-		// using default values for vehicle type
 		VehicleTypeDefaults.Type defaultValues = VehicleTypeDefaults.Type.OTHER;
 		try {
 			defaultValues = VehicleTypeDefaults.Type.valueOf(defVehType);
 		} catch (IllegalArgumentException e) {
 			log.warn("Vehicle category '" + defVehType + "' is unknown. Falling back to generic OTHER and adding to schedule.");
 		}
+
+		return createDefaultVehicleType(id, defaultValues);
+	}
+
+	/**
+	 * Creates a vehicle type with the given id and parameters from the provided {@link VehicleTypeDefaults.Type}.
+	 */
+	public static VehicleType createDefaultVehicleType(String id, VehicleTypeDefaults.Type defaultValues) {
+		VehiclesFactory vf = VehicleUtils.createVehiclesContainer().getFactory();
+		Id<VehicleType> vTypeId = Id.create(id, VehicleType.class);
 
 		VehicleType vehicleType = vf.createVehicleType(vTypeId);
 		vehicleType.setLength(defaultValues.length);

--- a/src/main/java/org/matsim/pt2matsim/tools/VehicleTypeDefaults.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/VehicleTypeDefaults.java
@@ -44,7 +44,6 @@ public final class VehicleTypeDefaults {
 		BAV	("BAV",	RouteType.FERRY,	true,	50,		6,		0.5,	0.5,	VehicleType.DoorOperationMode.serial,	250,	50,		7.1,	false,	"Steam ship"),
 		BEX ("BEX",	RouteType.RAIL,		true,	150,	2.8,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	240,	50,		20.4,	false,	"Bernina Express"),
 		B	("BUS",	RouteType.BUS,		true,	18,		2.5,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	70,		50,		2.8,	true,	"Bus"),
-		BUS	("BUS",	RouteType.BUS,		true,	18,		2.5,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	70,		50,		2.8,	true,	"Bus"),
 		C	("C",	RouteType.RAIL,		true,	150,	2.8,	0.25,	0.25,	VehicleType.DoorOperationMode.serial,	400,	400,	20.4,	false,	"Citybahn"),
 		CD	("CD",	RouteType.RAIL,		true,	150,	2.8,	0.25,	0.25,	VehicleType.DoorOperationMode.serial,	400,	400,	20.4,	false,	"Ceske Drahy"),
 		CNL ("CNL",	RouteType.RAIL,		true,	200,	2.8,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	400,	0,		27.1,	false,	"CityNightLine"),
@@ -107,15 +106,15 @@ public final class VehicleTypeDefaults {
 		//								            add		DEFAULT VALUES
 		//								            to		length	width	accT	egrT	doorOp									capSeat	capSt	pcuEq	usesRN	description
 		//								            sched.	[m]		[m]		s/pers	s/pers
-		TRAM ("TRAM",       RouteType.TRAM,			true,	36,		2.4,	0.25,	0.25,	VehicleType.DoorOperationMode.serial, 	180,	100,	5.2	,	true,	"tram"),
-		SUBWAY ("SUBWAY",   RouteType.SUBWAY,		true,	30,		2.45,	0.1,	0.1,	VehicleType.DoorOperationMode.serial,	300,	300,	4.4,	false,	"subway"),
-		RAIL ("RAIL",       RouteType.RAIL,			true,	200,	2.8,	0.25,	0.25,	VehicleType.DoorOperationMode.serial,	400,	200,	27.1,	false,	"rail"),
-		// BUS exists for HAFAS
-		FERRY	("FERRY",	RouteType.FERRY,		true,	50,		6,		0.5,	0.5,	VehicleType.DoorOperationMode.serial,	250,	50,		7.1,	false,	"ferry"),
-		CABLE_CAR ("CABLE_CAR",RouteType.CABLE_CAR,	true,	12,		3,		0.5,	0.5,	VehicleType.DoorOperationMode.serial,	60,		20,		5.2,	false,	"cable car"),
-		GONDOLA	("GONDOLA",	RouteType.GONDOLA,		true,	6,		3.5,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	80,		20,		1.2,	false,	"gondola"),
+		TRAM ("Tram",       RouteType.TRAM,			true,	36,		2.4,	0.25,	0.25,	VehicleType.DoorOperationMode.serial, 	180,	100,	5.2	,	true,	"tram"),
+		SUBWAY ("Subway",   RouteType.SUBWAY,		true,	30,		2.45,	0.1,	0.1,	VehicleType.DoorOperationMode.serial,	300,	300,	4.4,	false,	"subway"),
+		RAIL ("Rail",       RouteType.RAIL,			true,	200,	2.8,	0.25,	0.25,	VehicleType.DoorOperationMode.serial,	400,	200,	27.1,	false,	"rail"),
+		BUS	("Bus",	RouteType.BUS,		true,	18,		2.5,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	70,		50,		2.8,	true,	"Bus"),
+		FERRY	("Ferry",	RouteType.FERRY,		true,	50,		6,		0.5,	0.5,	VehicleType.DoorOperationMode.serial,	250,	50,		7.1,	false,	"ferry"),
+		CABLE_CAR ("CableCar",RouteType.CABLE_CAR,	true,	12,		3,		0.5,	0.5,	VehicleType.DoorOperationMode.serial,	60,		20,		5.2,	false,	"cable car"),
+		GONDOLA	("Gondola",	RouteType.GONDOLA,		true,	6,		3.5,	0.5,	0.5,	VehicleType.DoorOperationMode.serial,	80,		20,		1.2,	false,	"gondola"),
 		FUNICULAR	("FUN",	RouteType.FUNICULAR,	true,	10,		2.5,	0.5	,	0.5, 	VehicleType.DoorOperationMode.serial,	100,	50,		1.7,	false,	"funicular"),
-		OTHER	("OTHER",	RouteType.OTHER,		true,	10,		2.5,	0.5	,	0.5, 	VehicleType.DoorOperationMode.serial,	50,	    20,		2.0,    false,	"other");
+		OTHER	("Other",	RouteType.OTHER,		true,	10,		2.5,	0.5	,	0.5, 	VehicleType.DoorOperationMode.serial,	50,	    20,		2.0,    false,	"other");
 
 		public double length, width, accessTime, egressTime, pcuEquivalents;
 		public int capacitySeats, capacityStanding;

--- a/src/test/java/org/matsim/pt2matsim/gtfs/ResolveVehicleTypeTest.java
+++ b/src/test/java/org/matsim/pt2matsim/gtfs/ResolveVehicleTypeTest.java
@@ -1,0 +1,197 @@
+package org.matsim.pt2matsim.gtfs;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.matsim.pt2matsim.gtfs.lib.*;
+import org.matsim.pt2matsim.gtfs.lib.GtfsDefinitions.RouteType;
+import org.matsim.pt2matsim.tools.VehicleTypeDefaults;
+
+/**
+ * Tests for {@link GtfsConverter#resolveVehicleType(Route)}.
+ */
+class ResolveVehicleTypeTest {
+
+	private TestableGtfsConverter converter;
+
+	@BeforeEach
+	void setUp() {
+		GtfsFeed feed = new GtfsFeedImpl("test/gtfs-feed/");
+		converter = new TestableGtfsConverter(feed);
+	}
+
+	// --- Prefix matching: rail short names ---
+
+	@Test
+	void iceRoute() {
+		Route route = createRoute("ICE 1234", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.ICE, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void sbahnRoute() {
+		Route route = createRoute("S1", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.S, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void reRoute() {
+		Route route = createRoute("RE5", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.RE, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void rbRoute() {
+		Route route = createRoute("RB51", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.RB, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void icRoute() {
+		Route route = createRoute("IC 2042", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.IC, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void ecRoute() {
+		Route route = createRoute("EC 8", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.EC, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void fexRoute() {
+		Route route = createRoute("FEX", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.FEX, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void mexRoute() {
+		Route route = createRoute("MEX18", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.MEX, converter.resolveVehicleType(route));
+	}
+
+	// --- Cross-mode guard: bus with rail-like short name ---
+
+	@Test
+	void busWithSbahnName() {
+		// SEV bus named "S1" should NOT get S-Bahn type
+		Route route = createRoute("S1", RouteType.BUS);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.BUS, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void busWithReName() {
+		// SEV bus named "RE1" should NOT get RegioExpress type
+		Route route = createRoute("RE1", RouteType.BUS);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.BUS, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void busWithRbName() {
+		Route route = createRoute("RB49", RouteType.BUS);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.BUS, converter.resolveVehicleType(route));
+	}
+
+	// --- U-Bahn coded as RAIL should still match SUBWAY type ---
+
+	@Test
+	void ubahnCodedAsRail() {
+		Route route = createRoute("U1", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.U, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void ubahnCodedAsSubway() {
+		Route route = createRoute("U7", RouteType.SUBWAY);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.U, converter.resolveVehicleType(route));
+	}
+
+	// --- Tram matching ---
+
+	@Test
+	void tramRoute() {
+		Route route = createRoute("T3", RouteType.TRAM);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.T, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void tramWithMPrefix() {
+		// Berlin MetroTram "M1" — M is SUBWAY type, TRAM route_type -> not compatible -> fallback
+		Route route = createRoute("M1", RouteType.TRAM);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.TRAM, converter.resolveVehicleType(route));
+	}
+
+	// --- Fallback: numeric-only short name ---
+
+	@Test
+	void numericShortName() {
+		Route route = createRoute("5007", RouteType.BUS);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.BUS, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void numericRailShortName() {
+		Route route = createRoute("12345", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.RAIL, converter.resolveVehicleType(route));
+	}
+
+	// --- Fallback: null or empty short name ---
+
+	@Test
+	void nullShortName() {
+		Route route = createRoute(null, RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.RAIL, converter.resolveVehicleType(route));
+	}
+
+	@Test
+	void emptyShortName() {
+		Route route = createRoute("", RouteType.BUS);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.BUS, converter.resolveVehicleType(route));
+	}
+
+	// --- Fallback: unknown prefix ---
+
+	@Test
+	void unknownPrefix() {
+		Route route = createRoute("XYZ99", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.RAIL, converter.resolveVehicleType(route));
+	}
+
+	// --- Bus prefix matching ---
+
+	@Test
+	void sevBusRoute() {
+		Route route = createRoute("SEV", RouteType.BUS);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.SEV, converter.resolveVehicleType(route));
+	}
+
+	// --- Case insensitivity of prefix ---
+
+	@Test
+	void lowercasePrefix() {
+		Route route = createRoute("ice 801", RouteType.RAIL);
+		Assertions.assertEquals(VehicleTypeDefaults.Type.ICE, converter.resolveVehicleType(route));
+	}
+
+	// --- Helper methods ---
+
+	private static final Agency DUMMY_AGENCY = new AgencyImpl("test", "Test Agency", "http://test.com", "Europe/Berlin");
+
+	private static Route createRoute(String shortName, RouteType routeType) {
+		return new RouteImpl("test_route", shortName, "Test Route", DUMMY_AGENCY, routeType);
+	}
+
+	/**
+	 * Exposes the protected resolveVehicleType method for testing.
+	 */
+	private static class TestableGtfsConverter extends GtfsConverter {
+		TestableGtfsConverter(GtfsFeed feed) {
+			super(feed);
+		}
+
+		@Override
+		public VehicleTypeDefaults.Type resolveVehicleType(Route gtfsRoute) {
+			return super.resolveVehicleType(gtfsRoute);
+		}
+	}
+}

--- a/test/Gtfs2TransitScheduleIT/testNoAdditionalInfo/vehicles.xml
+++ b/test/Gtfs2TransitScheduleIT/testNoAdditionalInfo/vehicles.xml
@@ -21,6 +21,25 @@
 		<flowEfficiencyFactor factor="1.0"/>
 	</vehicleType>
 
+	<vehicleType id="Other">
+		<attributes>
+			<attribute name="accessTimeInSecondsPerPerson" class="java.lang.Double">0.5</attribute>
+			<attribute name="doorOperationMode" class="org.matsim.vehicles.VehicleType$DoorOperationMode">serial</attribute>
+			<attribute name="egressTimeInSecondsPerPerson" class="java.lang.Double">0.5</attribute>
+		</attributes>
+		<capacity seats="50" standingRoomInPersons="0">
+
+		</capacity>
+		<length meter="10.0"/>
+		<width meter="2.5"/>
+		<costInformation>
+
+		</costInformation>
+		<passengerCarEquivalents pce="2.0"/>
+		<networkMode networkMode="other"/>
+		<flowEfficiencyFactor factor="1.0"/>
+	</vehicleType>
+
 	<vehicleType id="Tram">
 		<attributes>
 			<attribute name="accessTimeInSecondsPerPerson" class="java.lang.Double">0.25</attribute>
@@ -37,25 +56,6 @@
 		</costInformation>
 		<passengerCarEquivalents pce="5.2"/>
 		<networkMode networkMode="tram"/>
-		<flowEfficiencyFactor factor="1.0"/>
-	</vehicleType>
-
-	<vehicleType id="Unknown">
-		<attributes>
-			<attribute name="accessTimeInSecondsPerPerson" class="java.lang.Double">0.5</attribute>
-			<attribute name="doorOperationMode" class="org.matsim.vehicles.VehicleType$DoorOperationMode">serial</attribute>
-			<attribute name="egressTimeInSecondsPerPerson" class="java.lang.Double">0.5</attribute>
-		</attributes>
-		<capacity seats="50" standingRoomInPersons="0">
-
-		</capacity>
-		<length meter="10.0"/>
-		<width meter="2.5"/>
-		<costInformation>
-
-		</costInformation>
-		<passengerCarEquivalents pce="2.0"/>
-		<networkMode networkMode="other"/>
 		<flowEfficiencyFactor factor="1.0"/>
 	</vehicleType>
 


### PR DESCRIPTION
**Add `resolveVehicleType()` with short-name prefix matching in `GtfsConverter`**

Refactors vehicle type resolution to extract alphabetic prefixes from `route_short_name` (e.g. `ICE 28` → `ICE`, `S1` → `S`) for more specific vehicle parameters instead of relying solely on `ExtendedRouteType`.

**Changes:**
- `GtfsConverter`: Add `resolveVehicleType(Route)` with prefix extraction, `VehicleTypeDefaults.Type` lookup, and `isCompatible()` cross-mode guard (e.g. SEV bus named "S1" won't get S-Bahn parameters). U-Bahn/SUBWAY is allowed to match RAIL since German GTFS frequently miscodes it.
- `ScheduleTools`: Add `createDefaultVehicleType(String, VehicleTypeDefaults.Type)` overload to accept a resolved type directly.
- `VehicleTypeDefaults`: Move `BUS` entry to GTFS converter defaults section with display name `"Bus"`.

**Breaking changes:**
- Vehicle type IDs now use `VehicleTypeDefaults.Type.name` field: `Bus`, `Tram`, `Rail`, `Other` instead of `ExtendedRouteType` names (`Unknown` → `Other`).
- Routes with recognized prefixes get specific vehicle type IDs (`ICE`, `S`, `RE`, `RB`, etc.) instead of the generic base type.

**Backward compatibility:** 78% of German GTFS routes have numeric-only short names and fall back to base route type, unchanged from previous behavior.