### PR TITLE
Support CHRouter as networkRouter option

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/config/PublicTransitMappingConfigGroup.java
+++ b/src/main/java/org/matsim/pt2matsim/config/PublicTransitMappingConfigGroup.java
@@ -189,7 +189,11 @@ public class PublicTransitMappingConfigGroup extends ReflectiveConfigGroup {
 				"The maximal distance [meter] a link candidate is allowed to have from the stop facility.\n" +
 				"\t\tNo link candidates beyond this distance are added.");
 		map.put(NETWORK_ROUTER,
-				"The router that should be used. Possible options are: [SpeedyALT, AStarLandmarks]");
+				"The router that should be used. Possible options are: [SpeedyALT, AStarLandmarks, CHRouter].\n" +
+				"\t\tCHRouter (Contraction Hierarchies) is typically ~2-3x faster per query than SpeedyALT on\n" +
+				"\t\tlarger networks, at the cost of a one-time preprocessing step per mode-filtered network\n" +
+				"\t\t(seconds to minutes). Recommended for medium/large scenarios where the routing phase\n" +
+				"\t\tdominates total mapping time. Requires MATSim >= 2027.");
 		map.put(USE_MODE_SPECIFIC_RULES, "Instead of using general number of links and maximum search distance rule, use the schedule mode specific rules "
 				+ "to be defined within the parameter sets. For those that no information is provided the general values will be used. Options: [false, true]. Default: false.");
 		map.put(THREAD_CHUNK_SIZE, "The size of the chunk that is sent to the pt mapper thread at the time to build"

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
@@ -10,6 +10,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.config.groups.ControllerConfigGroup.RoutingAlgorithmType;
 import org.matsim.core.config.groups.RoutingConfigGroup;
 import org.matsim.core.router.AStarLandmarksFactory;
+import org.matsim.core.router.speedy.CHRouterFactory;
 import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
@@ -99,6 +100,8 @@ public class ScheduleRoutersStandard implements ScheduleRouters {
 		    factory = new SpeedyALTFactory();
 		} else if (this.networkRouter.equals(RoutingAlgorithmType.AStarLandmarks)) {
 			factory = new AStarLandmarksFactory(nThreads, networkRoutingLandmarks);
+		} else if (this.networkRouter.equals(RoutingAlgorithmType.CHRouter)) {
+			factory = new CHRouterFactory();
 		}
 		else
 			new RuntimeException("You are trying to use the routing algorithm that is not supported.");


### PR DESCRIPTION
Adds `CHRouter` (Contraction Hierarchies) as a third option for `PublicTransitMapping.networkRouter`, alongside `SpeedyALT` (default) and `AStarLandmarks`. Typically ~2–3× faster per query than `SpeedyALT` on larger networks, at the cost of a one-time preprocessing step per mode-filtered network. Recommended for medium/large scenarios where the routing phase dominates total mapping time.

**Changes**

- `ScheduleRoutersStandard.load()`: new branch instantiating `CHRouterFactory` when `networkRouter = CHRouter`.
- `PublicTransitMappingConfigGroup`: `networkRouter` comment updated to list `CHRouter` and document the trade-off.

**Requirements**

Requires MATSim ≥ 2027 (where `CHRouter` is part of `ControllerConfigGroup.RoutingAlgorithmType`). Default is unchanged.