### PR TITLE
Bound per-candidate routing by maxAllowedTravelCost

### DIFF
--- a/doc/defaultPTMapperConfig.xml
+++ b/doc/defaultPTMapperConfig.xml
@@ -35,7 +35,11 @@
 		performance. Somewhere between 4 and 10 seems reasonable for bus stops, depending on the
 		accuracy of the stop facility coordinates and performance desires. Default: 6 -->
 		<param name="nLinkThreshold" value="6" />
-		<!-- The router that should be used. Possible options are: [SpeedyALT, AStarLandmarks] -->
+		<!-- The router that should be used. Possible options are: [SpeedyALT, AStarLandmarks, CHRouter].
+		CHRouter (Contraction Hierarchies) is typically ~2-3x faster per query than SpeedyALT on
+		larger networks, at the cost of a one-time preprocessing step per mode-filtered network
+		(seconds to minutes). Recommended for medium/large scenarios where the routing phase
+		dominates total mapping time. Requires MATSim >= 2027. -->
 		<param name="networkRouter" value="SpeedyALT" />
 		<!-- Defines the number of numOfThreads that should be used for pseudoRouting. Default: 2. -->
 		<param name="numOfThreads" value="2" />

--- a/doc/defaultPTMapperConfig.xml
+++ b/doc/defaultPTMapperConfig.xml
@@ -2,6 +2,14 @@
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
 	<module name="PublicTransitMapping" >
+		<!-- If true (default), each Dijkstra/ALT call between two link candidates is bounded by
+		[maxTravelCostFactor] * [minTravelCost]. Pairs whose shortest path exceeds
+		that bound return null quickly instead of exhausting the reachable mode subgraph,
+		dramatically reducing pseudoRouting wall-clock on disconnected networks. Output is
+		equivalent to the unbounded variant because any path with cost >= maxAllowedTravelCost
+		is already discarded downstream and replaced by an artificial link. Requires MATSim >=
+		2027 to take effect. -->
+		<param name="boundedSearch" value="true" />
 		<!-- After nLinkThreshold link candidates have been found, additional link 
 		candidates within [candidateDistanceMultiplier] * [distance to the Nth link] are added to the set.
 		Must be >= 1. -->

--- a/src/main/java/org/matsim/pt2matsim/config/PublicTransitMappingConfigGroup.java
+++ b/src/main/java/org/matsim/pt2matsim/config/PublicTransitMappingConfigGroup.java
@@ -76,6 +76,8 @@ public class PublicTransitMappingConfigGroup extends ReflectiveConfigGroup {
 	
 	private static final String THREAD_CHUNK_SIZE = "threadChunkSize";
 
+	private static final String BOUNDED_SEARCH = "boundedSearch";
+
 	// default values
 	private Map<String, Set<String>> transportModeAssignment = new HashMap<>();
 	private Map<String, TransportModeParameterSet> parameterSetsForMode = new HashMap<>();
@@ -85,6 +87,27 @@ public class PublicTransitMappingConfigGroup extends ReflectiveConfigGroup {
 	private int numOfThreads = 2;
 	private int chunkSize = 100;
 	private boolean removeNotUsedStopFacilities = true;
+
+	/**
+	 * If true, each {@code calcLeastCostPath} call between two link candidates passes
+	 * {@code maxTravelCostFactor * minTravelCost} as a cost cutoff to the underlying
+	 * {@link org.matsim.core.router.util.LeastCostPathCalculator} (Speedy Dijkstra / ALT).
+	 * Pairs whose true shortest path exceeds that bound return {@code null} in milliseconds
+	 * instead of seconds-to-minutes after exhausting the reachable mode subgraph.
+	 * <p>
+	 * Output equivalence: the caller in {@code PseudoRoutingImpl#processRoute} already discards
+	 * any returned path with {@code cost >= maxAllowedTravelCost} and replaces it with an
+	 * artificial link. Since both Speedy routers use admissible cost lower bounds (Dijkstra: the
+	 * proven shortest-path cost {@code g}; ALT: {@code g + h} with landmark heuristic {@code h}),
+	 * the cutoff only returns {@code null} when no path with cost {@code <= cutoff} exists. So
+	 * any path the bounded search drops would have been discarded by the caller anyway: the
+	 * pseudoSchedule, artificial-link set, and final routed network are unchanged. Wins are
+	 * concentrated on disconnected mode subgraphs (the long-tail case).
+	 * <p>
+	 * Requires MATSim &gt;= 2027 to take effect (older versions ignore the {@code maxCost}
+	 * argument via the {@link org.matsim.core.router.util.LeastCostPathCalculator} default).
+	 */
+	private boolean boundedSearch = true;
 
 	private String inputNetworkFile = null;
 	private String inputScheduleFile = null;
@@ -198,6 +221,14 @@ public class PublicTransitMappingConfigGroup extends ReflectiveConfigGroup {
 				+ "to be defined within the parameter sets. For those that no information is provided the general values will be used. Options: [false, true]. Default: false.");
 		map.put(THREAD_CHUNK_SIZE, "The size of the chunk that is sent to the pt mapper thread at the time to build"
 				+ "facilities and links. Default: 100.");
+		map.put(BOUNDED_SEARCH,
+				"If true (default), each Dijkstra/ALT call between two link candidates is bounded by\n" +
+				"\t\t[" + MAX_TRAVEL_COST_FACTOR + "] * [minTravelCost]. Pairs whose shortest path exceeds\n" +
+				"\t\tthat bound return null quickly instead of exhausting the reachable mode subgraph,\n" +
+				"\t\tdramatically reducing pseudoRouting wall-clock on disconnected networks. Output is\n" +
+				"\t\tequivalent to the unbounded variant because any path with cost >= maxAllowedTravelCost\n" +
+				"\t\tis already discarded downstream and replaced by an artificial link. Requires MATSim >=\n" +
+				"\t\t2027 to take effect.");
 		return map;
 	}
 
@@ -298,6 +329,19 @@ public class PublicTransitMappingConfigGroup extends ReflectiveConfigGroup {
 	@StringSetter(REMOVE_NOT_USED_STOP_FACILITIES)
 	public void setRemoveNotUsedStopFacilities(boolean v) {
 		this.removeNotUsedStopFacilities = v;
+	}
+
+	/**
+	 * Bounded search cutoff (see field doc).
+	 */
+	@StringGetter(BOUNDED_SEARCH)
+	public boolean getBoundedSearch() {
+		return boundedSearch;
+	}
+
+	@StringSetter(BOUNDED_SEARCH)
+	public void setBoundedSearch(boolean v) {
+		this.boundedSearch = v;
 	}
 
 	/**

--- a/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
@@ -34,6 +34,7 @@ import org.matsim.pt2matsim.tools.PTMapperTools;
 import org.matsim.pt2matsim.tools.ScheduleTools;
 import org.matsim.pt2matsim.tools.debug.ScheduleCleaner;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -203,12 +204,13 @@ public class PTMapper {
 		}
 
 		// initiate pseudoRouting workers (each owns its own ScheduleRouters instance)
-		PseudoRouting[] pseudoRoutingRunnables = new PseudoRouting[numThreads];
+		PseudoRoutingImpl[] pseudoRoutingRunnables = new PseudoRoutingImpl[numThreads];
 		for (int i = 0; i < numThreads; i++) {
 			pseudoRoutingRunnables[i] = new PseudoRoutingImpl(scheduleRoutersFactory, linkCandidates,
-					maxTravelCostFactor, progress, sharedQueue, boundedSearch);
+					maxTravelCostFactor, progress, sharedQueue, "pseudoRouting-" + i, boundedSearch);
 		}
 
+		long phase1Start = System.nanoTime();
 		Thread[] threads = new Thread[numThreads];
 		// start pseudoRouting
 		for (int i = 0; i < numThreads; i++) {
@@ -223,16 +225,20 @@ public class PTMapper {
 				throw new RuntimeException(e);
 			}
 		}
+		logPhase("PseudoRouting", System.nanoTime() - phase1Start);
+		logGlobalSlowestRoutes(pseudoRoutingRunnables, 10);
 
 		/*
 		 * [2] Collect artificial links from threads and add them to network. Collect pseudoSchedules from threads.
 		 */
 		log.info("=====================================");
 		log.info("Adding artificial links to network...");
+		long phase2Start = System.nanoTime();
 		for (PseudoRouting prt : pseudoRoutingRunnables) {
 			prt.addArtificialLinks(network);
 			pseudoSchedule.mergePseudoSchedule(prt.getPseudoSchedule());
 		}
+		logPhase("AddArtificialLinks+MergePseudoSchedule", System.nanoTime() - phase2Start);
 
 		/*
 		 * [3] Replace the parent stop facilities in each transitRoute's routeProfile with child StopFacilities. Add the
@@ -240,7 +246,9 @@ public class PTMapper {
 		 */
 		log.info("==========================================================================================");
 		log.info("Replacing parent StopFacilities in schedule, creating link sequences for transit routes...");
+		long phase3Start = System.nanoTime();
 		pseudoSchedule.createFacilitiesAndLinkSequences(schedule, numThreads, chunkSize);
+		logPhase("CreateFacilitiesAndLinkSequences", System.nanoTime() - phase3Start);
 
 		/*
 		 * [4] Now that all lines have been routed, it is possible that a route passes a link closer to a stop facility
@@ -248,15 +256,22 @@ public class PTMapper {
 		 */
 		log.info("================================");
 		log.info("Pulling child stop facilities...");
+		long phase4Start = System.nanoTime();
 		int nPulled = 1;
+		int pullPasses = 0;
 		while (nPulled != 0) {
 			nPulled = PTMapperTools.pullChildStopFacilitiesTogether(this.schedule, this.network);
+			pullPasses++;
 		}
+		log.info(String.format("PullChildStopFacilities: %d fixpoint passes", pullPasses));
+		logPhase("PullChildStopFacilities", System.nanoTime() - phase4Start);
 
 		/* [5] */
 		log.info("==========================================");
 		log.info("Add transfers for child stop facilities...");
+		long phase5Start = System.nanoTime();
 		PTMapperTools.addTransfersForChildStopFacilities(this.schedule);
+		logPhase("AddTransfersForChildStopFacilities", System.nanoTime() - phase5Start);
 
 		/*
 		 * [6] After all lines are created, clean the schedule and network. Removing not used transit links includes
@@ -264,14 +279,18 @@ public class PTMapper {
 		 */
 		log.info("=============================");
 		log.info("Clean schedule and network...");
+		long phase6Start = System.nanoTime();
 		cleanScheduleAndNetwork(scheduleFreespeedModes, modesToKeepOnCleanup, removeNotUsedStopFacilities);
+		logPhase("CleanScheduleAndNetwork", System.nanoTime() - phase6Start);
 
 		/*
 		 * [7] Validate the schedule
 		 */
 		log.info("======================");
 		log.info("Validating schedule...");
+		long phase7Start = System.nanoTime();
 		printValidateSchedule();
+		logPhase("ValidateSchedule", System.nanoTime() - phase7Start);
 
 		log.info("==================================================");
 		log.info("= Mapping transit schedule to network completed! =");
@@ -281,6 +300,38 @@ public class PTMapper {
 		 * Statistics
 		 */
 		printStatistics(nStopFacilities);
+	}
+
+	private static void logPhase(String name, long elapsedNanos) {
+		log.info(String.format("PTMapper phase [%s] completed in %.2fs", name, elapsedNanos / 1e9));
+	}
+
+	/**
+	 * Aggregates the per-worker slowest-route lists and logs the global top-N. Helps identify which routes dominate the
+	 * pseudoRouting wall-clock.
+	 */
+	private static void logGlobalSlowestRoutes(PseudoRoutingImpl[] workers, int topN) {
+		List<PseudoRoutingImpl.RouteTiming> all = new ArrayList<>();
+		long sumRouteNanos = 0L;
+		long sumRoutes = 0L;
+		for (PseudoRoutingImpl w : workers) {
+			all.addAll(w.getSlowestRoutes());
+			sumRouteNanos += w.getTotalRouteNanos();
+			sumRoutes += w.getRoutesProcessed();
+		}
+		all.sort((a, b) -> Long.compare(b.elapsedNanos(), a.elapsedNanos()));
+		log.info(String.format("PseudoRouting aggregate: routes=%d sumPerRouteTime=%.1fs (across %d workers)",
+				sumRoutes, sumRouteNanos / 1e9, workers.length));
+		if (all.isEmpty()) {
+			return;
+		}
+		int limit = Math.min(topN, all.size());
+		log.info(String.format("PseudoRouting global slowest %d routes:", limit));
+		for (int i = 0; i < limit; i++) {
+			PseudoRoutingImpl.RouteTiming rt = all.get(i);
+			log.info(String.format("    line=%s route=%s mode=%s stops=%d pairs=%d elapsed=%.2fs",
+					rt.lineId(), rt.routeId(), rt.mode(), rt.nStops(), rt.candidatePairs(), rt.elapsedNanos() / 1e9));
+		}
 	}
 
 	private void cleanScheduleAndNetwork(Set<String> scheduleFreespeedModes, Set<String> modesToKeepOnCleanup,

--- a/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
@@ -1,22 +1,11 @@
 /*
- * *********************************************************************** *
- * project: org.matsim.*                                                   *
- *                                                                         *
- * *********************************************************************** *
- *                                                                         *
- * copyright       : (C) 2015 by the members listed in the COPYING,        *
- *                   LICENSE and WARRANTY file.                            *
- * email           : info at matsim dot org                                *
- *                                                                         *
- * *********************************************************************** *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *   See also COPYING, LICENSE and WARRANTY file                           *
- *                                                                         *
- * *********************************************************************** *
+ * *********************************************************************** * project: org.matsim.* * *
+ * *********************************************************************** * * copyright : (C) 2015 by the members
+ * listed in the COPYING, * LICENSE and WARRANTY file. * email : info at matsim dot org * *
+ * *********************************************************************** * * This program is free software; you can
+ * redistribute it and/or modify * it under the terms of the GNU General Public License as published by * the Free
+ * Software Foundation; either version 2 of the License, or * (at your option) any later version. * See also COPYING,
+ * LICENSE and WARRANTY file * * *********************************************************************** *
  */
 
 package org.matsim.pt2matsim.mapping;
@@ -51,18 +40,17 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 
 /**
- * References an unmapped transit schedule to a network. Combines
- * finding link sequences for TransitRoutes and referencing
- * TransitStopFacilities to link. Calculates the least cost path
- * from the transit route's first to its last stop with the constraint
- * that the path must contain a link candidate of every stop.<p/>
+ * References an unmapped transit schedule to a network. Combines finding link sequences for TransitRoutes and
+ * referencing TransitStopFacilities to link. Calculates the least cost path from the transit route's first to its last
+ * stop with the constraint that the path must contain a link candidate of every stop.
+ * <p/>
  * <p>
- * Additional stop facilities are created if a stop facility has more
- * than one plausible link. Artificial links are added to the network
- * if no path can be found.</p>
+ * Additional stop facilities are created if a stop facility has more than one plausible link. Artificial links are
+ * added to the network if no path can be found.
+ * </p>
  * <p>
- * {@link LinkCandidateCreator} is applied to find link candidates and
- * {@link ScheduleRouters} to find the shortest paths on the network.
+ * {@link LinkCandidateCreator} is applied to find link candidates and {@link ScheduleRouters} to find the shortest
+ * paths on the network.
  * </p>
  *
  * @author polettif
@@ -74,21 +62,21 @@ public class PTMapper {
 	private Network network;
 	private TransitSchedule schedule;
 
-	public static void mapScheduleToNetwork(TransitSchedule schedule, Network network, PublicTransitMappingConfigGroup config) throws InterruptedException, ExecutionException {
-		if(config.getInputNetworkFile() != null) {
+	public static void mapScheduleToNetwork(TransitSchedule schedule, Network network,
+			PublicTransitMappingConfigGroup config) throws InterruptedException, ExecutionException {
+		if (config.getInputNetworkFile() != null) {
 			log.warn("The input network file set in PublicTransitMappingConfigGroup is ignored");
 		}
-		if(config.getInputScheduleFile() != null) {
+		if (config.getInputScheduleFile() != null) {
 			log.warn("The input schedule file set in PublicTransitMappingConfigGroup is ignored");
 		}
 		new PTMapper(schedule, network).run(config);
 	}
 
 	/**
-	 * The provided schedule is expected to contain the stops sequence and
-	 * the stop facilities each transit route. The routes will be newly routed,
-	 * any former routes will be overwritten. Changes are done on the schedule and
-	 * network provided here.
+	 * The provided schedule is expected to contain the stops sequence and the stop facilities each transit route. The
+	 * routes will be newly routed, any former routes will be overwritten. Changes are done on the schedule and network
+	 * provided here.
 	 * <p/>
 	 *
 	 * @param schedule which will be newly routed.
@@ -102,52 +90,83 @@ public class PTMapper {
 	public void run(PublicTransitMappingConfigGroup config) throws InterruptedException, ExecutionException {
 		run(config, null, null);
 	}
-	
+
 	/**
 	 * Maps the schedule to the network with parameters defined in config
-	 * @throws ExecutionException 
-	 * @throws InterruptedException 
+	 * 
+	 * @throws ExecutionException
+	 * @throws InterruptedException
 	 */
-	public void run(PublicTransitMappingConfigGroup config, LinkCandidateCreator linkCandidateCreator, ScheduleRoutersFactory scheduleRoutersFactory) throws InterruptedException, ExecutionException {
+	public void run(PublicTransitMappingConfigGroup config, LinkCandidateCreator linkCandidateCreator,
+			ScheduleRoutersFactory scheduleRoutersFactory) throws InterruptedException, ExecutionException {
 		// use defaults
-		if(linkCandidateCreator == null) {
+		if (linkCandidateCreator == null) {
 			linkCandidateCreator = new LinkCandidateCreatorStandard(schedule, network,
 					config);
 		}
-		
-		if(scheduleRoutersFactory == null) {
-			scheduleRoutersFactory = new ScheduleRoutersStandard.Factory(schedule, network, config.getTransportModeAssignment(), config.getTravelCostType(), config.getRoutingWithCandidateDistance(), config.getNetworkRouter());
+
+		if (scheduleRoutersFactory == null) {
+			scheduleRoutersFactory = new ScheduleRoutersStandard.Factory(schedule, network,
+					config.getTransportModeAssignment(), config.getTravelCostType(),
+					config.getRoutingWithCandidateDistance(), config.getNetworkRouter());
 		}
 
 		run(linkCandidateCreator,
-			scheduleRoutersFactory,
-			config.getNumOfThreads(), config.getMaxTravelCostFactor(),
-			config.getScheduleFreespeedModes(), config.getModesToKeepOnCleanUp(),
-			config.getRemoveNotUsedStopFacilities(), config.getChunkSize());
+				scheduleRoutersFactory,
+				config.getNumOfThreads(), config.getMaxTravelCostFactor(),
+				config.getScheduleFreespeedModes(), config.getModesToKeepOnCleanUp(),
+				config.getRemoveNotUsedStopFacilities(), config.getChunkSize(),
+				config.getBoundedSearch());
 	}
 
 	/**
 	 * Maps the schedule to the network
-	 * @throws ExecutionException 
-	 * @throws InterruptedException 
+	 * 
+	 * @throws ExecutionException
+	 * @throws InterruptedException
 	 */
-	public void run(LinkCandidateCreator linkCandidates, ScheduleRoutersFactory scheduleRoutersFactory, int numThreads, double maxTravelCostFactor, Set<String> scheduleFreespeedModes, Set<String> modesToKeepOnCleanup, boolean removeNotUsedStopFacilities, int chunkSize) throws InterruptedException, ExecutionException {
-		if(schedule == null) throw new RuntimeException("No schedule defined!");
-		if(network == null) throw new RuntimeException("No network defined!");
+	public void run(LinkCandidateCreator linkCandidates, ScheduleRoutersFactory scheduleRoutersFactory, int numThreads,
+			double maxTravelCostFactor, Set<String> scheduleFreespeedModes, Set<String> modesToKeepOnCleanup,
+			boolean removeNotUsedStopFacilities, int chunkSize) throws InterruptedException, ExecutionException {
+		run(linkCandidates, scheduleRoutersFactory, numThreads, maxTravelCostFactor, scheduleFreespeedModes,
+				modesToKeepOnCleanup, removeNotUsedStopFacilities, chunkSize, false);
+	}
 
-		if(linkCandidates == null) throw new RuntimeException("No LinkCandidates defined!");
-		if(scheduleRoutersFactory == null) throw new RuntimeException("No ScheduleRoutersFactory defined!");
+	/**
+	 * Maps the schedule to the network.
+	 *
+	 * @param boundedSearch if true, route queries pass {@code maxAllowedTravelCost} as a cutoff to the underlying
+	 *                      Dijkstra/ALT — pairs that are unreachable within that bound return null quickly instead of
+	 *                      exhausting the reachable subgraph. Output is byte-identical because such paths are already
+	 *                      discarded downstream.
+	 * @throws ExecutionException
+	 * @throws InterruptedException
+	 */
+	public void run(LinkCandidateCreator linkCandidates, ScheduleRoutersFactory scheduleRoutersFactory, int numThreads,
+			double maxTravelCostFactor, Set<String> scheduleFreespeedModes, Set<String> modesToKeepOnCleanup,
+			boolean removeNotUsedStopFacilities, int chunkSize, boolean boundedSearch)
+			throws InterruptedException, ExecutionException {
+		if (schedule == null)
+			throw new RuntimeException("No schedule defined!");
+		if (network == null)
+			throw new RuntimeException("No network defined!");
 
-		if(ScheduleTools.idsContainChildStopString(schedule)) {
-			throw new RuntimeException("Some stopFacility ids contain the string \"" + PublicTransitMappingStrings.SUFFIX_CHILD_STOP_FACILITIES + "\"! Schedule cannot be mapped.");
+		if (linkCandidates == null)
+			throw new RuntimeException("No LinkCandidates defined!");
+		if (scheduleRoutersFactory == null)
+			throw new RuntimeException("No ScheduleRoutersFactory defined!");
+
+		if (ScheduleTools.idsContainChildStopString(schedule)) {
+			throw new RuntimeException("Some stopFacility ids contain the string \""
+					+ PublicTransitMappingStrings.SUFFIX_CHILD_STOP_FACILITIES + "\"! Schedule cannot be mapped.");
 		}
 
 		PTMapperTools.setLogLevels();
 
-		if(schedule.getTransitLines().size() == 0) {
+		if (schedule.getTransitLines().size() == 0) {
 			throw new IllegalArgumentException("No transit lines available in schedule");
 		}
-		if(schedule.getFacilities().size() == 0) {
+		if (schedule.getFacilities().size() == 0) {
 			throw new IllegalArgumentException("No stop facilities available in schedule");
 		}
 
@@ -155,21 +174,20 @@ public class PTMapper {
 		log.info("Mapping transit schedule to network...");
 
 		/*
-		  Some schedule statistics
+		 * Some schedule statistics
 		 */
 		int nStopFacilities = schedule.getFacilities().size();
 		int nTransitRoutes = 0;
-		for(TransitLine transitLine : this.schedule.getTransitLines().values()) {
+		for (TransitLine transitLine : this.schedule.getTransitLines().values()) {
 			nTransitRoutes += transitLine.getRoutes().size();
 		}
 
-		/* [1]
-		  PseudoRouting
-		  Initiate and start threads, calculate PseudoTransitRoutes
-		  for all transit routes.
+		/*
+		 * [1] PseudoRouting Initiate and start threads, calculate PseudoTransitRoutes for all transit routes.
 		 */
 		log.info("==================================");
-		log.info("Calculating pseudoTransitRoutes... (" + nTransitRoutes + " transit routes in " + schedule.getTransitLines().size() + " transit lines)");
+		log.info("Calculating pseudoTransitRoutes... (" + nTransitRoutes + " transit routes in "
+				+ schedule.getTransitLines().size() + " transit lines)");
 
 		Progress progress = new Progress(nTransitRoutes, "Calculating pseudoTransitRoutes ...");
 
@@ -178,26 +196,26 @@ public class PTMapper {
 		// (dynamic load balancing). This eliminates the line-level pre-assignment
 		// long-tail problem ("stuck at 99 %").
 		ConcurrentLinkedQueue<PseudoRoutingImpl.QueuedRoute> sharedQueue = new ConcurrentLinkedQueue<>();
-		for(TransitLine transitLine : schedule.getTransitLines().values()) {
-			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {
+		for (TransitLine transitLine : schedule.getTransitLines().values()) {
+			for (TransitRoute transitRoute : transitLine.getRoutes().values()) {
 				sharedQueue.add(new PseudoRoutingImpl.QueuedRoute(transitLine, transitRoute));
 			}
 		}
 
 		// initiate pseudoRouting workers (each owns its own ScheduleRouters instance)
 		PseudoRouting[] pseudoRoutingRunnables = new PseudoRouting[numThreads];
-		for(int i = 0; i < numThreads; i++) {
+		for (int i = 0; i < numThreads; i++) {
 			pseudoRoutingRunnables[i] = new PseudoRoutingImpl(scheduleRoutersFactory, linkCandidates,
-					maxTravelCostFactor, progress, sharedQueue);
+					maxTravelCostFactor, progress, sharedQueue, boundedSearch);
 		}
 
 		Thread[] threads = new Thread[numThreads];
 		// start pseudoRouting
-		for(int i = 0; i < numThreads; i++) {
+		for (int i = 0; i < numThreads; i++) {
 			threads[i] = new Thread(pseudoRoutingRunnables[i], "pseudoRouting-" + i);
 			threads[i].start();
 		}
-		for(Thread thread : threads) {
+		for (Thread thread : threads) {
 			try {
 				thread.join();
 			} catch (InterruptedException e) {
@@ -206,35 +224,32 @@ public class PTMapper {
 			}
 		}
 
-
-		/* [2]
-		  Collect artificial links from threads and add them to network.
-		  Collect pseudoSchedules from threads.
+		/*
+		 * [2] Collect artificial links from threads and add them to network. Collect pseudoSchedules from threads.
 		 */
 		log.info("=====================================");
 		log.info("Adding artificial links to network...");
-		for(PseudoRouting prt : pseudoRoutingRunnables) {
+		for (PseudoRouting prt : pseudoRoutingRunnables) {
 			prt.addArtificialLinks(network);
 			pseudoSchedule.mergePseudoSchedule(prt.getPseudoSchedule());
 		}
 
-
-		/* [3]
-		  Replace the parent stop facilities in each transitRoute's routeProfile
-		  with child StopFacilities. Add the new transitRoutes to the schedule.
+		/*
+		 * [3] Replace the parent stop facilities in each transitRoute's routeProfile with child StopFacilities. Add the
+		 * new transitRoutes to the schedule.
 		 */
 		log.info("==========================================================================================");
 		log.info("Replacing parent StopFacilities in schedule, creating link sequences for transit routes...");
 		pseudoSchedule.createFacilitiesAndLinkSequences(schedule, numThreads, chunkSize);
 
-		/* [4]
-		  Now that all lines have been routed, it is possible that a route passes
-		  a link closer to a stop facility than its referenced link.
+		/*
+		 * [4] Now that all lines have been routed, it is possible that a route passes a link closer to a stop facility
+		 * than its referenced link.
 		 */
 		log.info("================================");
 		log.info("Pulling child stop facilities...");
 		int nPulled = 1;
-		while(nPulled != 0) {
+		while (nPulled != 0) {
 			nPulled = PTMapperTools.pullChildStopFacilitiesTogether(this.schedule, this.network);
 		}
 
@@ -243,17 +258,16 @@ public class PTMapper {
 		log.info("Add transfers for child stop facilities...");
 		PTMapperTools.addTransfersForChildStopFacilities(this.schedule);
 
-		/* [6]
-		  After all lines are created, clean the schedule and network. Removing
-		  not used transit links includes removing artificial links that
-		  needed to be added to the network for routing purposes.
+		/*
+		 * [6] After all lines are created, clean the schedule and network. Removing not used transit links includes
+		 * removing artificial links that needed to be added to the network for routing purposes.
 		 */
 		log.info("=============================");
 		log.info("Clean schedule and network...");
 		cleanScheduleAndNetwork(scheduleFreespeedModes, modesToKeepOnCleanup, removeNotUsedStopFacilities);
 
-		/* [7]
-		  Validate the schedule
+		/*
+		 * [7] Validate the schedule
 		 */
 		log.info("======================");
 		log.info("Validating schedule...");
@@ -264,12 +278,13 @@ public class PTMapper {
 		log.info("==================================================");
 
 		/*
-		  Statistics
+		 * Statistics
 		 */
 		printStatistics(nStopFacilities);
 	}
 
-	private void cleanScheduleAndNetwork(Set<String> scheduleFreespeedModes, Set<String> modesToKeepOnCleanup, boolean removeNotUsedStopFacilities) {
+	private void cleanScheduleAndNetwork(Set<String> scheduleFreespeedModes, Set<String> modesToKeepOnCleanup,
+			boolean removeNotUsedStopFacilities) {
 		NetworkTools.resetLinkLength(network, PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE);
 
 		// changing the freespeed of the artificial links (value is used in simulations)
@@ -277,7 +292,7 @@ public class PTMapper {
 
 		// Remove unnecessary parts of schedule
 		ScheduleCleaner.removeNotUsedTransitLinks(schedule, network, modesToKeepOnCleanup, true);
-		if(removeNotUsedStopFacilities) {
+		if (removeNotUsedStopFacilities) {
 			ScheduleCleaner.removeNotUsedStopFacilities(schedule);
 		}
 		ScheduleCleaner.removeNotUsedMinimalTransferTimes(schedule);
@@ -293,21 +308,22 @@ public class PTMapper {
 	 * Log the result of the schedule validator
 	 */
 	private void printValidateSchedule() {
-		TransitScheduleValidator.ValidationResult validationResult = TransitScheduleValidator.validateAll(schedule, network);
-		if(validationResult.isValid()) {
+		TransitScheduleValidator.ValidationResult validationResult = TransitScheduleValidator.validateAll(schedule,
+				network);
+		if (validationResult.isValid()) {
 			log.info("Schedule appears valid!");
 		} else {
 			log.warn("Schedule is NOT valid!");
 		}
-		if(validationResult.getErrors().size() > 0) {
+		if (validationResult.getErrors().size() > 0) {
 			log.info("Validation errors:");
-			for(String e : validationResult.getErrors()) {
+			for (String e : validationResult.getErrors()) {
 				log.info(e);
 			}
 		}
-		if(validationResult.getWarnings().size() > 0) {
+		if (validationResult.getWarnings().size() > 0) {
 			log.info("Validation warnings:");
-			for(String w : validationResult.getWarnings()) {
+			for (String w : validationResult.getWarnings()) {
 				log.info(w);
 			}
 		}
@@ -318,24 +334,25 @@ public class PTMapper {
 	 */
 	private void printStatistics(int inputNStopFacilities) {
 		int nArtificialLinks = 0;
-		for(Link l : network.getLinks().values()) {
-			if(l.getAllowedModes().contains(PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE)) {
+		for (Link l : network.getLinks().values()) {
+			if (l.getAllowedModes().contains(PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE)) {
 				nArtificialLinks++;
 			}
 		}
 		int withoutArtificialLinks = 0;
 		int nRoutes = 0;
-		for(TransitLine transitLine : this.schedule.getTransitLines().values()) {
-			for(TransitRoute transitRoute : transitLine.getRoutes().values()) {
+		for (TransitLine transitLine : this.schedule.getTransitLines().values()) {
+			for (TransitRoute transitRoute : transitLine.getRoutes().values()) {
 				nRoutes++;
 				boolean routeHasArtificialLink = false;
 				List<Id<Link>> linkIds = ScheduleTools.getTransitRouteLinkIds(transitRoute);
-				for(Id<Link> linkId : linkIds) {
-					if(network.getLinks().get(linkId).getAllowedModes().contains(PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE)) {
+				for (Id<Link> linkId : linkIds) {
+					if (network.getLinks().get(linkId).getAllowedModes()
+							.contains(PublicTransitMappingStrings.ARTIFICIAL_LINK_MODE)) {
 						routeHasArtificialLink = true;
 					}
 				}
-				if(!routeHasArtificialLink) {
+				if (!routeHasArtificialLink) {
 					withoutArtificialLinks++;
 				}
 			}

--- a/src/main/java/org/matsim/pt2matsim/mapping/PseudoRoutingImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PseudoRoutingImpl.java
@@ -24,8 +24,11 @@ import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRouters;
 import org.matsim.pt2matsim.mapping.networkRouter.ScheduleRoutersFactory;
 import org.matsim.pt2matsim.mapping.pseudoRouter.*;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -52,7 +55,18 @@ public class PseudoRoutingImpl implements PseudoRouting {
 	public record QueuedRoute(TransitLine line, TransitRoute route) {
 	}
 
+	/** Per-route timing snapshot used for the slowest-routes summary log. */
+	public record RouteTiming(String lineId, String routeId, String mode, int nStops, long candidatePairs,
+			long elapsedNanos) {
+	}
+
+	/** Log routes that took longer than this in wall-clock as INFO while they happen. */
+	private static final long SLOW_ROUTE_LOG_NS = 30L * 1_000_000_000L; // 30 s
+	/** How many slowest routes to keep per worker. */
+	private static final int KEEP_TOP_N_SLOW = 5;
+
 	private final Queue<QueuedRoute> queue;
+	private final String workerName;
 
 	private final LinkCandidateCreator linkCandidates;
 	private final ScheduleRouters scheduleRouters;
@@ -63,6 +77,12 @@ public class PseudoRoutingImpl implements PseudoRouting {
 	private final double maxTravelCostFactor;
 	private final boolean boundedSearch;
 
+	// per-worker timing stats
+	private long routesProcessed = 0L;
+	private long totalRouteNanos = 0L;
+	private final PriorityQueue<RouteTiming> slowest = new PriorityQueue<>(
+			Comparator.comparingLong(RouteTiming::elapsedNanos));
+
 	/**
 	 * Backward-compatible constructor: the runnable owns a private queue and bounded search is disabled. Prefer the
 	 * shared-queue overload below so multiple workers can balance load dynamically.
@@ -70,7 +90,7 @@ public class PseudoRoutingImpl implements PseudoRouting {
 	public PseudoRoutingImpl(ScheduleRoutersFactory scheduleRoutersFactory, LinkCandidateCreator linkCandidates,
 			double maxTravelCostFactor, Progress progress) {
 		this(scheduleRoutersFactory, linkCandidates, maxTravelCostFactor, progress,
-				new ConcurrentLinkedQueue<>(), false);
+				new ConcurrentLinkedQueue<>(), "pseudoRouting", false);
 	}
 
 	/**
@@ -83,12 +103,14 @@ public class PseudoRoutingImpl implements PseudoRouting {
 	 *                      discarded by the caller.
 	 */
 	public PseudoRoutingImpl(ScheduleRoutersFactory scheduleRoutersFactory, LinkCandidateCreator linkCandidates,
-			double maxTravelCostFactor, Progress progress, Queue<QueuedRoute> sharedQueue, boolean boundedSearch) {
+			double maxTravelCostFactor, Progress progress, Queue<QueuedRoute> sharedQueue, String workerName,
+			boolean boundedSearch) {
 		this.maxTravelCostFactor = maxTravelCostFactor;
 		this.scheduleRouters = scheduleRoutersFactory.createInstance();
 		this.linkCandidates = linkCandidates;
 		this.progress = progress;
 		this.queue = sharedQueue;
+		this.workerName = workerName;
 		this.boundedSearch = boundedSearch;
 	}
 
@@ -97,12 +119,68 @@ public class PseudoRoutingImpl implements PseudoRouting {
 		queue.add(new QueuedRoute(line, route));
 	}
 
+	/** Snapshot of this worker's slowest routes, sorted descending by elapsed time. */
+	public List<RouteTiming> getSlowestRoutes() {
+		List<RouteTiming> out = new ArrayList<>(slowest);
+		out.sort((a, b) -> Long.compare(b.elapsedNanos(), a.elapsedNanos()));
+		return out;
+	}
+
+	public long getRoutesProcessed() {
+		return routesProcessed;
+	}
+
+	public long getTotalRouteNanos() {
+		return totalRouteNanos;
+	}
+
 	@Override
 	public void run() {
+		long workerStart = System.nanoTime();
 		QueuedRoute qr;
 		while ((qr = queue.poll()) != null) {
-			processRoute(qr.line(), qr.route());
+			long t0 = System.nanoTime();
+			long pairs = processRoute(qr.line(), qr.route());
+			long elapsed = System.nanoTime() - t0;
+
+			routesProcessed++;
+			totalRouteNanos += elapsed;
+			recordTiming(qr.line(), qr.route(), pairs, elapsed);
+
+			if (elapsed > SLOW_ROUTE_LOG_NS) {
+				log.info(String.format(
+						"[%s] slow route: line=%s route=%s mode=%s stops=%d candidatePairs=%d elapsed=%.1fs",
+						workerName, qr.line().getId(), qr.route().getId(), qr.route().getTransportMode(),
+						qr.route().getStops().size(), pairs, elapsed / 1e9));
+			}
+
 			progress.update();
+		}
+		long workerElapsed = System.nanoTime() - workerStart;
+		double avgMs = routesProcessed == 0 ? 0.0 : (totalRouteNanos / 1e6 / (double) routesProcessed);
+		log.info(String.format(
+				"[%s] finished: routes=%d wall=%.1fs sumPerRoute=%.1fs avgPerRoute=%.0fms",
+				workerName, routesProcessed, workerElapsed / 1e9, totalRouteNanos / 1e9, avgMs));
+		List<RouteTiming> top = getSlowestRoutes();
+		if (!top.isEmpty()) {
+			log.info(String.format("[%s] slowest %d routes on this worker:", workerName, top.size()));
+			for (RouteTiming rt : top) {
+				log.info(String.format(
+						"    line=%s route=%s mode=%s stops=%d pairs=%d elapsed=%.2fs",
+						rt.lineId(), rt.routeId(), rt.mode(), rt.nStops(), rt.candidatePairs(),
+						rt.elapsedNanos() / 1e9));
+			}
+		}
+	}
+
+	private void recordTiming(TransitLine line, TransitRoute route, long pairs, long elapsed) {
+		RouteTiming rt = new RouteTiming(line.getId().toString(), route.getId().toString(),
+				route.getTransportMode(), route.getStops().size(), pairs, elapsed);
+		if (slowest.size() < KEEP_TOP_N_SLOW) {
+			slowest.add(rt);
+		} else if (slowest.peek().elapsedNanos() < elapsed) {
+			slowest.poll();
+			slowest.add(rt);
 		}
 	}
 
@@ -112,8 +190,12 @@ public class PseudoRoutingImpl implements PseudoRouting {
 	 * The body below is intentionally identical to the previous in-line implementation; only the surrounding
 	 * {@code for (TransitRoute ...)} loop has moved out.
 	 * </p>
+	 *
+	 * @return the number of (currentCandidate, nextCandidate) pairs evaluated for this route, used by the
+	 *         slowest-routes log to indicate the search work performed.
 	 */
-	private void processRoute(TransitLine transitLine, TransitRoute transitRoute) {
+	private long processRoute(TransitLine transitLine, TransitRoute transitRoute) {
+		long pairsEvaluated = 0L;
 		/*
 		 * [1] Initiate pseudoGraph and Dijkstra algorithm for the current transitRoute. In the pseudoGraph, all link
 		 * candidates are represented as nodes and the network paths between link candidates are reduced to a
@@ -147,6 +229,7 @@ public class PseudoRoutingImpl implements PseudoRouting {
 			 */
 			for (LinkCandidate linkCandidateCurrent : linkCandidatesCurrent) {
 				for (LinkCandidate linkCandidateNext : linkCandidatesNext) {
+					pairsEvaluated++;
 
 					boolean useExistingNetworkLinks = false;
 					double pathCost = 2 * maxAllowedTravelCost;
@@ -236,6 +319,7 @@ public class PseudoRoutingImpl implements PseudoRouting {
 			necessaryArtificialLinks.addAll(pseudoGraph.getArtificialNetworkLinks());
 			threadPseudoSchedule.addPseudoRoute(transitLine, transitRoute, pseudoPath, pseudoGraph.getNetworkLinkIds());
 		}
+		return pairsEvaluated;
 	}
 
 	/**

--- a/src/main/java/org/matsim/pt2matsim/mapping/PseudoRoutingImpl.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PseudoRoutingImpl.java
@@ -1,20 +1,12 @@
-/* *********************************************************************** *
- * project: org.matsim.*
- * *********************************************************************** *
- *                                                                         *
- * copyright       : (C) 2016 by the members listed in the COPYING,        *
- *                   LICENSE and WARRANTY file.                            *
- * email           : info at matsim dot org                                *
- *                                                                         *
- * *********************************************************************** *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *   See also COPYING, LICENSE and WARRANTY file                           *
- *                                                                         *
- * *********************************************************************** */
+/*
+ * *********************************************************************** * project: org.matsim.*
+ * *********************************************************************** * * copyright : (C) 2016 by the members
+ * listed in the COPYING, * LICENSE and WARRANTY file. * email : info at matsim dot org * *
+ * *********************************************************************** * * This program is free software; you can
+ * redistribute it and/or modify * it under the terms of the GNU General Public License as published by * the Free
+ * Software Foundation; either version 2 of the License, or * (at your option) any later version. * See also COPYING,
+ * LICENSE and WARRANTY file * * ***********************************************************************
+ */
 
 package org.matsim.pt2matsim.mapping;
 
@@ -39,15 +31,13 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
- * Generates and calculates the pseudoRoutes for all the queued
- * transit routes. If no route on the network can be found (or the
- * scheduleTransportMode should not be mapped to the network), artificial
- * links between link candidates are stored to be created later.
+ * Generates and calculates the pseudoRoutes for all the queued transit routes. If no route on the network can be found
+ * (or the scheduleTransportMode should not be mapped to the network), artificial links between link candidates are
+ * stored to be created later.
  * <p>
- * The unit of work is a single {@link TransitRoute}. When several worker
- * instances share the same {@link Queue}, idle workers automatically pick
- * up remaining routes from busy workers, eliminating the "stuck at 99 %"
- * long-tail behaviour caused by line-level pre-assignment.
+ * The unit of work is a single {@link TransitRoute}. When several worker instances share the same {@link Queue}, idle
+ * workers automatically pick up remaining routes from busy workers, eliminating the "stuck at 99 %" long-tail behaviour
+ * caused by line-level pre-assignment.
  *
  * @author polettif
  */
@@ -59,7 +49,8 @@ public class PseudoRoutingImpl implements PseudoRouting {
 	private static boolean warnMinTravelCost = true;
 
 	/** Element of the work queue: the route to map plus its owning line. */
-	public record QueuedRoute(TransitLine line, TransitRoute route) {}
+	public record QueuedRoute(TransitLine line, TransitRoute route) {
+	}
 
 	private final Queue<QueuedRoute> queue;
 
@@ -70,28 +61,35 @@ public class PseudoRoutingImpl implements PseudoRouting {
 
 	private final PseudoSchedule threadPseudoSchedule = new PseudoScheduleImpl();
 	private final double maxTravelCostFactor;
+	private final boolean boundedSearch;
 
 	/**
-	 * Backward-compatible constructor: the runnable owns a private queue.
-	 * Prefer the shared-queue overload below so multiple workers can balance load dynamically.
+	 * Backward-compatible constructor: the runnable owns a private queue and bounded search is disabled. Prefer the
+	 * shared-queue overload below so multiple workers can balance load dynamically.
 	 */
 	public PseudoRoutingImpl(ScheduleRoutersFactory scheduleRoutersFactory, LinkCandidateCreator linkCandidates,
 			double maxTravelCostFactor, Progress progress) {
 		this(scheduleRoutersFactory, linkCandidates, maxTravelCostFactor, progress,
-				new ConcurrentLinkedQueue<>());
+				new ConcurrentLinkedQueue<>(), false);
 	}
 
 	/**
-	 * Shared-queue constructor. All workers given the same {@code sharedQueue} poll dynamically,
-	 * so a thread that finishes early picks up routes pending on slower threads.
+	 * Shared-queue constructor. All workers given the same {@code sharedQueue} poll dynamically, so a thread that
+	 * finishes early picks up routes pending on slower threads.
+	 *
+	 * @param boundedSearch if true, route queries pass {@code maxAllowedTravelCost} as a cutoff to the underlying
+	 *                      {@link org.matsim.core.router.util.LeastCostPathCalculator}. Output is byte-identical to the
+	 *                      unbounded variant because any path with {@code cost >= maxAllowedTravelCost} is already
+	 *                      discarded by the caller.
 	 */
 	public PseudoRoutingImpl(ScheduleRoutersFactory scheduleRoutersFactory, LinkCandidateCreator linkCandidates,
-			double maxTravelCostFactor, Progress progress, Queue<QueuedRoute> sharedQueue) {
+			double maxTravelCostFactor, Progress progress, Queue<QueuedRoute> sharedQueue, boolean boundedSearch) {
 		this.maxTravelCostFactor = maxTravelCostFactor;
 		this.scheduleRouters = scheduleRoutersFactory.createInstance();
 		this.linkCandidates = linkCandidates;
 		this.progress = progress;
 		this.queue = sharedQueue;
+		this.boundedSearch = boundedSearch;
 	}
 
 	@Override
@@ -110,122 +108,135 @@ public class PseudoRoutingImpl implements PseudoRouting {
 
 	/**
 	 * Per-route processing.
-	 *
-	 * <p>The body below is intentionally identical to the previous in-line implementation;
-	 * only the surrounding {@code for (TransitRoute ...)} loop has moved out.</p>
+	 * <p>
+	 * The body below is intentionally identical to the previous in-line implementation; only the surrounding
+	 * {@code for (TransitRoute ...)} loop has moved out.
+	 * </p>
 	 */
 	private void processRoute(TransitLine transitLine, TransitRoute transitRoute) {
-		/* [1]
-		  Initiate pseudoGraph and Dijkstra algorithm for the current transitRoute.
-
-		  In the pseudoGraph, all link candidates are represented as nodes and the
-		  network paths between link candidates are reduced to a representation edge
-		  only storing the travel cost. With the pseudoGraph, the best linkCandidate
-		  sequence can be calculated (using Dijkstra). From this sequence, the actual
-		  path on the network can be routed later on.
+		/*
+		 * [1] Initiate pseudoGraph and Dijkstra algorithm for the current transitRoute. In the pseudoGraph, all link
+		 * candidates are represented as nodes and the network paths between link candidates are reduced to a
+		 * representation edge only storing the travel cost. With the pseudoGraph, the best linkCandidate sequence can
+		 * be calculated (using Dijkstra). From this sequence, the actual path on the network can be routed later on.
 		 */
 		PseudoGraph pseudoGraph = new PseudoGraphImpl();
 
-		/* [2]
-		  Calculate the shortest paths between each pair of routeStops/ParentStopFacility
+		/*
+		 * [2] Calculate the shortest paths between each pair of routeStops/ParentStopFacility
 		 */
 		List<TransitRouteStop> routeStops = transitRoute.getStops();
-		for(int i = 0; i < routeStops.size() - 1; i++) {
-			Set<LinkCandidate> linkCandidatesCurrent = linkCandidates.getLinkCandidates(routeStops.get(i), transitLine, transitRoute);
-			Set<LinkCandidate> linkCandidatesNext = linkCandidates.getLinkCandidates(routeStops.get(i + 1), transitLine, transitRoute);
+		for (int i = 0; i < routeStops.size() - 1; i++) {
+			Set<LinkCandidate> linkCandidatesCurrent = linkCandidates.getLinkCandidates(routeStops.get(i), transitLine,
+					transitRoute);
+			Set<LinkCandidate> linkCandidatesNext = linkCandidates.getLinkCandidates(routeStops.get(i + 1), transitLine,
+					transitRoute);
 
-			double minTravelCost = scheduleRouters.getMinimalTravelCost(routeStops.get(i), routeStops.get(i + 1), transitLine, transitRoute);
+			double minTravelCost = scheduleRouters.getMinimalTravelCost(routeStops.get(i), routeStops.get(i + 1),
+					transitLine, transitRoute);
 			double maxAllowedTravelCost = minTravelCost * maxTravelCostFactor;
 
-			if(minTravelCost == 0 && warnMinTravelCost) {
-				log.warn("There are stop pairs where minTravelCost is 0.0! This might happen if two stops are on the same coordinate or if departure and arrival time of two subsequent stops are identical. Further messages are suppressed.");
+			if (minTravelCost == 0 && warnMinTravelCost) {
+				log.warn(
+						"There are stop pairs where minTravelCost is 0.0! This might happen if two stops are on the same coordinate or if departure and arrival time of two subsequent stops are identical. Further messages are suppressed.");
 				warnMinTravelCost = false;
 			}
 
-			/* [3]
-			  Calculate the shortest path between all link candidates.
+			/*
+			 * [3] Calculate the shortest path between all link candidates.
 			 */
-			for(LinkCandidate linkCandidateCurrent : linkCandidatesCurrent) {
-				for(LinkCandidate linkCandidateNext : linkCandidatesNext) {
+			for (LinkCandidate linkCandidateCurrent : linkCandidatesCurrent) {
+				for (LinkCandidate linkCandidateNext : linkCandidatesNext) {
 
 					boolean useExistingNetworkLinks = false;
 					double pathCost = 2 * maxAllowedTravelCost;
 					List<Link> pathLinks = null;
 
-					/* [3.1]
-					  If one or both link candidates are loop links we don't have
-					  to search a least cost path on the network.
+					/*
+					 * [3.1] If one or both link candidates are loop links we don't have to search a least cost path on
+					 * the network.
 					 */
-					if(!linkCandidateCurrent.isLoopLink() && !linkCandidateNext.isLoopLink()) {
+					if (!linkCandidateCurrent.isLoopLink() && !linkCandidateNext.isLoopLink()) {
 						/*
-						  Calculate the least cost path on the network
+						 * Calculate the least cost path on the network. When boundedSearch is enabled and minTravelCost
+						 * > 0, pass maxAllowedTravelCost as a cutoff so the underlying Dijkstra/ALT can abort as soon
+						 * as no path <= cutoff is provably reachable. This is equivalent to the unbounded search for
+						 * downstream purposes because the caller below already discards any returned path with cost >=
+						 * maxAllowedTravelCost and replaces it with an artificial link.
 						 */
-						LeastCostPathCalculator.Path leastCostPath = scheduleRouters.calcLeastCostPath(linkCandidateCurrent, linkCandidateNext, transitLine, transitRoute);
+						double cutoff = (boundedSearch && minTravelCost > 0.0)
+								? maxAllowedTravelCost
+								: Double.POSITIVE_INFINITY;
+						LeastCostPathCalculator.Path leastCostPath = scheduleRouters.calcLeastCostPath(
+								linkCandidateCurrent, linkCandidateNext, transitLine, transitRoute, cutoff);
 
-						if(leastCostPath != null) {
+						if (leastCostPath != null) {
 							pathCost = leastCostPath.travelCost;
 							pathLinks = leastCostPath.links;
 							// if both link candidates are the same, cost should get higher
-							if(linkCandidateCurrent.getLink().getId().equals(linkCandidateNext.getLink().getId())) {
+							if (linkCandidateCurrent.getLink().getId().equals(linkCandidateNext.getLink().getId())) {
 								pathCost *= 4;
 							}
 						}
 						useExistingNetworkLinks = pathCost < maxAllowedTravelCost;
 					}
 
-					/* [3.2]
-					  If a path on the network could be found and its travel cost are
-					  below maxAllowedTravelCost, a normal edge is added to the pseudoGraph
+					/*
+					 * [3.2] If a path on the network could be found and its travel cost are below maxAllowedTravelCost,
+					 * a normal edge is added to the pseudoGraph
 					 */
-					if(useExistingNetworkLinks) {
-						double currentCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateCurrent);
+					if (useExistingNetworkLinks) {
+						double currentCandidateTravelCost = scheduleRouters
+								.getLinkCandidateTravelCost(linkCandidateCurrent);
 						double nextCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateNext);
 						double edgeWeight = pathCost + 0.5 * currentCandidateTravelCost + 0.5 * nextCandidateTravelCost;
 
-						pseudoGraph.addEdge(i, routeStops.get(i), linkCandidateCurrent, routeStops.get(i + 1), linkCandidateNext, edgeWeight, pathLinks);
+						pseudoGraph.addEdge(i, routeStops.get(i), linkCandidateCurrent, routeStops.get(i + 1),
+								linkCandidateNext, edgeWeight, pathLinks);
 					}
-					/* [3.2]
-					  Create artificial links between two routeStops if:
-					  	 - no path on the network could be found
-					    - the travel cost of the path are greater than maxAllowedTravelCost
-
-					  Artificial links are created between all LinkCandidates
-					  (usually this means between one dummy link for the stop
-					  facility and the other linkCandidates).
+					/*
+					 * [3.2] Create artificial links between two routeStops if: - no path on the network could be found
+					 * - the travel cost of the path are greater than maxAllowedTravelCost Artificial links are created
+					 * between all LinkCandidates (usually this means between one dummy link for the stop facility and
+					 * the other linkCandidates).
 					 */
 					else {
-						double currentCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateCurrent);
+						double currentCandidateTravelCost = scheduleRouters
+								.getLinkCandidateTravelCost(linkCandidateCurrent);
 						double nextCandidateTravelCost = scheduleRouters.getLinkCandidateTravelCost(linkCandidateNext);
-						double artificialEdgeWeight = maxAllowedTravelCost - 0.5 * currentCandidateTravelCost - 0.5 * nextCandidateTravelCost;
+						double artificialEdgeWeight = maxAllowedTravelCost - 0.5 * currentCandidateTravelCost
+								- 0.5 * nextCandidateTravelCost;
 
-						pseudoGraph.addEdge(i, routeStops.get(i), linkCandidateCurrent, routeStops.get(i + 1), linkCandidateNext, artificialEdgeWeight, null);
+						pseudoGraph.addEdge(i, routeStops.get(i), linkCandidateCurrent, routeStops.get(i + 1),
+								linkCandidateNext, artificialEdgeWeight, null);
 					}
 				}
 			}
 		} // - routeStop loop
 
-		/* [4]
-		  Finish the pseudoGraph by adding dummy nodes.
+		/*
+		 * [4] Finish the pseudoGraph by adding dummy nodes.
 		 */
 		pseudoGraph.addDummyEdges(routeStops,
 				linkCandidates.getLinkCandidates(routeStops.get(0), transitLine, transitRoute),
 				linkCandidates.getLinkCandidates(routeStops.get(routeStops.size() - 1), transitLine, transitRoute));
 
-		/* [5]
-		  Find the least cost path i.e. the PseudoRouteStop sequence
+		/*
+		 * [5] Find the least cost path i.e. the PseudoRouteStop sequence
 		 */
 		List<PseudoRouteStop> pseudoPath = pseudoGraph.getLeastCostStopSequence();
 
-		if(pseudoPath == null) {
-			throw new RuntimeException("PseudoGraph has no path from SOURCE to DESTINATION for transit route " + transitRoute.getId() + " " +
-					"on line " + transitLine.getId() + " from \"" + routeStops.get(0).getStopFacility().getName() + "\" " +
+		if (pseudoPath == null) {
+			throw new RuntimeException("PseudoGraph has no path from SOURCE to DESTINATION for transit route "
+					+ transitRoute.getId() + " " +
+					"on line " + transitLine.getId() + " from \"" + routeStops.get(0).getStopFacility().getName()
+					+ "\" " +
 					"to \"" + routeStops.get(routeStops.size() - 1).getStopFacility().getName() + "\"");
 		} else {
 			necessaryArtificialLinks.addAll(pseudoGraph.getArtificialNetworkLinks());
 			threadPseudoSchedule.addPseudoRoute(transitLine, transitRoute, pseudoPath, pseudoGraph.getNetworkLinkIds());
 		}
 	}
-
 
 	/**
 	 * @return a pseudo schedule generated during run()
@@ -236,14 +247,12 @@ public class PseudoRoutingImpl implements PseudoRouting {
 	}
 
 	/**
-	 * Adds the artificial links to the network.
-	 *
-	 * Not thread safe.
+	 * Adds the artificial links to the network. Not thread safe.
 	 */
 	@Override
 	public void addArtificialLinks(Network network) {
-		for(ArtificialLink a : necessaryArtificialLinks) {
-			if(!network.getLinks().containsKey(a.getId())) {
+		for (ArtificialLink a : necessaryArtificialLinks) {
+			if (!network.getLinks().containsKey(a.getId())) {
 				network.addLink(a);
 			}
 		}

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRouters.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRouters.java
@@ -44,6 +44,19 @@ public interface ScheduleRouters extends MapperModule {
 
 	LeastCostPathCalculator.Path calcLeastCostPath(Id<Link> fromLink, Id<Link> toLink, TransitLine transitLine, TransitRoute transitRoute);
 
+	/**
+	 * Bounded variant of {@link #calcLeastCostPath(LinkCandidate, LinkCandidate, TransitLine, TransitRoute)}.
+	 * Implementations may abort the search and return {@code null} as soon as it is provable that
+	 * no path with cost {@code <= maxCost} exists. {@link Double#POSITIVE_INFINITY} disables the cutoff.
+	 *
+	 * <p>The default implementation ignores {@code maxCost} and delegates to the unbounded overload,
+	 * preserving behaviour for implementations that do not yet support the cutoff.</p>
+	 */
+	default LeastCostPathCalculator.Path calcLeastCostPath(LinkCandidate fromLinkCandidate, LinkCandidate toLinkCandidate,
+			TransitLine transitLine, TransitRoute transitRoute, double maxCost) {
+		return calcLeastCostPath(fromLinkCandidate, toLinkCandidate, transitLine, transitRoute);
+	}
+
 	double getMinimalTravelCost(TransitRouteStop fromTransitRouteStop, TransitRouteStop toTransitRouteStop, TransitLine transitLine, TransitRoute transitRoute);
 
 	double getLinkCandidateTravelCost(LinkCandidate linkCandidateCurrent);
@@ -61,6 +74,15 @@ public interface ScheduleRouters extends MapperModule {
 
 		synchronized LeastCostPathCalculator.Path calcPath(Link fromLink, Link toLink) {
 			return leastCostPathCalculator.calcLeastCostPath(fromLink, toLink, 0, null, null);
+		}
+
+		/**
+		 * Bounded variant of {@link #calcPath(Link, Link)}: requires MATSim's {@code LeastCostPathCalculator}
+		 * to provide the {@code maxCost} overload (added 2027.0). Implementations that do not honour the
+		 * cutoff will fall back to the unbounded search via the default method on the MATSim interface.
+		 */
+		synchronized LeastCostPathCalculator.Path calcPath(Link fromLink, Link toLink, double maxCost) {
+			return leastCostPathCalculator.calcLeastCostPath(fromLink, toLink, 0, null, null, maxCost);
 		}
 
 	}

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersGtfsShapes.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersGtfsShapes.java
@@ -127,6 +127,20 @@ public class ScheduleRoutersGtfsShapes implements ScheduleRouters {
 	}
 
 	@Override
+	public LeastCostPathCalculator.Path calcLeastCostPath(LinkCandidate fromLinkCandidate, LinkCandidate toLinkCandidate, TransitLine transitLine, TransitRoute transitRoute, double maxCost) {
+		Network n = networks.get(transitLine).get(transitRoute);
+		if (n == null) {
+			return null;
+		}
+		Link fromLink = n.getLinks().get(fromLinkCandidate.getLink().getId());
+		Link toLink = n.getLinks().get(toLinkCandidate.getLink().getId());
+		if (fromLink == null || toLink == null) {
+			return null;
+		}
+		return pathCalculators.get(transitLine).get(transitRoute).calcPath(fromLink, toLink, maxCost);
+	}
+
+	@Override
 	public LeastCostPathCalculator.Path calcLeastCostPath(Id<Link> fromLinkId, Id<Link> toLinkId, TransitLine transitLine, TransitRoute transitRoute) {
 		Network n = networks.get(transitLine).get(transitRoute);
 		if (n == null) {

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersOsmAttributes.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersOsmAttributes.java
@@ -130,6 +130,20 @@ public class ScheduleRoutersOsmAttributes implements ScheduleRouters {
     }
 
     @Override
+    public LeastCostPathCalculator.Path calcLeastCostPath(LinkCandidate fromLinkCandidate, LinkCandidate toLinkCandidate, TransitLine transitLine, TransitRoute transitRoute, double maxCost) {
+        Network n = networksByMode.get(transitRoute.getTransportMode());
+        if (n == null) {
+            return null;
+        }
+        Link fromLink = n.getLinks().get(fromLinkCandidate.getLink().getId());
+        Link toLink = n.getLinks().get(toLinkCandidate.getLink().getId());
+        if (fromLink == null || toLink == null) {
+            return null;
+        }
+        return pathCalculatorsByMode.get(transitRoute.getTransportMode()).calcPath(fromLink, toLink, maxCost);
+    }
+
+    @Override
     public LeastCostPathCalculator.Path calcLeastCostPath(Id<Link> fromLinkId, Id<Link> toLinkId, TransitLine transitLine, TransitRoute transitRoute) {
         Network n = networksByMode.get(transitRoute.getTransportMode());
         if (n == null) {

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
@@ -138,6 +138,20 @@ public class ScheduleRoutersStandard implements ScheduleRouters {
 	}
 
 	@Override
+	public LeastCostPathCalculator.Path calcLeastCostPath(LinkCandidate fromLinkCandidate, LinkCandidate toLinkCandidate, TransitLine transitLine, TransitRoute transitRoute, double maxCost) {
+		Network n = networksByMode.get(transitRoute.getTransportMode());
+		if (n == null) {
+			return null;
+		}
+		Link fromLink = n.getLinks().get(fromLinkCandidate.getLink().getId());
+		Link toLink = n.getLinks().get(toLinkCandidate.getLink().getId());
+		if (fromLink == null || toLink == null) {
+			return null;
+		}
+		return pathCalculatorsByMode.get(transitRoute.getTransportMode()).calcPath(fromLink, toLink, maxCost);
+	}
+
+	@Override
 	public LeastCostPathCalculator.Path calcLeastCostPath(Id<Link> fromLinkId, Id<Link> toLinkId, TransitLine transitLine, TransitRoute transitRoute) {
 		Network n = networksByMode.get(transitRoute.getTransportMode());
 		if (n == null) {

--- a/src/test/java/org/matsim/pt2matsim/mapping/PTMapperShapesTest.java
+++ b/src/test/java/org/matsim/pt2matsim/mapping/PTMapperShapesTest.java
@@ -77,4 +77,42 @@ class PTMapperShapesTest {
 		}
 	}
 
+	/**
+	 * Equivalence test on the shapes-based mapping (uses {@link ScheduleRoutersGtfsShapes}
+	 * rather than the standard router). {@code boundedSearch=true} (the @BeforeEach default)
+	 * and {@code boundedSearch=false} must produce identical link sequences for every route.
+	 */
+	@Test
+	void boundedSearchEquivalence() throws InterruptedException, ExecutionException {
+		PublicTransitMappingConfigGroup ptmConfigUnbounded = initPTMConfig();
+		ptmConfigUnbounded.setBoundedSearch(false);
+
+		TransitSchedule scheduleUnbounded = ScheduleToolsTest.initUnmappedSchedule();
+		Network networkUnbounded = NetworkToolsTest.initNetwork();
+		Map<Id<RouteShape>, RouteShape> shapesUnbounded = ShapeToolsTest.initShapes();
+		ScheduleRoutersFactory factoryUnbounded = new ScheduleRoutersGtfsShapes.Factory(scheduleUnbounded,
+				networkUnbounded, shapesUnbounded, ptmConfigUnbounded.getTransportModeAssignment(),
+				PublicTransitMappingConfigGroup.TravelCostType.linkLength, 10.0, 99);
+
+		new PTMapper(scheduleUnbounded, networkUnbounded).run(ptmConfigUnbounded, null, factoryUnbounded);
+		ScheduleCleaner.removeNotUsedStopFacilities(scheduleUnbounded);
+
+		Assertions.assertEquals(schedule.getTransitLines().keySet(), scheduleUnbounded.getTransitLines().keySet());
+
+		for (TransitLine boundedLine : schedule.getTransitLines().values()) {
+			TransitLine unboundedLine = scheduleUnbounded.getTransitLines().get(boundedLine.getId());
+			Assertions.assertNotNull(unboundedLine);
+			Assertions.assertEquals(boundedLine.getRoutes().keySet(), unboundedLine.getRoutes().keySet(),
+					"route ids differ for line " + boundedLine.getId());
+
+			for (TransitRoute boundedRoute : boundedLine.getRoutes().values()) {
+				TransitRoute unboundedRoute = unboundedLine.getRoutes().get(boundedRoute.getId());
+				List<Id<Link>> boundedLinkIds = ScheduleTools.getTransitRouteLinkIds(boundedRoute);
+				List<Id<Link>> unboundedLinkIds = ScheduleTools.getTransitRouteLinkIds(unboundedRoute);
+				Assertions.assertEquals(unboundedLinkIds, boundedLinkIds,
+						"link sequence differs for line=" + boundedLine.getId() + " route=" + boundedRoute.getId());
+			}
+		}
+	}
+
 }

--- a/src/test/java/org/matsim/pt2matsim/mapping/PTMapperTest.java
+++ b/src/test/java/org/matsim/pt2matsim/mapping/PTMapperTest.java
@@ -170,4 +170,45 @@ public class PTMapperTest {
 		CreateDefaultPTMapperConfig.main(new String[]{"doc/defaultPTMapperConfig.xml"});
 	}
 
+	/**
+	 * Equivalence test: mapping the same scenario with {@code boundedSearch=true} and
+	 * {@code boundedSearch=false} must produce identical link sequences for every transit
+	 * route. This locks in the central correctness claim of the bounded-search wire-through:
+	 * for routes that are mapped, the bounded variant returns exactly the same routed path
+	 * as the unbounded one (cutoff fires only on candidate pairs that would have been
+	 * discarded downstream as exceeding {@code maxAllowedTravelCost} anyway).
+	 * <p>
+	 * Uses the same scenario as the {@link BeforeEach}-prepared instance (which already runs
+	 * with the default {@code boundedSearch=true}), and reruns with the flag flipped to
+	 * {@code false}.
+	 */
+	@Test
+	void boundedSearchEquivalence() throws InterruptedException, ExecutionException {
+		// schedule + network from @BeforeEach were mapped with boundedSearch=true (default).
+		PublicTransitMappingConfigGroup ptmConfigUnbounded = initPTMConfig();
+		ptmConfigUnbounded.setBoundedSearch(false);
+
+		TransitSchedule scheduleUnbounded = ScheduleToolsTest.initUnmappedSchedule();
+		Network networkUnbounded = NetworkToolsTest.initNetwork();
+		new PTMapper(scheduleUnbounded, networkUnbounded).run(ptmConfigUnbounded);
+
+		Assertions.assertEquals(schedule.getTransitLines().keySet(), scheduleUnbounded.getTransitLines().keySet(),
+				"bounded and unbounded mappings must produce the same set of transit lines");
+
+		for (TransitLine boundedLine : schedule.getTransitLines().values()) {
+			TransitLine unboundedLine = scheduleUnbounded.getTransitLines().get(boundedLine.getId());
+			Assertions.assertNotNull(unboundedLine, "missing line in unbounded schedule: " + boundedLine.getId());
+			Assertions.assertEquals(boundedLine.getRoutes().keySet(), unboundedLine.getRoutes().keySet(),
+					"route ids differ for line " + boundedLine.getId());
+
+			for (TransitRoute boundedRoute : boundedLine.getRoutes().values()) {
+				TransitRoute unboundedRoute = unboundedLine.getRoutes().get(boundedRoute.getId());
+				List<Id<Link>> boundedLinkIds = ScheduleTools.getTransitRouteLinkIds(boundedRoute);
+				List<Id<Link>> unboundedLinkIds = ScheduleTools.getTransitRouteLinkIds(unboundedRoute);
+				Assertions.assertEquals(unboundedLinkIds, boundedLinkIds,
+						"link sequence differs for line=" + boundedLine.getId() + " route=" + boundedRoute.getId());
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
Caps every router call between two link candidates by the `maxAllowedTravelCost` cutoff the caller already uses to discard the result. Paths that would have been thrown away are no longer fully expanded. This helps schedules with disconnected mode-filtered networks (rural buses, ferries, isolated tram fragments), where the previous code exhausted the full reachable component before returning `null`.

**Changes**

- New `boundedSearch` config flag (default `true`). When `true`, `maxAllowedTravelCost` is passed as `maxCost` to `calcLeastCostPath`. When `false`, falls back to the unbounded call.

This requires matsim-org/matsim-libs#4985 (new bounded API in MATSim 2027).