### PR TITLE
Replace CHRouterFactory with StaticCHRouterFactory

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
@@ -8,9 +8,10 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.config.groups.ControllerConfigGroup.RoutingAlgorithmType;
+import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.config.groups.RoutingConfigGroup;
 import org.matsim.core.router.AStarLandmarksFactory;
-import org.matsim.core.router.speedy.CHRouterFactory;
+import org.matsim.core.router.speedy.StaticCHRouterFactory;
 import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
@@ -101,7 +102,9 @@ public class ScheduleRoutersStandard implements ScheduleRouters {
 		} else if (this.networkRouter.equals(RoutingAlgorithmType.AStarLandmarks)) {
 			factory = new AStarLandmarksFactory(nThreads, networkRoutingLandmarks);
 		} else if (this.networkRouter.equals(RoutingAlgorithmType.CHRouter)) {
-			factory = new CHRouterFactory();
+			GlobalConfigGroup global = new GlobalConfigGroup();
+			global.setNumberOfThreads(this.nThreads);
+			factory = new StaticCHRouterFactory(global);
 		}
 		else
 			new RuntimeException("You are trying to use the routing algorithm that is not supported.");


### PR DESCRIPTION
This PR switches to the new `StaticCHRouterFactory` (see https://github.com/matsim-org/matsim-libs/pull/5001) avoiding a a lot of memory allocation of time-dependent routing which we do not need here.