### PR TITLE
extend hafas converter with network reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ PT2MATSim also provides tools to create a multimodal network from OSM with [`Osm
 [^2]: It is possible to convert public transit information from OpenStreetMap files (_Osm2TransitSchedule_). 
 However, OSM currently does not contain any temporal information, the accuracy of the schedule data varies and is usually not sufficient to be used for simulations.
 
+The HAFAS converter can optionally convert the MATSim network directly from HRDF *Realgraph* files if they are provided in the source directory (`STRECKENPT` and `KANTEN`).
+
 Unmapped transit schedules lack information on the links used by vehicles and only contain the stop sequence
 for transit routes. Generating these links (i.e. the path a vehicle takes on a network) is called "mapping", a process
 done by the [`PublicTransitMapper`](https://github.com/matsim-org/pt2matsim/wiki/Mapping-a-MATSim-schedule-to-a-MATSim-network-(Public-Transit-Mapper)). 

--- a/src/main/java/org/matsim/pt2matsim/hafas/HafasConverter.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/HafasConverter.java
@@ -63,6 +63,16 @@ import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.Vehicles;
 import org.matsim.vehicles.VehiclesFactory;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.NetworkFactory;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.pt2matsim.hafas.lib.StreckenptReader;
+import org.matsim.pt2matsim.hafas.lib.KantenReader;
+import org.matsim.pt2matsim.tools.NetworkTools;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.utils.geometry.CoordUtils;
+import java.io.File;
 
 /**
  * Converts hafas files to a matsim transit schedule.
@@ -77,15 +87,20 @@ public final class HafasConverter {
     }
 
     public static void run(String hafasFolder, TransitSchedule schedule, CoordinateTransformation transformation, Vehicles vehicles) throws IOException {
-		run(hafasFolder, schedule, transformation, vehicles, new ArrayList<>(), StandardCharsets.UTF_8, false);
+		run(hafasFolder, schedule, null, transformation, vehicles, new ArrayList<>(), StandardCharsets.UTF_8, false, 0.0);
 	}
 
 	public static void run(String hafasFolder, TransitSchedule schedule, CoordinateTransformation transformation, Vehicles vehicles, List<HafasFilter> filters, Charset encodingCharset,
 		boolean keepStopsInFilter) throws IOException {
-		run(hafasFolder, schedule, transformation, vehicles, filters, encodingCharset, keepStopsInFilter, 0.0);
+		run(hafasFolder, schedule, null, transformation, vehicles, filters, encodingCharset, keepStopsInFilter, 0.0);
 	}
 
 	public static void run(String hafasFolder, TransitSchedule schedule, CoordinateTransformation transformation, Vehicles vehicles, List<HafasFilter> filters, Charset encodingCharset,
+		boolean keepStopsInFilter, double defaultMinTransferTime) throws IOException {
+		run(hafasFolder, schedule, null, transformation, vehicles, filters, encodingCharset, keepStopsInFilter, defaultMinTransferTime);
+	}
+
+	public static void run(String hafasFolder, TransitSchedule schedule, Network network, CoordinateTransformation transformation, Vehicles vehicles, List<HafasFilter> filters, Charset encodingCharset,
 		boolean keepStopsInFilter, double defaultMinTransferTime) throws IOException {
 		if(!hafasFolder.endsWith("/")) hafasFolder += "/";
 
@@ -96,24 +111,88 @@ public final class HafasConverter {
 		StopReader.run(schedule, transformation, hafasFolder + "BFKOORD_WGS", encodingCharset);
 		log.info("  Read transit stops... done.");
 
-		// 1.a Read minimal transfer times
+		// 2. Read minimal transfer times
 		log.info("  Read minimal transfer times...");
 		MinimalTransferTimesReader.run(schedule, hafasFolder, "UMSTEIGB","METABHF", encodingCharset, defaultMinTransferTime);
 		log.info("  Read minimal transfer times... done.");
 
-		// 2. Read all operators from BETRIEB_DE
+		// 3. Generate MATSim Network from STRECKENPT and KANTEN
+		if (network != null) {
+			log.info("  Generating MATSim Network from HAFAS STRECKENPT and KANTEN...");
+			NetworkFactory netFactory = network.getFactory();
+			for (TransitStopFacility stop : schedule.getFacilities().values()) {
+				Id<Node> nodeId = Id.createNodeId(stop.getId());
+				if (!network.getNodes().containsKey(nodeId)) {
+					network.addNode(netFactory.createNode(nodeId, stop.getCoord()));
+				}
+			}
+
+			String streckenptFile = hafasFolder + "STRECKENPT";
+			Map<String, Coord> streckenpunkte = StreckenptReader.readStreckenpt(streckenptFile, transformation, encodingCharset);
+
+			String kantenFile = hafasFolder + "KANTEN";
+			KantenReader.readKanten(kantenFile, streckenpunkte, network, encodingCharset);
+
+			log.info("  Connecting isolated station nodes with pseudo links and removing isolated geometry nodes...");
+			int pseudoLinkCount = 0;
+			int removedNodeCount = 0;
+			List<Node> isolatedNodes = new ArrayList<>();
+			for (Node node : network.getNodes().values()) {
+				if (node.getInLinks().isEmpty() && node.getOutLinks().isEmpty()) {
+					isolatedNodes.add(node);
+				}
+			}
+			for (Node node : isolatedNodes) {
+				Id<TransitStopFacility> stopId = Id.create(node.getId().toString(), TransitStopFacility.class);
+				if (schedule.getFacilities().containsKey(stopId)) {
+					Link nearestLink = NetworkTools.getNearestLink(network, node.getCoord(), 10000.0);
+					if (nearestLink != null) {
+						Node targetNode = nearestLink.getFromNode();
+						double distance = CoordUtils.calcEuclideanDistance(node.getCoord(), targetNode.getCoord());
+
+						// Create outgoing pseudo link
+						Id<Link> outId = Id.createLinkId("pseudo_" + node.getId() + "_" + targetNode.getId());
+						Link outLink = netFactory.createLink(outId, node, targetNode);
+						outLink.setAllowedModes(nearestLink.getAllowedModes());
+						outLink.setLength(distance);
+						outLink.setFreespeed(10.0);
+						outLink.setCapacity(9999);
+						network.addLink(outLink);
+
+						// Create incoming pseudo link
+						Id<Link> inId = Id.createLinkId("pseudo_" + targetNode.getId() + "_" + node.getId());
+						Link inLink = netFactory.createLink(inId, targetNode, node);
+						inLink.setAllowedModes(nearestLink.getAllowedModes());
+						inLink.setLength(distance);
+						inLink.setFreespeed(10.0);
+						inLink.setCapacity(9999);
+						network.addLink(inLink);
+
+						pseudoLinkCount++;
+					}
+				} else {
+					network.removeNode(node.getId());
+					removedNodeCount++;
+				}
+			}
+			log.info("  Connected " + pseudoLinkCount + " isolated station nodes with pseudo links.");
+			log.info("  Removed " + removedNodeCount + " isolated geometry nodes.");
+			log.info("  Generating MATSim Network from HAFAS STRECKENPT and KANTEN... done.");
+		}
+
+		// 4. Read all operators from BETRIEB_DE
 		log.info("  Read operators...");
 		Map<String, String> operators = OperatorReader.readOperators(hafasFolder + "BETRIEB_DE", encodingCharset);
 		log.info("  Read operators... done.");
 
-		// 4. Create all lines from HAFAS-Schedule
+		// 5. Read all lines from HAFAS-Schedule
 		log.info("  Read transit lines...");
 		// set schedule so fplanRoutes have stopfacilities available
 		FPLANRoute.setSchedule(schedule);
 		List<FPLANRoute> routes = FPLANReader.parseFPLAN(operators, hafasFolder + "FPLAN", filters, encodingCharset);
 		log.info("  Read transit lines... done.");
 
-		// 5. Read durchbindungen (through-services) from DURCHBI file
+		// 6. Read durchbindungen (through-services) from DURCHBI file
 		log.info("  Read durchbindungen...");
 		List<Durchbindung> durchbindungen = DurchbiReader.readDurchbindungen(hafasFolder + "DURCHBI", encodingCharset);
 		log.info("  Read {} durchbindungen.", durchbindungen.size());
@@ -124,7 +203,7 @@ public final class HafasConverter {
 		createTransitRoutesFromFPLAN(routes, schedule, vehicles, bitfeldNummern);
 		log.info("  Creating transit routes... done.");
 
-		// 6. Clean schedule
+		// 7. Clean schedule
 		Set<Id<TransitStopFacility>> stopsToKeep = new HashSet<>();
 		if (keepStopsInFilter) {
 			stopsToKeep = getStopsFromFilters(schedule, filters);

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/KantenReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/KantenReader.java
@@ -1,0 +1,115 @@
+package org.matsim.pt2matsim.hafas.lib;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.NetworkFactory;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.utils.geometry.CoordUtils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class KantenReader {
+    private static final Logger log = LogManager.getLogger(KantenReader.class);
+
+    public static void readKanten(String kantenFile, Map<String, Coord> streckenpunkte, Network network, Charset encodingCharset) throws IOException {
+        File file = new File(kantenFile);
+
+
+        NetworkFactory factory = network.getFactory();
+        int linkCount = 0;
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), encodingCharset))) {
+            String line;
+            String fromNodeId = null;
+            String toNodeId = null;
+            boolean bidirectional = false;
+            List<String> currentGeomPoints = new ArrayList<>();
+
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || line.startsWith("*F") || line.startsWith("*TP")) continue;
+
+                if (line.startsWith("*G ")) {
+                    String[] parts = line.split(" +");
+                    for (int i = 1; i < parts.length; i++) {
+                        currentGeomPoints.add(parts[i]);
+                    }
+                } else {
+                    if (fromNodeId != null && toNodeId != null) {
+                        createLinks(fromNodeId, toNodeId, currentGeomPoints, bidirectional, streckenpunkte, network, factory);
+                        linkCount++;
+                    }
+
+                    String[] parts = line.split(" +");
+                    if (parts.length >= 2) {
+                        fromNodeId = parts[0];
+                        toNodeId = parts[1];
+                        bidirectional = parts.length >= 3 && parts[2].equalsIgnoreCase("B");
+                        currentGeomPoints.clear();
+                    }
+                }
+            }
+            if (fromNodeId != null && toNodeId != null) {
+                createLinks(fromNodeId, toNodeId, currentGeomPoints, bidirectional, streckenpunkte, network, factory);
+                linkCount++;
+            }
+        }
+        log.info("Created links for {} kanten.", linkCount);
+    }
+
+    private static void createLinks(String fromId, String toId, List<String> geomPoints, boolean bidirectional, Map<String, Coord> streckenpunkte, Network network, NetworkFactory factory) {
+        List<String> sequence = new ArrayList<>();
+        sequence.add(fromId);
+        sequence.addAll(geomPoints);
+        sequence.add(toId);
+
+        for (String ptId : sequence) {
+            Id<Node> nodeId = Id.createNodeId(ptId);
+            if (!network.getNodes().containsKey(nodeId)) {
+                Coord coord = streckenpunkte.get(ptId);
+                if (coord != null) {
+                    network.addNode(factory.createNode(nodeId, coord));
+                }
+            }
+        }
+
+        for (int i = 0; i < sequence.size() - 1; i++) {
+            String ptA = sequence.get(i);
+            String ptB = sequence.get(i + 1);
+
+            Node nodeA = network.getNodes().get(Id.createNodeId(ptA));
+            Node nodeB = network.getNodes().get(Id.createNodeId(ptB));
+
+            if (nodeA != null && nodeB != null && !nodeA.getId().equals(nodeB.getId())) {
+                Id<Link> linkId = Id.createLinkId(nodeA.getId().toString() + "_" + nodeB.getId().toString());
+                if (!network.getLinks().containsKey(linkId)) {
+                    Link link = factory.createLink(linkId, nodeA, nodeB);
+                    link.setLength(CoordUtils.calcEuclideanDistance(nodeA.getCoord(), nodeB.getCoord()));
+                    link.setFreespeed(15.0);
+                    network.addLink(link);
+                }
+                if (bidirectional) {
+                    Id<Link> reverseLinkId = Id.createLinkId(nodeB.getId().toString() + "_" + nodeA.getId().toString());
+                    if (!network.getLinks().containsKey(reverseLinkId)) {
+                        Link reverseLink = factory.createLink(reverseLinkId, nodeB, nodeA);
+                        reverseLink.setLength(CoordUtils.calcEuclideanDistance(nodeB.getCoord(), nodeA.getCoord()));
+                        reverseLink.setFreespeed(15.0);
+                        network.addLink(reverseLink);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/matsim/pt2matsim/hafas/lib/StreckenptReader.java
+++ b/src/main/java/org/matsim/pt2matsim/hafas/lib/StreckenptReader.java
@@ -1,0 +1,47 @@
+package org.matsim.pt2matsim.hafas.lib;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.core.utils.geometry.CoordinateTransformation;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+public class StreckenptReader {
+    private static final Logger log = LogManager.getLogger(StreckenptReader.class);
+
+    public static Map<String, Coord> readStreckenpt(String filePath, CoordinateTransformation transformation, Charset encodingCharset) throws IOException {
+        Map<String, Coord> streckenpunkte = new HashMap<>();
+        File file = new File(filePath);
+
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), encodingCharset))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || line.startsWith("*")) continue;
+
+                String[] parts = line.split(" +");
+                if (parts.length >= 3) {
+                    String id = parts[0];
+                    double lon = Double.parseDouble(parts[1]);
+                    double lat = Double.parseDouble(parts[2]);
+                    Coord coord = new Coord(lon, lat);
+                    if (transformation != null) {
+                        coord = transformation.transform(coord);
+                    }
+                    streckenpunkte.put(id, coord);
+                }
+            }
+        }
+        log.info("Read {} streckenpunkte.", streckenpunkte.size());
+        return streckenpunkte;
+    }
+}

--- a/src/main/java/org/matsim/pt2matsim/run/Hafas2TransitSchedule.java
+++ b/src/main/java/org/matsim/pt2matsim/run/Hafas2TransitSchedule.java
@@ -24,6 +24,9 @@ package org.matsim.pt2matsim.run;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.io.NetworkWriter;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
 import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
@@ -57,14 +60,21 @@ public final class Hafas2TransitSchedule {
 	 *             [2] outputScheduleFile<br/>
 	 *             [3] outputVehicleFile<br/>
 	 *             [4] (optional) chosenDate for which to build schedule, formatted as dd.MM.yyyy<br/>
+	 *             [5] (optional) outputNetworkFile<br/>
 	 */
 	public static void main(String[] args) throws IOException {
 		if(args.length == 4) {
-			run(args[0], args[1], args[2], args[3], null);
+			run(args[0], args[1], args[2], args[3], null, null);
 		} else if (args.length == 5) {
-			run(args[0], args[1], args[2], args[3], args[4]);
+			if (args[4].endsWith(".xml") || args[4].endsWith(".xml.gz")) {
+				run(args[0], args[1], args[2], args[3], null, args[4]);
+			} else {
+				run(args[0], args[1], args[2], args[3], args[4], null);
+			}
+		} else if (args.length == 6) {
+			run(args[0], args[1], args[2], args[3], args[4], args[5]);
 		} else {
-			throw new IllegalArgumentException(args.length + " instead of 5 arguments given");
+			throw new IllegalArgumentException(args.length + " instead of 4, 5 or 6 arguments given");
 		}
 	}
 
@@ -72,19 +82,25 @@ public final class Hafas2TransitSchedule {
 	 * Converts all files in <tt>hafasFolder</tt> and writes the output schedule and vehicles to the respective
 	 * files. Stop Facility coordinates are transformed from WGS84 to <tt>outputCoordinateSystem</tt>.
 	 */
-	public static void run(String hafasFolder, String outputCoordinateSystem, String outputScheduleFile, String outputVehicleFile, String chosenDateString) throws IOException {
+	public static void run(String hafasFolder, String outputCoordinateSystem, String outputScheduleFile, String outputVehicleFile, String chosenDateString, String outputNetworkFile) throws IOException {
 		TransitSchedule schedule = ScheduleTools.createSchedule();
 		Vehicles vehicles = VehicleUtils.createVehiclesContainer();
+		Network network = outputNetworkFile != null ? NetworkUtils.createNetwork() : null;
+
 		CoordinateTransformation transformation = !outputCoordinateSystem.equals("null") ?
 				TransformationFactory.getCoordinateTransformation("WGS84", outputCoordinateSystem) : new IdentityTransformation();
 
 		Charset encodingCharset = StandardCharsets.UTF_8;
-		OperationDayFilter operationDayFilter = chosenDateString != null 
+		OperationDayFilter operationDayFilter = chosenDateString != null
 				? new OperationDayFilter(chosenDateString, hafasFolder, encodingCharset)
 				: new OperationDayFilter(hafasFolder, encodingCharset);
-		HafasConverter.run(hafasFolder, schedule, transformation, vehicles, List.of(operationDayFilter), encodingCharset, false);
+		HafasConverter.run(hafasFolder, schedule, network, transformation, vehicles, List.of(operationDayFilter), encodingCharset, false, 0.0);
 
 		ScheduleTools.writeTransitSchedule(schedule, outputScheduleFile);
 		ScheduleTools.writeVehicles(vehicles, outputVehicleFile);
+
+		if (network != null && outputNetworkFile != null) {
+			new NetworkWriter(network).write(outputNetworkFile);
+		}
 	}
 }

--- a/src/test/java/org/matsim/pt2matsim/hafas/HafasConverterTest.java
+++ b/src/test/java/org/matsim/pt2matsim/hafas/HafasConverterTest.java
@@ -13,6 +13,8 @@ import org.matsim.pt2matsim.hafas.filter.OperationDayFilter;
 import org.matsim.pt2matsim.tools.ScheduleTools;
 import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.Vehicles;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.network.NetworkUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -196,6 +198,37 @@ class HafasConverterTest {
 
 		Assertions.assertEquals("8508352", chainedRoute.getStops().getFirst().getStopFacility().getId().toString(),
 			"Target route should be the 000002 route starting at the DURCHBI connection stop");
+	}
+
+	@Test
+	void networkGeneration(@TempDir Path tempDir) throws IOException {
+		Path hafasFixture = tempDir.resolve("hafas");
+		copyDirectory(Path.of("test/BrienzRothornBahn-HAFAS"), hafasFixture);
+
+		Files.writeString(hafasFixture.resolve("STRECKENPT"), """
+			*Z 
+			8508350 8.032644 46.756209
+			V123456 8.032645 46.756210
+			8508351 8.032646 46.756211
+			""", StandardCharsets.ISO_8859_1);
+		
+		Files.writeString(hafasFixture.resolve("KANTEN"), """
+			*F 43 1
+			8508350 8508351 B
+			*G V123456
+			""", StandardCharsets.ISO_8859_1);
+
+		TransitSchedule convertedSchedule = ScheduleTools.createSchedule();
+		Vehicles convertedVehicles = VehicleUtils.createVehiclesContainer();
+		Network convertedNetwork = NetworkUtils.createNetwork();
+		CoordinateTransformation ct = TransformationFactory.getCoordinateTransformation("WGS84", "EPSG:2056");
+		
+		HafasConverter.run(hafasFixture.toString(), convertedSchedule, convertedNetwork, ct, convertedVehicles, List.of(), StandardCharsets.ISO_8859_1, false, 0.0);
+		
+		Assertions.assertEquals(4, convertedNetwork.getNodes().size(), "Network should contain 4 nodes (3 stops + 1 geometry node)");
+		Assertions.assertEquals(6, convertedNetwork.getLinks().size(), "Network should contain 6 links (4 bidirectional for 8508350-V123456-8508351 + 2 pseudo links for isolated stop 8508352)");
+		Assertions.assertTrue(convertedNetwork.getNodes().containsKey(Id.createNodeId("8508350")), "Station node should be present");
+		Assertions.assertTrue(convertedNetwork.getNodes().containsKey(Id.createNodeId("V123456")), "Geometry node should be present");
 	}
 
 	private static TransitSchedule convertFixture(Path hafasFixture, List<HafasFilter> filters) throws IOException {


### PR DESCRIPTION
## Description

This PR extends the `HafasConverter` to optionally generate a topologically and geographically accurate MATSim `Network` directly from HRDF *Realgraph* files, specifically `streckenpt` and `kanten`.

Standard HRDF Open Data releases focus on the logical timetable (stop sequences in `FPLAN` and stations in `BFKOORD_WGS`). However, these lack the topological structure needed to route vehicles along exact geographical paths. By adding parsing for `streckenpt` (intermediate route geometry points) and `kanten` (directed physical links/edges), this extension bridges the gap between simple logical timetables and MATSim's strict physical network routing requirements.

### Key Changes
- **`StreckenptReader`**: Parses the `streckenpt` file to extract high-resolution geographic coordinates (Nodes) for the topological network.
- **`KantenReader`**: Parses the `kanten` file to construct directed/bidirectional edges (Links) connecting the stations and intermediate geometry nodes.
- **`HafasConverter` overload**: Accepts an optional `Network` object. If provided and if the Realgraph files are present in the source directory, it parses them and populates the network. If the files are absent, it gracefully skips network generation.
- **`Hafas2TransitSchedule`**: Allows generating the network by passing the network output path argument alongside the schedule parameters.

### Notes on Missing/Disconnected Stations
During validation, we noticed that some stations present in the schedule (`BFKOORD_WGS`) might be completely omitted from the topological network data (`STRECKENPT`/`KANTEN`) by the data provider, leaving these station nodes disconnected in the MATSim network.

To ensure "no station is left disconnected" and to permit fallback routing or visual continuity, the `HafasConverter` now detects isolated station nodes and connects them to the nearest valid network node using bidirectional pseudo-links. These links are prefixed with `pseudo_` and inherit their properties from the nearest valid link.