### PR TITLE
feat(mapper): cache router factories

### DIFF
--- a/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/PTMapper.java
@@ -107,9 +107,7 @@ public class PTMapper {
 		}
 
 		if (scheduleRoutersFactory == null) {
-			scheduleRoutersFactory = new ScheduleRoutersStandard.Factory(schedule, network,
-					config.getTransportModeAssignment(), config.getTravelCostType(),
-					config.getRoutingWithCandidateDistance(), config.getNetworkRouter());
+			scheduleRoutersFactory = new ScheduleRoutersStandard.Factory(schedule, network, config);
 		}
 
 		run(linkCandidateCreator,

--- a/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
+++ b/src/main/java/org/matsim/pt2matsim/mapping/networkRouter/ScheduleRoutersStandard.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.LogManager;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.config.groups.ControllerConfigGroup.RoutingAlgorithmType;
 import org.matsim.core.config.groups.GlobalConfigGroup;
@@ -31,6 +30,7 @@ import org.matsim.vehicles.Vehicle;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Creates a Router for each transportMode of a schedule.
@@ -41,99 +41,61 @@ import java.util.Set;
  */
 public class ScheduleRoutersStandard implements ScheduleRouters {
 
-	protected static Logger log = LogManager.getLogger(ScheduleRoutersStandard.class);
+	private static final Logger log = LogManager.getLogger(ScheduleRoutersStandard.class);
 
-	// standard fields
-	private final TransitSchedule schedule;
-	private final Network network;
-	private final Map<String, Set<String>> transportModeAssignment;
 	private final PublicTransitMappingConfigGroup.TravelCostType travelCostType;
-
-	// path calculators
+	private final boolean considerCandidateDist;
 	private final Map<String, PathCalculator> pathCalculatorsByMode = new HashMap<>();
 	private final Map<String, Network> networksByMode = new HashMap<>();
-	private final boolean considerCandidateDist;
-	private final int nThreads;
-	private final int networkRoutingLandmarks;
-	private final RoutingAlgorithmType networkRouter;
 
-	private ScheduleRoutersStandard(TransitSchedule schedule, Network network, Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType costType, boolean routingWithCandidateDistance,
-			RoutingAlgorithmType networkRouter) {
-		this.schedule = schedule;
-		this.network = network;
-		this.transportModeAssignment = transportModeAssignment;
+	/**
+	 * Constructor used by {@link Factory} with pre-computed filtered networks and a
+	 * shared {@link LeastCostPathCalculatorFactory}. This avoids redundant network
+	 * filtering and router preprocessing (ALT landmarks / CH contraction) across
+	 * parallel instances.
+	 */
+	private ScheduleRoutersStandard(TransitSchedule schedule,
+			Map<String, Set<String>> transportModeAssignment,
+			PublicTransitMappingConfigGroup.TravelCostType costType,
+			boolean routingWithCandidateDistance,
+			Map<String, Network> sharedFilteredNetworks,
+			LeastCostPathCalculatorFactory sharedLcpFactory) {
 		this.travelCostType = costType;
 		this.considerCandidateDist = routingWithCandidateDistance;
-		this.nThreads = 8;
-		this.networkRoutingLandmarks = new RoutingConfigGroup().getNetworkRoutingLandmarks(); // use default for now
-		this.networkRouter = networkRouter;
-
-		load();
-	}
-
-	private ScheduleRoutersStandard(TransitSchedule schedule, Network network,
-			Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType costType,
-			boolean routingWithCandidateDistance, int nThreads, int networkRoutingLandmarks,
-			RoutingAlgorithmType networkRouter) {
-		this.schedule = schedule;
-		this.network = network;
-		this.transportModeAssignment = transportModeAssignment;
-		this.travelCostType = costType;
-		this.considerCandidateDist = routingWithCandidateDistance;
-		this.nThreads = nThreads;
-		this.networkRoutingLandmarks = networkRoutingLandmarks;
-		this.networkRouter = networkRouter;
-		load();
+		this.initRouters(schedule, transportModeAssignment, sharedFilteredNetworks, sharedLcpFactory);
 	}
 
 	/**
-	 * Load path calculators for all transit routes
+	 * Initialize path calculators for all schedule modes that are both declared
+	 * in the config and actually used by at least one transit route.
 	 */
-	private void load() {
-		log.info("==============================================");
+	private void initRouters(TransitSchedule schedule,
+			Map<String, Set<String>> transportModeAssignment,
+			Map<String, Network> sharedFilteredNetworks,
+			LeastCostPathCalculatorFactory factory) {
 		log.info("Creating network routers for transit routes...");
-		log.info("Initiating network and router for transit routes...");
-		
-		
-		LeastCostPathCalculatorFactory factory = null;
 
-		if (this.networkRouter.equals(RoutingAlgorithmType.SpeedyALT)) {
-		    factory = new SpeedyALTFactory();
-		} else if (this.networkRouter.equals(RoutingAlgorithmType.AStarLandmarks)) {
-			factory = new AStarLandmarksFactory(nThreads, networkRoutingLandmarks);
-		} else if (this.networkRouter.equals(RoutingAlgorithmType.CHRouter)) {
-			GlobalConfigGroup global = new GlobalConfigGroup();
-			global.setNumberOfThreads(this.nThreads);
-			factory = new StaticCHRouterFactory(global);
+		Set<String> actualScheduleModes = schedule.getTransitLines().values().stream()
+				.flatMap(line -> line.getRoutes().values().stream())
+				.map(TransitRoute::getTransportMode)
+				.collect(Collectors.toSet());
+
+		for (String scheduleMode : transportModeAssignment.keySet()) {
+			if (!actualScheduleModes.contains(scheduleMode)) {
+				log.warn("Schedule mode '{}' declared in config but not used by any transit route -- creating empty router.", scheduleMode);
+			}
+
+			log.info("New router for schedule mode {}", scheduleMode);
+
+			Network filteredNetwork = sharedFilteredNetworks.get(scheduleMode);
+			LocalRouter r = new LocalRouter();
+			PathCalculator pathCalculator = new PathCalculator(
+					factory.createPathCalculator(filteredNetwork, r, r));
+
+			this.pathCalculatorsByMode.put(scheduleMode, pathCalculator);
+			this.networksByMode.put(scheduleMode, filteredNetwork);
 		}
-		else
-			new RuntimeException("You are trying to use the routing algorithm that is not supported.");
-
-		if (factory != null) { // at this point it should not be null
-		    for (TransitLine transitLine : schedule.getTransitLines().values()) {
-		        for (TransitRoute transitRoute : transitLine.getRoutes().values()) {
-		            String scheduleMode = transitRoute.getTransportMode();
-		            PathCalculator tmpRouter = pathCalculatorsByMode.get(scheduleMode);
-		            if (tmpRouter == null) {
-		                log.info("New router for schedule mode " + scheduleMode);
-		                Set<String> networkTransportModes = transportModeAssignment.get(scheduleMode);
-
-		                Network filteredNetwork = NetworkTools.createFilteredNetworkByLinkMode(this.network, networkTransportModes);
-
-		                LocalRouter r = new LocalRouter();
-		                tmpRouter = new PathCalculator(factory.createPathCalculator(filteredNetwork, r, r));
-
-		                pathCalculatorsByMode.put(scheduleMode, tmpRouter);
-		                networksByMode.put(scheduleMode, filteredNetwork);
-		            }
-		        }
-		    }
-		}
-		else
-			new RuntimeException("LeastCostPathCalculatorFactory is null but it should not be!");
-		
 	}
-
 
 	@Override
 	public LeastCostPathCalculator.Path calcLeastCostPath(LinkCandidate fromLinkCandidate, LinkCandidate toLinkCandidate, TransitLine transitLine, TransitRoute transitRoute) {
@@ -142,7 +104,7 @@ public class ScheduleRoutersStandard implements ScheduleRouters {
 
 	@Override
 	public LeastCostPathCalculator.Path calcLeastCostPath(LinkCandidate fromLinkCandidate, LinkCandidate toLinkCandidate, TransitLine transitLine, TransitRoute transitRoute, double maxCost) {
-		Network n = networksByMode.get(transitRoute.getTransportMode());
+		Network n = this.networksByMode.get(transitRoute.getTransportMode());
 		if (n == null) {
 			return null;
 		}
@@ -151,45 +113,47 @@ public class ScheduleRoutersStandard implements ScheduleRouters {
 		if (fromLink == null || toLink == null) {
 			return null;
 		}
-		return pathCalculatorsByMode.get(transitRoute.getTransportMode()).calcPath(fromLink, toLink, maxCost);
+		return this.pathCalculatorsByMode.get(transitRoute.getTransportMode()).calcPath(fromLink, toLink, maxCost);
 	}
 
 	@Override
 	public LeastCostPathCalculator.Path calcLeastCostPath(Id<Link> fromLinkId, Id<Link> toLinkId, TransitLine transitLine, TransitRoute transitRoute) {
-		Network n = networksByMode.get(transitRoute.getTransportMode());
+		Network n = this.networksByMode.get(transitRoute.getTransportMode());
 		if (n == null) {
 			return null;
 		}
-
 		Link fromLink = n.getLinks().get(fromLinkId);
 		Link toLink = n.getLinks().get(toLinkId);
 		if (fromLink == null || toLink == null) {
 			return null;
 		}
-
-		return pathCalculatorsByMode.get(transitRoute.getTransportMode()).calcPath(fromLink, toLink);
+		return this.pathCalculatorsByMode.get(transitRoute.getTransportMode()).calcPath(fromLink, toLink);
 	}
 
 	@Override
 	public double getMinimalTravelCost(TransitRouteStop fromTransitRouteStop, TransitRouteStop toTransitRouteStop, TransitLine transitLine, TransitRoute transitRoute) {
-		double minTC = PTMapperTools.calcMinTravelCost(fromTransitRouteStop, toTransitRouteStop, travelCostType);
-		if(minTC == 0)
+		double minTC = PTMapperTools.calcMinTravelCost(fromTransitRouteStop, toTransitRouteStop, this.travelCostType);
+		if (minTC == 0) {
 			minTC = CoordUtils.calcEuclideanDistance(fromTransitRouteStop.getStopFacility().getCoord(), toTransitRouteStop.getStopFacility().getCoord()) / 10;
+		}
 		return minTC;
 	}
 
 	@Override
 	public double getLinkCandidateTravelCost(LinkCandidate linkCandidateCurrent) {
 		double dist = 0;
-		if(considerCandidateDist) {
-			dist += (travelCostType.equals(PublicTransitMappingConfigGroup.TravelCostType.travelTime) ? linkCandidateCurrent.getStopFacilityDistance() / linkCandidateCurrent.getLink().getFreespeed() : linkCandidateCurrent.getStopFacilityDistance());
+		if (this.considerCandidateDist) {
+			dist += (this.travelCostType.equals(PublicTransitMappingConfigGroup.TravelCostType.travelTime)
+					? linkCandidateCurrent.getStopFacilityDistance() / linkCandidateCurrent.getLink().getFreespeed()
+					: linkCandidateCurrent.getStopFacilityDistance());
 			dist *= 2;
 		}
-		return dist + PTMapperTools.calcTravelCost(linkCandidateCurrent.getLink(), travelCostType);
+		return dist + PTMapperTools.calcTravelCost(linkCandidateCurrent.getLink(), this.travelCostType);
 	}
 
 	/**
-	 * Class is sent to path calculator factory
+	 * Combined {@link TravelDisutility} and {@link TravelTime} implementation
+	 * passed to the path calculator factory.
 	 */
 	private class LocalRouter implements TravelDisutility, TravelTime {
 
@@ -210,34 +174,95 @@ public class ScheduleRoutersStandard implements ScheduleRouters {
 	}
 
 	/**
-	 * Factory for a ScheduleRoutersStandard instance
+	 * Factory for {@link ScheduleRoutersStandard} instances.
+	 * <p>
+	 * Pre-computes filtered networks and a shared
+	 * {@link LeastCostPathCalculatorFactory} on first use, so that subsequent calls
+	 * to {@link #createInstance()} only create cheap per-thread router instances
+	 * without redundant network filtering, graph building, or ALT landmark / CH
+	 * contraction computation.
 	 */
 	public static class Factory implements ScheduleRoutersFactory {
 		private final TransitSchedule schedule;
 		private final Network network;
 		private final Map<String, Set<String>> transportModeAssignment;
 		private final PublicTransitMappingConfigGroup.TravelCostType costType;
-		private boolean routingWithCandidateDistance;
-		private RoutingAlgorithmType networkRouter;
-		
+		private final boolean routingWithCandidateDistance;
+		private final int networkRoutingLandmarks;
+		private final RoutingAlgorithmType networkRouter;
+		private final int nThreads;
+
+		// Cached infrastructure, lazily initialized by ensureInitialized()
+		private Map<String, Network> filteredNetworkCache;
+		private LeastCostPathCalculatorFactory lcpFactoryCache;
+
 		public Factory(TransitSchedule schedule, Network network, Map<String, Set<String>> transportModeAssignment, PublicTransitMappingConfigGroup.TravelCostType costType, boolean routingWithCandidateDistance,
-				RoutingAlgorithmType networkRouter) {
+				RoutingAlgorithmType networkRouter, int nThreads) {
 			this.schedule = schedule;
 			this.network = network;
 			this.transportModeAssignment = transportModeAssignment;
 			this.costType = costType;
 			this.routingWithCandidateDistance = routingWithCandidateDistance;
+			this.networkRoutingLandmarks = new RoutingConfigGroup().getNetworkRoutingLandmarks();
 			this.networkRouter = networkRouter;
+			this.nThreads = nThreads;
 		}
-		
+
 		public Factory(TransitSchedule schedule, Network network, PublicTransitMappingConfigGroup config) {
-			this(schedule, network, config.getTransportModeAssignment(), config.getTravelCostType(), config.getRoutingWithCandidateDistance(), config.getNetworkRouter());
+			this(schedule, network, config.getTransportModeAssignment(), config.getTravelCostType(),
+					config.getRoutingWithCandidateDistance(), config.getNetworkRouter(), config.getNumOfThreads());
+		}
+
+		/**
+		 * Pre-computes filtered networks (one per unique network mode set) and creates
+		 * a single shared {@link LeastCostPathCalculatorFactory}. The factory's
+		 * internal caches (keyed by Network identity) ensure that graph building and
+		 * routing preprocessing (ALT landmarks / CH contraction) are performed only
+		 * once per mode set, regardless of how many instances are created.
+		 */
+		private synchronized void ensureInitialized() {
+			if (this.filteredNetworkCache != null) {
+				return;
+			}
+			log.info("Pre-computing filtered networks and router factory for schedule mode assignment...");
+
+			this.filteredNetworkCache = new HashMap<>();
+			Map<Set<String>, Network> byModeSet = new HashMap<>();
+			for (Map.Entry<String, Set<String>> entry : this.transportModeAssignment.entrySet()) {
+				Network filtered = byModeSet.computeIfAbsent(entry.getValue(),
+						modes -> NetworkTools.createFilteredNetworkByLinkMode(this.network, modes));
+				this.filteredNetworkCache.put(entry.getKey(), filtered);
+			}
+
+			this.lcpFactoryCache = createLcpFactory(this.networkRouter, this.nThreads, this.networkRoutingLandmarks);
+
+			log.info("Pre-computed {} filtered network(s) and shared router factory.", byModeSet.size());
 		}
 
 		@Override
 		public ScheduleRouters createInstance() {
-			return new ScheduleRoutersStandard(schedule, network, transportModeAssignment, costType, routingWithCandidateDistance, networkRouter);
+			this.ensureInitialized();
+			return new ScheduleRoutersStandard(this.schedule, this.transportModeAssignment,
+					this.costType, this.routingWithCandidateDistance,
+					this.filteredNetworkCache, this.lcpFactoryCache);
 		}
 
+		/**
+		 * Creates a {@link LeastCostPathCalculatorFactory} for the given routing
+		 * algorithm type.
+		 */
+		private static LeastCostPathCalculatorFactory createLcpFactory(RoutingAlgorithmType routerType,
+				int nThreads, int networkRoutingLandmarks) {
+			if (routerType.equals(RoutingAlgorithmType.SpeedyALT)) {
+				return new SpeedyALTFactory();
+			} else if (routerType.equals(RoutingAlgorithmType.AStarLandmarks)) {
+				return new AStarLandmarksFactory(nThreads, networkRoutingLandmarks);
+			} else if (routerType.equals(RoutingAlgorithmType.CHRouter)) {
+				GlobalConfigGroup global = new GlobalConfigGroup();
+				global.setNumberOfThreads(nThreads);
+				return new StaticCHRouterFactory(global);
+			}
+			throw new IllegalArgumentException("Unsupported routing algorithm: " + routerType);
+		}
 	}
 }

--- a/src/main/java/org/matsim/pt2matsim/tools/NetworkTools.java
+++ b/src/main/java/org/matsim/pt2matsim/tools/NetworkTools.java
@@ -487,7 +487,7 @@ public final class NetworkTools {
 			config.addParameterSet(mra);
 		}
 
-		return new ScheduleRoutersStandard.Factory(schedule, network, modeAssignments, PublicTransitMappingConfigGroup.TravelCostType.linkLength, true, config.getNetworkRouter());
+		return new ScheduleRoutersStandard.Factory(schedule, network, modeAssignments, PublicTransitMappingConfigGroup.TravelCostType.linkLength, true, config.getNetworkRouter(), config.getNumOfThreads());
 	}
 
 	/**


### PR DESCRIPTION
This change keeps only one instance of the respective RouterFactory per transport mode so network preprocessing results are not recreated for each router.