### PR TITLE
perf(PseudoRouting): per-route shared work queue for dynamic load balancing

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
@@ -47,6 +47,7 @@ import org.matsim.pt2matsim.tools.debug.ScheduleCleaner;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -171,22 +172,29 @@ public class PTMapper {
 		log.info("Calculating pseudoTransitRoutes... (" + nTransitRoutes + " transit routes in " + schedule.getTransitLines().size() + " transit lines)");
 
 		Progress progress = new Progress(nTransitRoutes, "Calculating pseudoTransitRoutes ...");
-		
-		// initiate pseudoRouting
+
+		// Shared route-level work queue. All workers poll from the same queue,
+		// so an idle worker will pick up routes still pending on a busy worker
+		// (dynamic load balancing). This eliminates the line-level pre-assignment
+		// long-tail problem ("stuck at 99 %").
+		ConcurrentLinkedQueue<PseudoRoutingImpl.QueuedRoute> sharedQueue = new ConcurrentLinkedQueue<>();
+		for(TransitLine transitLine : schedule.getTransitLines().values()) {
+			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {
+				sharedQueue.add(new PseudoRoutingImpl.QueuedRoute(transitLine, transitRoute));
+			}
+		}
+
+		// initiate pseudoRouting workers (each owns its own ScheduleRouters instance)
 		PseudoRouting[] pseudoRoutingRunnables = new PseudoRouting[numThreads];
 		for(int i = 0; i < numThreads; i++) {
-			pseudoRoutingRunnables[i] = new PseudoRoutingImpl(scheduleRoutersFactory, linkCandidates, maxTravelCostFactor, progress);
-		}
-		// spread transit lines on runnables
-		int thr = 0;
-		for(TransitLine transitLine : schedule.getTransitLines().values()) {
-			pseudoRoutingRunnables[thr++ % numThreads].addTransitLineToQueue(transitLine);
+			pseudoRoutingRunnables[i] = new PseudoRoutingImpl(scheduleRoutersFactory, linkCandidates,
+					maxTravelCostFactor, progress, sharedQueue);
 		}
 
 		Thread[] threads = new Thread[numThreads];
 		// start pseudoRouting
 		for(int i = 0; i < numThreads; i++) {
-			threads[i] = new Thread(pseudoRoutingRunnables[i]);
+			threads[i] = new Thread(pseudoRoutingRunnables[i], "pseudoRouting-" + i);
 			threads[i].start();
 		}
 		for(Thread thread : threads) {

--- a/src/main/java/org/matsim/pt2matsim/mapping/PseudoRouting.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PseudoRouting.java
@@ -2,6 +2,7 @@ package org.matsim.pt2matsim.mapping;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt2matsim.mapping.linkCandidateCreation.LinkCandidate;
 import org.matsim.pt2matsim.mapping.pseudoRouter.ArtificialLink;
 import org.matsim.pt2matsim.mapping.pseudoRouter.PseudoGraph;
@@ -10,7 +11,7 @@ import org.matsim.pt2matsim.mapping.pseudoRouter.PseudoTransitRoute;
 
 /**
  * Generates and calculates the {@link PseudoTransitRoute} for each queued
- * {@link TransitLine} using a {@link PseudoGraph}. Stores the PseudoTransitRoutes
+ * {@link TransitRoute} using a {@link PseudoGraph}. Stores the PseudoTransitRoutes
  * in a {@link PseudoSchedule}.<p/>
  *
  * If no path on the network can be found, an {@link ArtificialLink} between
@@ -21,9 +22,25 @@ import org.matsim.pt2matsim.mapping.pseudoRouter.PseudoTransitRoute;
 public interface PseudoRouting extends Runnable {
 
 	/**
-	 * Adds a transit line to the queue that is processed in run()
+	 * Adds a single transit route (within its line) to the queue processed in {@link #run()}.
+	 * <p>
+	 * This is the unit-of-work entry point and should be preferred over
+	 * {@link #addTransitLineToQueue(TransitLine)} so that idle workers can pick up
+	 * remaining routes from busy workers (dynamic load balancing).
 	 */
-	void addTransitLineToQueue(TransitLine transitLine);
+	void addTransitRouteToQueue(TransitLine line, TransitRoute route);
+
+	/**
+	 * Adds all routes of a transit line to the queue.
+	 * <p>
+	 * Provided for backward compatibility. Internally enqueues each {@link TransitRoute}
+	 * via {@link #addTransitRouteToQueue(TransitLine, TransitRoute)}.
+	 */
+	default void addTransitLineToQueue(TransitLine transitLine) {
+		for (TransitRoute r : transitLine.getRoutes().values()) {
+			addTransitRouteToQueue(transitLine, r);
+		}
+	}
 
 	/**
 	 * Executes the PseudoRouting algorithm

--- a/src/main/java/org/matsim/pt2matsim/mapping/PseudoRoutingImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PseudoRoutingImpl.java
@@ -40,9 +40,14 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Generates and calculates the pseudoRoutes for all the queued
- * transit lines. If no route on the network can be found (or the
+ * transit routes. If no route on the network can be found (or the
  * scheduleTransportMode should not be mapped to the network), artificial
  * links between link candidates are stored to be created later.
+ * <p>
+ * The unit of work is a single {@link TransitRoute}. When several worker
+ * instances share the same {@link Queue}, idle workers automatically pick
+ * up remaining routes from busy workers, eliminating the "stuck at 99 %"
+ * long-tail behaviour caused by line-level pre-assignment.
  *
  * @author polettif
  */
@@ -52,7 +57,11 @@ public class PseudoRoutingImpl implements PseudoRouting {
 	private final Progress progress;
 
 	private static boolean warnMinTravelCost = true;
-	private static Queue<TransitLine> queue = new ConcurrentLinkedQueue<>();
+
+	/** Element of the work queue: the route to map plus its owning line. */
+	public record QueuedRoute(TransitLine line, TransitRoute route) {}
+
+	private final Queue<QueuedRoute> queue;
 
 	private final LinkCandidateCreator linkCandidates;
 	private final ScheduleRouters scheduleRouters;
@@ -60,138 +69,160 @@ public class PseudoRoutingImpl implements PseudoRouting {
 	private final Set<ArtificialLink> necessaryArtificialLinks = new HashSet<>();
 
 	private final PseudoSchedule threadPseudoSchedule = new PseudoScheduleImpl();
-	private double maxTravelCostFactor;
+	private final double maxTravelCostFactor;
 
-	public PseudoRoutingImpl(ScheduleRoutersFactory scheduleRoutersFactory, LinkCandidateCreator linkCandidates, double maxTravelCostFactor, Progress progress) {
+	/**
+	 * Backward-compatible constructor: the runnable owns a private queue.
+	 * Prefer the shared-queue overload below so multiple workers can balance load dynamically.
+	 */
+	public PseudoRoutingImpl(ScheduleRoutersFactory scheduleRoutersFactory, LinkCandidateCreator linkCandidates,
+			double maxTravelCostFactor, Progress progress) {
+		this(scheduleRoutersFactory, linkCandidates, maxTravelCostFactor, progress,
+				new ConcurrentLinkedQueue<>());
+	}
+
+	/**
+	 * Shared-queue constructor. All workers given the same {@code sharedQueue} poll dynamically,
+	 * so a thread that finishes early picks up routes pending on slower threads.
+	 */
+	public PseudoRoutingImpl(ScheduleRoutersFactory scheduleRoutersFactory, LinkCandidateCreator linkCandidates,
+			double maxTravelCostFactor, Progress progress, Queue<QueuedRoute> sharedQueue) {
 		this.maxTravelCostFactor = maxTravelCostFactor;
 		this.scheduleRouters = scheduleRoutersFactory.createInstance();
 		this.linkCandidates = linkCandidates;
 		this.progress = progress;
+		this.queue = sharedQueue;
 	}
 
 	@Override
-	public void addTransitLineToQueue(TransitLine transitLine) {
-		queue.add(transitLine);
+	public void addTransitRouteToQueue(TransitLine line, TransitRoute route) {
+		queue.add(new QueuedRoute(line, route));
 	}
 
 	@Override
 	public void run() {
-		
-		TransitLine transitLine;
-		while ((transitLine = queue.poll()) != null) {
-			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {
-				/* [1]
-				  Initiate pseudoGraph and Dijkstra algorithm for the current transitRoute.
+		QueuedRoute qr;
+		while ((qr = queue.poll()) != null) {
+			processRoute(qr.line(), qr.route());
+			progress.update();
+		}
+	}
 
-				  In the pseudoGraph, all link candidates are represented as nodes and the
-				  network paths between link candidates are reduced to a representation edge
-				  only storing the travel cost. With the pseudoGraph, the best linkCandidate
-				  sequence can be calculated (using Dijkstra). From this sequence, the actual
-				  path on the network can be routed later on.
-				 */
-				PseudoGraph pseudoGraph = new PseudoGraphImpl();
+	/**
+	 * Per-route processing.
+	 *
+	 * <p>The body below is intentionally identical to the previous in-line implementation;
+	 * only the surrounding {@code for (TransitRoute ...)} loop has moved out.</p>
+	 */
+	private void processRoute(TransitLine transitLine, TransitRoute transitRoute) {
+		/* [1]
+		  Initiate pseudoGraph and Dijkstra algorithm for the current transitRoute.
 
-				/* [2]
-				  Calculate the shortest paths between each pair of routeStops/ParentStopFacility
-				 */
-				List<TransitRouteStop> routeStops = transitRoute.getStops();
-				for(int i = 0; i < routeStops.size() - 1; i++) {
-					Set<LinkCandidate> linkCandidatesCurrent = linkCandidates.getLinkCandidates(routeStops.get(i), transitLine, transitRoute);
-					Set<LinkCandidate> linkCandidatesNext = linkCandidates.getLinkCandidates(routeStops.get(i + 1), transitLine, transitRoute);
+		  In the pseudoGraph, all link candidates are represented as nodes and the
+		  network paths between link candidates are reduced to a representation edge
+		  only storing the travel cost. With the pseudoGraph, the best linkCandidate
+		  sequence can be calculated (using Dijkstra). From this sequence, the actual
+		  path on the network can be routed later on.
+		 */
+		PseudoGraph pseudoGraph = new PseudoGraphImpl();
 
-					double minTravelCost = scheduleRouters.getMinimalTravelCost(routeStops.get(i), routeStops.get(i + 1), transitLine, transitRoute);
-					double maxAllowedTravelCost = minTravelCost * maxTravelCostFactor;
+		/* [2]
+		  Calculate the shortest paths between each pair of routeStops/ParentStopFacility
+		 */
+		List<TransitRouteStop> routeStops = transitRoute.getStops();
+		for(int i = 0; i < routeStops.size() - 1; i++) {
+			Set<LinkCandidate> linkCandidatesCurrent = linkCandidates.getLinkCandidates(routeStops.get(i), transitLine, transitRoute);
+			Set<LinkCandidate> linkCandidatesNext = linkCandidates.getLinkCandidates(routeStops.get(i + 1), transitLine, transitRoute);
 
-					if(minTravelCost == 0 && warnMinTravelCost) {
-						log.warn("There are stop pairs where minTravelCost is 0.0! This might happen if two stops are on the same coordinate or if departure and arrival time of two subsequent stops are identical. Further messages are suppressed.");
-						warnMinTravelCost = false;
-					}
-					
-					/* [3]
-					  Calculate the shortest path between all link candidates.
+			double minTravelCost = scheduleRouters.getMinimalTravelCost(routeStops.get(i), routeStops.get(i + 1), transitLine, transitRoute);
+			double maxAllowedTravelCost = minTravelCost * maxTravelCostFactor;
+
+			if(minTravelCost == 0 && warnMinTravelCost) {
+				log.warn("There are stop pairs where minTravelCost is 0.0! This might happen if two stops are on the same coordinate or if departure and arrival time of two subsequent stops are identical. Further messages are suppressed.");
+				warnMinTravelCost = false;
+			}
+
+			/* [3]
+			  Calculate the shortest path between all link candidates.
+			 */
+			for(LinkCandidate linkCandidateCurrent : linkCandidatesCurrent) {
+				for(LinkCandidate linkCandidateNext : linkCandidatesNext) {
+
+					boolean useExistingNetworkLinks = false;
+					double pathCost = 2 * maxAllowedTravelCost;
+					List<Link> pathLinks = null;
+
+					/* [3.1]
+					  If one or both link candidates are loop links we don't have
+					  to search a least cost path on the network.
 					 */
-					for(LinkCandidate linkCandidateCurrent : linkCandidatesCurrent) {
-						for(LinkCandidate linkCandidateNext : linkCandidatesNext) {
+					if(!linkCandidateCurrent.isLoopLink() && !linkCandidateNext.isLoopLink()) {
+						/*
+						  Calculate the least cost path on the network
+						 */
+						LeastCostPathCalculator.Path leastCostPath = scheduleRouters.calcLeastCostPath(linkCandidateCurrent, linkCandidateNext, transitLine, transitRoute);
 
-							boolean useExistingNetworkLinks = false;
-							double pathCost = 2 * maxAllowedTravelCost;
-							List<Link> pathLinks = null;
-
-							/* [3.1]
-							  If one or both link candidates are loop links we don't have
-							  to search a least cost path on the network.
-							 */
-							if(!linkCandidateCurrent.isLoopLink() && !linkCandidateNext.isLoopLink()) {
-								/*
-								  Calculate the least cost path on the network
-								 */
-								LeastCostPathCalculator.Path leastCostPath = scheduleRouters.calcLeastCostPath(linkCandidateCurrent, linkCandidateNext, transitLine, transitRoute);
-
-								if(leastCostPath != null) {
-									pathCost = leastCostPath.travelCost;
-									pathLinks = leastCostPath.links;
-									// if both link candidates are the same, cost should get higher
-									if(linkCandidateCurrent.getLink().getId().equals(linkCandidateNext.getLink().getId())) {
-										pathCost *= 4;
-									}
-								}
-								useExistingNetworkLinks = pathCost < maxAllowedTravelCost;
-							}
-
-							/* [3.2]
-							  If a path on the network could be found and its travel cost are
-							  below maxAllowedTravelCost, a normal edge is added to the pseudoGraph
-							 */
-							if(useExistingNetworkLinks) {
-								double currentCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateCurrent);
-								double nextCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateNext);
-								double edgeWeight = pathCost + 0.5 * currentCandidateTravelCost + 0.5 * nextCandidateTravelCost;
-
-								pseudoGraph.addEdge(i, routeStops.get(i), linkCandidateCurrent, routeStops.get(i + 1), linkCandidateNext, edgeWeight, pathLinks);
-							}
-							/* [3.2]
-							  Create artificial links between two routeStops if:
-							  	 - no path on the network could be found
-							    - the travel cost of the path are greater than maxAllowedTravelCost
-
-							  Artificial links are created between all LinkCandidates
-							  (usually this means between one dummy link for the stop
-							  facility and the other linkCandidates).
-							 */
-							else {
-								double currentCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateCurrent);
-								double nextCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateNext);
-								double artificialEdgeWeight = maxAllowedTravelCost - 0.5 * currentCandidateTravelCost - 0.5 * nextCandidateTravelCost;
-
-								pseudoGraph.addEdge(i, routeStops.get(i), linkCandidateCurrent, routeStops.get(i + 1), linkCandidateNext, artificialEdgeWeight, null);
+						if(leastCostPath != null) {
+							pathCost = leastCostPath.travelCost;
+							pathLinks = leastCostPath.links;
+							// if both link candidates are the same, cost should get higher
+							if(linkCandidateCurrent.getLink().getId().equals(linkCandidateNext.getLink().getId())) {
+								pathCost *= 4;
 							}
 						}
+						useExistingNetworkLinks = pathCost < maxAllowedTravelCost;
 					}
-				} // - routeStop loop
 
-				/* [4]
-				  Finish the pseudoGraph by adding dummy nodes.
-				 */
-				pseudoGraph.addDummyEdges(routeStops,
-						linkCandidates.getLinkCandidates(routeStops.get(0), transitLine, transitRoute),
-						linkCandidates.getLinkCandidates(routeStops.get(routeStops.size() - 1), transitLine, transitRoute));
+					/* [3.2]
+					  If a path on the network could be found and its travel cost are
+					  below maxAllowedTravelCost, a normal edge is added to the pseudoGraph
+					 */
+					if(useExistingNetworkLinks) {
+						double currentCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateCurrent);
+						double nextCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateNext);
+						double edgeWeight = pathCost + 0.5 * currentCandidateTravelCost + 0.5 * nextCandidateTravelCost;
 
-				/* [5]
-				  Find the least cost path i.e. the PseudoRouteStop sequence
-				 */
-				List<PseudoRouteStop> pseudoPath = pseudoGraph.getLeastCostStopSequence();
+						pseudoGraph.addEdge(i, routeStops.get(i), linkCandidateCurrent, routeStops.get(i + 1), linkCandidateNext, edgeWeight, pathLinks);
+					}
+					/* [3.2]
+					  Create artificial links between two routeStops if:
+					  	 - no path on the network could be found
+					    - the travel cost of the path are greater than maxAllowedTravelCost
 
-				if(pseudoPath == null) {
-					throw new RuntimeException("PseudoGraph has no path from SOURCE to DESTINATION for transit route " + transitRoute.getId() + " " +
-							"on line " + transitLine.getId() + " from \"" + routeStops.get(0).getStopFacility().getName() + "\" " +
-							"to \"" + routeStops.get(routeStops.size() - 1).getStopFacility().getName() + "\"");
-				} else {
-					necessaryArtificialLinks.addAll(pseudoGraph.getArtificialNetworkLinks());
-					threadPseudoSchedule.addPseudoRoute(transitLine, transitRoute, pseudoPath, pseudoGraph.getNetworkLinkIds());
+					  Artificial links are created between all LinkCandidates
+					  (usually this means between one dummy link for the stop
+					  facility and the other linkCandidates).
+					 */
+					else {
+						double currentCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateCurrent);
+						double nextCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateNext);
+						double artificialEdgeWeight = maxAllowedTravelCost - 0.5 * currentCandidateTravelCost - 0.5 * nextCandidateTravelCost;
+
+						pseudoGraph.addEdge(i, routeStops.get(i), linkCandidateCurrent, routeStops.get(i + 1), linkCandidateNext, artificialEdgeWeight, null);
+					}
 				}
-				
-				progress.update();
 			}
+		} // - routeStop loop
+
+		/* [4]
+		  Finish the pseudoGraph by adding dummy nodes.
+		 */
+		pseudoGraph.addDummyEdges(routeStops,
+				linkCandidates.getLinkCandidates(routeStops.get(0), transitLine, transitRoute),
+				linkCandidates.getLinkCandidates(routeStops.get(routeStops.size() - 1), transitLine, transitRoute));
+
+		/* [5]
+		  Find the least cost path i.e. the PseudoRouteStop sequence
+		 */
+		List<PseudoRouteStop> pseudoPath = pseudoGraph.getLeastCostStopSequence();
+
+		if(pseudoPath == null) {
+			throw new RuntimeException("PseudoGraph has no path from SOURCE to DESTINATION for transit route " + transitRoute.getId() + " " +
+					"on line " + transitLine.getId() + " from \"" + routeStops.get(0).getStopFacility().getName() + "\" " +
+					"to \"" + routeStops.get(routeStops.size() - 1).getStopFacility().getName() + "\"");
+		} else {
+			necessaryArtificialLinks.addAll(pseudoGraph.getArtificialNetworkLinks());
+			threadPseudoSchedule.addPseudoRoute(transitLine, transitRoute, pseudoPath, pseudoGraph.getNetworkLinkIds());
 		}
 	}
 


### PR DESCRIPTION
Replaces the per-line static work partitioning with a shared `ConcurrentLinkedQueue<(TransitLine, TransitRoute)>` that all `PseudoRouting` workers poll dynamically. Idle workers automatically pick up routes still pending on busy ones.

**Motivation**

On large schedules the previous static slicing caused long tails: workers that happened to receive lines with expensive routes (e.g. long rural buses on sparse mode subgraphs) kept running for many minutes after every other worker had finished, leaving most cores idle.

**Changes**

- `PseudoRouting`: new `addTransitRouteToQueue(line, route)` entry point. `addTransitLineToQueue(line)` is kept as a default method that delegates per-route, preserving the existing API for external implementers.
- `PseudoRoutingImpl`: new `QueuedRoute` record and a shared-queue constructor overload. The `run()` loop polls the shared queue until empty.
- `PTMapper`: builds one `ConcurrentLinkedQueue`, enqueues every `(line, route)` pair once, and starts N workers all sharing it.

**Behavior**

Per-route processing logic is unchanged; only work distribution moves from static line-level partitioning to dynamic route-level stealing. Output is byte-identical to the previous implementation.